### PR TITLE
Fix gcc pedantic build warnings/errors

### DIFF
--- a/config
+++ b/config
@@ -86,7 +86,9 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS                             \
                 $ngx_addon_dir/hls/ngx_rtmp_mpegts.c        \
                 $ngx_addon_dir/dash/ngx_rtmp_mp4.c          \
                 "
+
 CFLAGS="$CFLAGS -I$ngx_addon_dir"
+# Debug build with all warnings as errors
+# CFLAGS="$CFLAGS -I$ngx_addon_dir -Wall -Wpointer-arith -Wno-unused-parameter -Werror"
 
 USE_OPENSSL=YES
-

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -854,7 +854,6 @@ ngx_rtmp_hls_get_fragment_id(ngx_rtmp_session_t *s, uint64_t ts)
 static ngx_str_t *
 ngx_rtmp_hls_get_fragment_datetime(ngx_rtmp_session_t *s, uint64_t ts)
 {
-    ngx_rtmp_hls_ctx_t         *ctx;
     ngx_rtmp_hls_app_conf_t    *hacf;
     ngx_str_t                  *datetime;
     ngx_tm_t                    tm;
@@ -864,7 +863,6 @@ ngx_rtmp_hls_get_fragment_datetime(ngx_rtmp_session_t *s, uint64_t ts)
     datetime->data = NULL;
     datetime->len = 0;
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_hls_module);
     hacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_hls_module);
 
     switch (hacf->datetime) {
@@ -889,7 +887,7 @@ ngx_rtmp_hls_get_fragment_datetime(ngx_rtmp_session_t *s, uint64_t ts)
 
     case NGX_RTMP_HLS_DATETIME_SYSTEM:
         datetime->data = (u_char *) ngx_pcalloc(s->connection->pool, ngx_cached_http_log_iso8601.len * sizeof(u_char));
-        ngx_cpymem(datetime->data, ngx_cached_http_log_iso8601.data, ngx_cached_http_log_iso8601.len);
+        ngx_memcpy(datetime->data, ngx_cached_http_log_iso8601.data, ngx_cached_http_log_iso8601.len);
         datetime->len = ngx_cached_http_log_iso8601.len;
         return datetime;
 

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -583,6 +583,9 @@ ngx_int_t ngx_rtmp_send_status(ngx_rtmp_session_t *s, char *code,
 ngx_int_t ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code,
         char* level, ngx_uint_t duration, ngx_uint_t bytes);
 ngx_int_t ngx_rtmp_send_sample_access(ngx_rtmp_session_t *s);
+ngx_int_t ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s,
+        char *callMethod, char *desc, ngx_str_t to_url);
+ngx_int_t ngx_rtmp_send_close_method(ngx_rtmp_session_t *s, char *methodName);
 
 
 /* Frame types */

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -501,7 +501,7 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
     rctx->session = rs;
     ngx_rtmp_set_ctx(rs, rctx, ngx_rtmp_relay_module);
     ngx_str_set(&rs->flashver, "ngx-local-relay");
-    ngx_cpymem(&rs->app, &rctx->app, sizeof(rctx->app));
+    ngx_memcpy(&rs->app, &rctx->app, sizeof(rctx->app));
 
 #if (NGX_STAT_STUB)
     (void) ngx_atomic_fetch_add(ngx_stat_active, 1);


### PR DESCRIPTION
- use ngx_memcpy if return value not needed
- remove some unused vars
- add new function definitions for send submodule