### PR TITLE
Correctly parse meta data

### DIFF
--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -663,10 +663,6 @@ ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s)
 
     static ngx_rtmp_amf_elt_t       out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onMetaData", 0 },
-
         { NGX_RTMP_AMF_OBJECT,
           ngx_null_string,
           out_inf, sizeof(out_inf) },


### PR DESCRIPTION
Flash video stream's meta data (onMetaData) contains only an object (and no string before it), so read the object only.