### PR TITLE
Update ngx_rtmp_handler.c

### DIFF
--- a/ngx_rtmp_handler.c
+++ b/ngx_rtmp_handler.c
@@ -868,6 +868,7 @@ ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
 
                 bi->pos += (ngx_cpymem(bo->last, bi->pos,
                             bo->end - bo->last) - bo->last);
+                bo->last = bo->end;
                 lo->next = ngx_rtmp_alloc_in_buf(s);
                 lo = lo->next;
                 if (lo == NULL) {


### PR DESCRIPTION
fixbug lost data when chunk_size changing, the frontier of stream data should by pointed by the pos and last of ngx_buf_t