### PR TITLE
Add publisher redirect support, partially

### DIFF
--- a/ngx_rtmp_amf.c
+++ b/ngx_rtmp_amf.c
@@ -27,7 +27,7 @@ ngx_rtmp_amf_reverse_copy(void *dst, void* src, size_t len)
     return dst;
 }
 
-#define NGX_RTMP_AMF_DEBUG_SIZE 16
+#define NGX_RTMP_AMF_DEBUG_SIZE 72
 
 #ifdef NGX_DEBUG
 static void

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -73,6 +73,7 @@ typedef struct {
     ngx_msec_t                                  update_timeout;
     ngx_flag_t                                  update_strict;
     ngx_flag_t                                  relay_redirect;
+    ngx_flag_t                                  send_redirect;
 } ngx_rtmp_notify_app_conf_t;
 
 

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -1059,10 +1059,22 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
     if (nacf->send_redirect) {
         // Send 302 redirect and go next
 
-        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                   "notify: send 302 redirect for stream '%s' to new location '%*s'", v->name, rc, name);
 
-        ngx_rtmp_send_redirect_status("Publish here", name);
+        local_name.data = ngx_palloc(s->connection->pool, rc);
+        local_name.len = rc;
+        *ngx_cpymem(local_name.data, name, rc) = 0;
+
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                      "notify: check redirect to location: '%s'", local_name.data);
+
+        ngx_rtmp_send_redirect_status(s, "Publish here", local_name);
+
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                      "notify: release location memory");
+
+        ngx_pfree(s->connection->pool, local_name.data);
 
         goto next;
 
@@ -1072,7 +1084,7 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
         ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t) rc);
     }
 
-    ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                   "notify: push '%s' to '%*s'", v->name, rc, name);
 
     local_name.data = v->name;

--- a/ngx_rtmp_send.c
+++ b/ngx_rtmp_send.c
@@ -491,7 +491,7 @@ ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code, char* level,
           NULL, 0 },
 
         { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
+          ngx_string("info"),
           out_inf,
           sizeof(out_inf) },
     };
@@ -597,16 +597,24 @@ ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code, char* level,
 // ----------- Based on Adobe FMS 3 application.redirectConnection description --------- //
 
 ngx_chain_t *
-ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
+ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_url)
 {
     ngx_rtmp_header_t               h;
     static double                   trans;
+    static double                   dcode;
 
-    static ngx_rtmp_amf_elt_t       out_inf_ex[] = {
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                   "create redirect status: got data");
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                   "create redirect status: status code='%s' level='%s' "
+                   "ex.code=%ui ex.redirect='%s'",
+                   "NetConnection.Connect.Rejected", "Error", 302, to_url.data);
 
-        { NGX_RTMP_AMF_STRING,
+    static ngx_rtmp_amf_elt_t       out_inf_ex_data[] = {
+
+        { NGX_RTMP_AMF_NUMBER,
           ngx_string("code"),
-          NULL, 0 },
+          &dcode, 0 },
 
         { NGX_RTMP_AMF_STRING,
           ngx_string("redirect"),
@@ -629,8 +637,8 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
 
         { NGX_RTMP_AMF_OBJECT,
           ngx_string("ex"),
-          out_inf_ex,
-          sizeof(out_inf_ex) },
+          out_inf_ex_data,
+          sizeof(out_inf_ex_data) },
     };
 
     static ngx_rtmp_amf_elt_t       out_elts[] = {
@@ -648,21 +656,19 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
           NULL, 0 },
 
         { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
+          ngx_string("info"),
           out_inf,
           sizeof(out_inf) },
     };
 
-    ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "create: status code='%s' level='%s' "
-                   "ex.code='%s' ex.redirect='%s'",
-                   "NetConnection.Connect.Rejected", "Error", "302", to_url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                   "create redirect status: set structure data");
 
     out_inf[0].data = "NetConnection.Connect.Rejected";
     out_inf[1].data = "Error";
     out_inf[2].data = desc;
-    out_inf_ex[0].data = "302";
-    out_inf_ex[1].data = to_url;
+    dcode = 302;
+    out_inf_ex_data[1].data = to_url.data;
 
     memset(&h, 0, sizeof(h));
 
@@ -677,7 +683,7 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
 
 ngx_int_t
 ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s,
-                          char *desc, char *to_url)
+                          char *desc, ngx_str_t to_url)
 {
     return ngx_rtmp_send_shared_packet(s,
            ngx_rtmp_create_redirect_status(s, desc, to_url));

--- a/ngx_rtmp_send.c
+++ b/ngx_rtmp_send.c
@@ -653,9 +653,9 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
     };
 
     ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "create: status code='%s' level='%s' description='%s' "
+                   "create: status code='%s' level='%s' "
                    "ex.code='%s' redirect='%s'",
-                   "NetConnection.Connect.Rejected", "Error", desc, "302", to_url);
+                   "NetConnection.Connect.Rejected", "Error", "302", to_url);
 
     out_inf[0].data = "NetConnection.Connect.Rejected";
     out_inf[1].data = "Error";

--- a/ngx_rtmp_send.c
+++ b/ngx_rtmp_send.c
@@ -629,7 +629,8 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
 
         { NGX_RTMP_AMF_OBJECT,
           ngx_string("ex"),
-          NULL, 0 },
+          out_inf_ex,
+          sizeof(out_inf_ex) },
     };
 
     static ngx_rtmp_amf_elt_t       out_elts[] = {
@@ -654,7 +655,7 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
 
     ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: status code='%s' level='%s' "
-                   "ex.code='%s' redirect='%s'",
+                   "ex.code='%s' ex.redirect='%s'",
                    "NetConnection.Connect.Rejected", "Error", "302", to_url);
 
     out_inf[0].data = "NetConnection.Connect.Rejected";
