### PR TITLE
Specifically state that we dont support HLS closed captions

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -457,7 +457,7 @@ ngx_rtmp_hls_write_variant_playlist(ngx_rtmp_session_t *s)
         p = buffer;
         last = buffer + sizeof(buffer);
 
-        p = ngx_slprintf(p, last, "#EXT-X-STREAM-INF:PROGRAM-ID=1");
+        p = ngx_slprintf(p, last, "#EXT-X-STREAM-INF:PROGRAM-ID=1,CLOSED-CAPTIONS=NONE");
 
         arg = var->args.elts;
         for (k = 0; k < var->args.nelts; k++, arg++) {


### PR DESCRIPTION
As per the title. iOS will show a closed caption icon in its player because we don't state in the m3u8 that closed captions are not available.

This module doesn't support closed captions/subtitles (yet) so until it does, this is just a nice tidy up