### PR TITLE
Store audio and video bitrate in variables of type double

### DIFF
--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -887,9 +887,9 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
     if (v.duration != -1) ctx->duration = (double) v.duration;
     if (v.frame_rate != -1) ctx->frame_rate = (double) v.frame_rate;
-    if (v.video_data_rate != -1) ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
+    if (v.video_data_rate != -1) ctx->video_data_rate = v.video_data_rate;
     if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
-    if (v.audio_data_rate != -1) ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
+    if (v.audio_data_rate != -1) ctx->audio_data_rate = v.audio_data_rate;
     if (v.audio_codec_id_n != -1) ctx->audio_codec_id = (v.audio_codec_id_n == 0
             ? NGX_RTMP_AUDIO_UNCOMPRESSED : (ngx_uint_t) v.audio_codec_id_n);
     if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -54,9 +54,9 @@ typedef struct {
     ngx_uint_t                  height;
     double                      duration;
     double                      frame_rate;
-    ngx_uint_t                  video_data_rate;
+    double                      video_data_rate;
     ngx_uint_t                  video_codec_id;
-    ngx_uint_t                  audio_data_rate;
+    double                      audio_data_rate;
     ngx_uint_t                  audio_codec_id;
     ngx_uint_t                  aac_profile;
     ngx_uint_t                  aac_chan_conf;


### PR DESCRIPTION
Bitrate's fraction part is lost when casting to integer type, so it
should be stored in double.