@@ -662,7 +663,6 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, char *to_url)
     out_inf[2].data = desc;
     out_inf_ex[0].data = "302";
     out_inf_ex[1].data = to_url;
-    out_inf[3].data = &out_inf_ex;
 
     memset(&h, 0, sizeof(h));
 

--- a/ngx_rtmp_send.c
+++ b/ngx_rtmp_send.c
@@ -491,7 +491,7 @@ ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code, char* level,
           NULL, 0 },
 
         { NGX_RTMP_AMF_OBJECT,
-          ngx_string("info"),
+          ngx_null_string,
           out_inf,
           sizeof(out_inf) },
     };
@@ -503,6 +503,7 @@ ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code, char* level,
     out_inf[0].data = level;
     out_inf[1].data = code;
     out_inf[2].data = desc;
+    trans = 0;
 
     memset(&h, 0, sizeof(h));
 
@@ -597,18 +598,18 @@ ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code, char* level,
 // ----------- Based on Adobe FMS 3 application.redirectConnection description --------- //
 
 ngx_chain_t *
-ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_url)
+ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *callMethod, char *desc, ngx_str_t to_url)
 {
     ngx_rtmp_header_t               h;
-    static double                   trans;
+    static double                   dtrans;
     static double                   dcode;
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                    "create redirect status: got data");
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                   "create redirect status: status code='%s' level='%s' "
-                   "ex.code=%ui ex.redirect='%s'",
-                   "NetConnection.Connect.Rejected", "Error", 302, to_url.data);
+                   "create redirect status: method='%s', status code='%s' level='%s' "
+                   "ex.code=%ui ex.redirect='%s'", callMethod,
+                   "NetConnection.Connect.Rejected", "error", 302, to_url.data);
 
     static ngx_rtmp_amf_elt_t       out_inf_ex_data[] = {
 
@@ -624,12 +625,12 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_
     static ngx_rtmp_amf_elt_t       out_inf[] = {
 
         { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          NULL, 0 },
+          ngx_string("level"),
+          "error", 0 },
 
         { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          NULL, 0 },
+          ngx_string("code"),
+          "NetConnection.Connect.Rejected", 0 },
 
         { NGX_RTMP_AMF_STRING,
           ngx_string("description"),
@@ -645,18 +646,18 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_
 
         { NGX_RTMP_AMF_STRING,
           ngx_null_string,
-          "onStatus", 0 },
+          NULL, 0 },
 
         { NGX_RTMP_AMF_NUMBER,
           ngx_null_string,
-          &trans, 0 },
+          &dtrans, 0 },
 
         { NGX_RTMP_AMF_NULL,
           ngx_null_string,
           NULL, 0 },
 
         { NGX_RTMP_AMF_OBJECT,
-          ngx_string("info"),
+          ngx_null_string,
           out_inf,
           sizeof(out_inf) },
     };
@@ -664,15 +665,15 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                    "create redirect status: set structure data");
 
-    out_inf[0].data = "NetConnection.Connect.Rejected";
-    out_inf[1].data = "Error";
+    out_elts[0].data = callMethod;
     out_inf[2].data = desc;
     dcode = 302;
+    dtrans = 0;
     out_inf_ex_data[1].data = to_url.data;
 
-    memset(&h, 0, sizeof(h));
+    ngx_memzero(&h, sizeof(h));
 
-    h.type = NGX_RTMP_MSG_AMF_META;
+    h.type = NGX_RTMP_MSG_AMF_CMD;
     h.csid = NGX_RTMP_CSID_AMF;
     h.msid = NGX_RTMP_MSID;
 
@@ -683,10 +684,52 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *desc, ngx_str_t to_
 
 ngx_int_t
 ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s,
-                          char *desc, ngx_str_t to_url)
+                          char *callMethod, char *desc, ngx_str_t to_url)
 {
     return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_redirect_status(s, desc, to_url));
+           ngx_rtmp_create_redirect_status(s, callMethod, desc, to_url));
+}
+
+
+ngx_chain_t *
+ngx_rtmp_create_close_method(ngx_rtmp_session_t *s, char *methodName)
+{
+    ngx_rtmp_header_t               h;
+    static double                   dtrans;
+
+    static ngx_rtmp_amf_elt_t       out_elts[] = {
+
+        { NGX_RTMP_AMF_STRING,
+          ngx_null_string,
+          NULL, 0 },
+
+        { NGX_RTMP_AMF_NUMBER,
+          ngx_null_string,
+          &dtrans, 0 },
+    };
+
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                   "create close method: set structure data");
+
+    out_elts[0].data = methodName;
+    dtrans = 0;
+
+    ngx_memzero(&h, sizeof(h));
+
+    h.type = NGX_RTMP_MSG_AMF_CMD;
+    h.csid = NGX_RTMP_CSID_AMF;
+    h.msid = NGX_RTMP_MSID;
+
+    return ngx_rtmp_create_amf(s, &h, out_elts,
+                               sizeof(out_elts) / sizeof(out_elts[0]));
+}
+
+
+ngx_int_t
+ngx_rtmp_send_close_method(ngx_rtmp_session_t *s, char *methodName)
+{
+    return ngx_rtmp_send_shared_packet(s,
+           ngx_rtmp_create_close_method(s, methodName));
 }
 
 


### PR DESCRIPTION
Support behaviour like FMS 3.

- new option for notify module
- magick reject on connect or publish with 302 code and redirect uri
- on_connect and on_publish notify url callbacks should return 302 and Location header

Now it works with patched rtmpdump (and ffmpeg).
FMLE 3.2 not support such thing. Abobe suck.