### PR TITLE
Data channel live record

### DIFF
--- a/ngx_rtmp_live_module.h
+++ b/ngx_rtmp_live_module.h
@@ -33,7 +33,7 @@ struct ngx_rtmp_live_ctx_s {
     ngx_rtmp_live_stream_t             *stream;
     ngx_rtmp_live_ctx_t                *next;
     ngx_uint_t                          ndropped;
-    ngx_rtmp_live_chunk_stream_t        cs[2];
+    ngx_rtmp_live_chunk_stream_t        cs[3];
     ngx_uint_t                          meta_version;
     ngx_event_t                         idle_evt;
     unsigned                            active:1;
@@ -50,6 +50,7 @@ struct ngx_rtmp_live_stream_s {
     ngx_rtmp_bandwidth_t                bw_in;
     ngx_rtmp_bandwidth_t                bw_in_audio;
     ngx_rtmp_bandwidth_t                bw_in_video;
+    ngx_rtmp_bandwidth_t                bw_in_data;
     ngx_rtmp_bandwidth_t                bw_out;
     ngx_msec_t                          epoch;
     unsigned                            active:1;

--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -31,9 +31,9 @@ static char * ngx_rtmp_record_merge_app_conf(ngx_conf_t *cf,
 static ngx_int_t ngx_rtmp_record_write_frame(ngx_rtmp_session_t *s,
        ngx_rtmp_record_rec_ctx_t *rctx,
        ngx_rtmp_header_t *h, ngx_chain_t *in, ngx_int_t inc_nframes);
-static ngx_int_t ngx_rtmp_record_av(ngx_rtmp_session_t *s,
+static ngx_int_t ngx_rtmp_record_avd(ngx_rtmp_session_t *s,
        ngx_rtmp_header_t *h, ngx_chain_t *in);
-static ngx_int_t ngx_rtmp_record_node_av(ngx_rtmp_session_t *s,
+static ngx_int_t ngx_rtmp_record_node_avd(ngx_rtmp_session_t *s,
        ngx_rtmp_record_rec_ctx_t *rctx, ngx_rtmp_header_t *h, ngx_chain_t *in);
 static ngx_int_t ngx_rtmp_record_node_open(ngx_rtmp_session_t *s,
        ngx_rtmp_record_rec_ctx_t *rctx);
@@ -47,9 +47,13 @@ static ngx_int_t ngx_rtmp_record_init(ngx_rtmp_session_t *s);
 static ngx_conf_bitmask_t  ngx_rtmp_record_mask[] = {
     { ngx_string("off"),                NGX_RTMP_RECORD_OFF         },
     { ngx_string("all"),                NGX_RTMP_RECORD_AUDIO       |
+                                        NGX_RTMP_RECORD_VIDEO       |
+                                        NGX_RTMP_RECORD_DATA        },
+    { ngx_string("av"),                 NGX_RTMP_RECORD_AUDIO       |
                                         NGX_RTMP_RECORD_VIDEO       },
     { ngx_string("audio"),              NGX_RTMP_RECORD_AUDIO       },
     { ngx_string("video"),              NGX_RTMP_RECORD_VIDEO       },
+    { ngx_string("data"),               NGX_RTMP_RECORD_DATA        },
     { ngx_string("keyframes"),          NGX_RTMP_RECORD_KEYFRAMES   },
     { ngx_string("manual"),             NGX_RTMP_RECORD_MANUAL      },
     { ngx_null_string,                  0                           }
@@ -886,7 +890,8 @@ ngx_rtmp_record_write_frame(ngx_rtmp_session_t *s,
 
     if (h->type == NGX_RTMP_MSG_VIDEO) {
         rctx->video = 1;
-    } else {
+    }
+    if (h->type == NGX_RTMP_MSG_AUDIO) {
         rctx->audio = 1;
     }
 
@@ -993,7 +998,7 @@ ngx_rtmp_record_get_chain_mlen(ngx_chain_t *in)
 
 
 static ngx_int_t
-ngx_rtmp_record_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+ngx_rtmp_record_avd(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                    ngx_chain_t *in)
 {
     ngx_rtmp_record_ctx_t          *ctx;
@@ -1009,7 +1014,7 @@ ngx_rtmp_record_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     rctx = ctx->rec.elts;
 
     for (n = 0; n < ctx->rec.nelts; ++n, ++rctx) {
-        ngx_rtmp_record_node_av(s, rctx, h, in);
+        ngx_rtmp_record_node_avd(s, rctx, h, in);
     }
 
     return NGX_OK;
@@ -1017,7 +1022,7 @@ ngx_rtmp_record_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
 
 static ngx_int_t
-ngx_rtmp_record_node_av(ngx_rtmp_session_t *s, ngx_rtmp_record_rec_ctx_t *rctx,
+ngx_rtmp_record_node_avd(ngx_rtmp_session_t *s, ngx_rtmp_record_rec_ctx_t *rctx,
                         ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
     ngx_time_t                      next;
@@ -1075,6 +1080,12 @@ ngx_rtmp_record_node_av(ngx_rtmp_session_t *s, ngx_rtmp_record_rec_ctx_t *rctx,
 
     if (h->type == NGX_RTMP_MSG_AUDIO &&
        (rracf->flags & NGX_RTMP_RECORD_AUDIO) == 0)
+    {
+        return NGX_OK;
+    }
+
+    if (h->type == NGX_RTMP_MSG_AMF_META &&
+       (rracf->flags & NGX_RTMP_RECORD_DATA) == 0)
     {
         return NGX_OK;
     }
@@ -1280,10 +1291,13 @@ ngx_rtmp_record_postconfiguration(ngx_conf_t *cf)
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
     h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AUDIO]);
-    *h = ngx_rtmp_record_av;
+    *h = ngx_rtmp_record_avd;
 
     h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
-    *h = ngx_rtmp_record_av;
+    *h = ngx_rtmp_record_avd;
+
+    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AMF_META]);
+    *h = ngx_rtmp_record_avd;
 
     next_publish = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_record_publish;

--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -16,9 +16,9 @@
 #define NGX_RTMP_RECORD_OFF             0x01
 #define NGX_RTMP_RECORD_AUDIO           0x02
 #define NGX_RTMP_RECORD_VIDEO           0x04
-#define NGX_RTMP_RECORD_KEYFRAMES       0x08
-#define NGX_RTMP_RECORD_MANUAL          0x10
-
+#define NGX_RTMP_RECORD_DATA            0x08
+#define NGX_RTMP_RECORD_KEYFRAMES       0x10
+#define NGX_RTMP_RECORD_MANUAL          0x20
 
 typedef struct {
     ngx_str_t                           id;

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -453,6 +453,8 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                              NGX_RTMP_STAT_BW);
             ngx_rtmp_stat_bw(r, lll, &stream->bw_in_video, "video",
                              NGX_RTMP_STAT_BW);
+            ngx_rtmp_stat_bw(r, lll, &stream->bw_in_data, "data",
+                             NGX_RTMP_STAT_BW);
 
             nclients = 0;
             codec = NULL;


### PR DESCRIPTION
ActionScript allows both onTextData and onCuePoint RPC calls to be encoded as AMF and sent over the wire as part of the FLV spec. This pull request updates the live module to support passing this data through to connected clients and recordings. It also updates the record module to support passing this data through to the recorded FLV files.

This should supersede #482 and should address #481 in a more robust way.

https://github.com/arut/nginx-rtmp-module/pull/511