### PR TITLE
HLS Live DVR Flag

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -22,3 +22,5 @@
   * Notify
     * [on_playlist](directives.md#on_playlist)
     * [notify_send_redirect](directives.md#notify_send_redirect)
+  * Client Caching
+  	* [hls_allow_client_cache](directives.md#hls_allow_client_cache)

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -98,6 +98,7 @@ Table of Contents
     * [hls_fragment_slicing](#hls_fragment_slicing)
     * [hls_variant](#hls_variant)
     * [hls_type](#hls_type)
+    * [hls_allow_client_cache](#hls_allow_client_cache)
     * [hls_keys](#hls_keys)
     * [hls_key_path](#hls_key_path)
     * [hls_key_url](#hls_key_url)
@@ -1413,6 +1414,19 @@ from the start of playlist. When in `event` mode make sure playlist length
 is enough for the whole event. Default is `live`;
 ```sh
 hls_type event;
+```
+
+#### hls_allow_client_cache
+Syntax: `hls_allow_client_cache enabled|disabled`  
+Context: rtmp, server, application  
+
+Enables (or disables) client cache with `#EXT-X-ALLOW-CACHE` playlist
+directive.  Setting value to enabled allows supported clients to
+cache segments in a live DVR manner.  Setting value to disabled explicitly 
+tells supported clients to never cache segments.
+Unset by default (playlist directive will be absent).
+```sh
+hls_allow_client_cache enabled;
 ```
 
 #### hls_keys

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -110,7 +110,7 @@ typedef struct {
     ngx_msec_t                          max_audio_delay;
     size_t                              audio_buffer_size;
     ngx_flag_t                          cleanup;
-    ngx_flag_t                          dvr;
+    ngx_uint_t                          allow_client_cache;
     ngx_array_t                        *variant;
     ngx_str_t                           base_url;
     ngx_int_t                           granularity;
@@ -137,6 +137,9 @@ typedef struct {
 
 #define NGX_RTMP_HLS_TYPE_LIVE          1
 #define NGX_RTMP_HLS_TYPE_EVENT         2
+
+#define NGX_RTMP_HLS_CACHE_DISABLED     1
+#define NGX_RTMP_HLS_CACHE_ENABLED      2
 
 
 static ngx_conf_enum_t                  ngx_rtmp_hls_naming_slots[] = {
@@ -168,6 +171,11 @@ static ngx_conf_enum_t                  ngx_rtmp_hls_type_slots[] = {
     { ngx_null_string,                  0 }
 };
 
+static ngx_conf_enum_t                  ngx_rtmp_hls_cache[] = {
+    { ngx_string("enabled"),            NGX_RTMP_HLS_CACHE_ENABLED  },
+    { ngx_string("disabled"),           NGX_RTMP_HLS_CACHE_DISABLED },
+    { ngx_null_string,                  0 }
+};
 
 static ngx_command_t ngx_rtmp_hls_commands[] = {
 
@@ -283,11 +291,11 @@ static ngx_command_t ngx_rtmp_hls_commands[] = {
       offsetof(ngx_rtmp_hls_app_conf_t, cleanup),
       NULL },
 
-    { ngx_string("hls_dvr"),
+    { ngx_string("hls_allow_client_cache"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
+      ngx_conf_set_enum_slot,
       NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_hls_app_conf_t, dvr),
+      offsetof(ngx_rtmp_hls_app_conf_t, allow_client_cache),
       NULL },       
 
     { ngx_string("hls_variant"),
@@ -572,8 +580,10 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
         p = ngx_slprintf(p, end, "#EXT-X-PLAYLIST-TYPE:EVENT\n");
     }
 
-    if (hacf->dvr) {
+    if (hacf->allow_client_cache && hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_ENABLED) {
         p = ngx_slprintf(p, end, "#EXT-X-ALLOW-CACHE:1\n");
+    } else if (hacf->allow_client_cache && hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_DISABLED) {
+        p = ngx_slprintf(p, end, "#EXT-X-ALLOW-CACHE:0\n");
     }
 
     n = ngx_write_fd(fd, buffer, p - buffer);
@@ -2452,7 +2462,7 @@ ngx_rtmp_hls_create_app_conf(ngx_conf_t *cf)
     conf->max_audio_delay = NGX_CONF_UNSET_MSEC;
     conf->audio_buffer_size = NGX_CONF_UNSET_SIZE;
     conf->cleanup = NGX_CONF_UNSET;
-    conf->dvr = NGX_CONF_UNSET;
+    conf->allow_client_cache = NGX_CONF_UNSET_UINT;
     conf->granularity = NGX_CONF_UNSET;
     conf->keys = NGX_CONF_UNSET;
     conf->frags_per_key = NGX_CONF_UNSET_UINT;
@@ -2490,7 +2500,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->audio_buffer_size, prev->audio_buffer_size,
                               NGX_RTMP_HLS_BUFSIZE);
     ngx_conf_merge_value(conf->cleanup, prev->cleanup, 1);
-    ngx_conf_merge_value(conf->dvr, prev->dvr, 0);
+    ngx_conf_merge_value(conf->allow_client_cache, prev->allow_client_cache, 0);
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -580,9 +580,9 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
         p = ngx_slprintf(p, end, "#EXT-X-PLAYLIST-TYPE:EVENT\n");
     }
 
-    if (hacf->allow_client_cache && hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_ENABLED) {
+    if (hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_ENABLED) {
         p = ngx_slprintf(p, end, "#EXT-X-ALLOW-CACHE:1\n");
-    } else if (hacf->allow_client_cache && hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_DISABLED) {
+    } else if (hacf->allow_client_cache == NGX_RTMP_HLS_CACHE_DISABLED) {
         p = ngx_slprintf(p, end, "#EXT-X-ALLOW-CACHE:0\n");
     }
 
@@ -2500,7 +2500,6 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->audio_buffer_size, prev->audio_buffer_size,
                               NGX_RTMP_HLS_BUFSIZE);
     ngx_conf_merge_value(conf->cleanup, prev->cleanup, 1);
-    ngx_conf_merge_value(conf->allow_client_cache, prev->allow_client_cache, 0);
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -296,7 +296,7 @@ static ngx_command_t ngx_rtmp_hls_commands[] = {
       ngx_conf_set_enum_slot,
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_hls_app_conf_t, allow_client_cache),
-      NULL },       
+      &ngx_rtmp_hls_cache },       
 
     { ngx_string("hls_variant"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -110,6 +110,7 @@ typedef struct {
     ngx_msec_t                          max_audio_delay;
     size_t                              audio_buffer_size;
     ngx_flag_t                          cleanup;
+    ngx_flag_t                          dvr;
     ngx_array_t                        *variant;
     ngx_str_t                           base_url;
     ngx_int_t                           granularity;

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -109,8 +109,7 @@ typedef struct {
     ngx_path_t                         *slot;
     ngx_msec_t                          max_audio_delay;
     size_t                              audio_buffer_size;
-    ngx_cleanup_t                       cleanup;
-    ngx_dvr_t                           dvr;
+    ngx_flag_t                          cleanup;
     ngx_array_t                        *variant;
     ngx_str_t                           base_url;
     ngx_int_t                           granularity;

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -262,13 +262,6 @@ static ngx_command_t ngx_rtmp_hls_commands[] = {
       offsetof(ngx_rtmp_hls_app_conf_t, type),
       &ngx_rtmp_hls_type_slots },
 
-    { ngx_string("hls_dvr"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_hls_app_conf_t, dvr),
-      NULL },      
-
     { ngx_string("hls_max_audio_delay"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,
@@ -289,6 +282,13 @@ static ngx_command_t ngx_rtmp_hls_commands[] = {
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_hls_app_conf_t, cleanup),
       NULL },
+
+    { ngx_string("hls_dvr"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_RTMP_APP_CONF_OFFSET,
+      offsetof(ngx_rtmp_hls_app_conf_t, dvr),
+      NULL },       
 
     { ngx_string("hls_variant"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
@@ -2449,10 +2449,10 @@ ngx_rtmp_hls_create_app_conf(ngx_conf_t *cf)
     conf->datetime = NGX_CONF_UNSET_UINT;
     conf->slicing = NGX_CONF_UNSET_UINT;
     conf->type = NGX_CONF_UNSET_UINT;
-    conf->dvr = NGX_CONF_UNSET;
     conf->max_audio_delay = NGX_CONF_UNSET_MSEC;
     conf->audio_buffer_size = NGX_CONF_UNSET_SIZE;
     conf->cleanup = NGX_CONF_UNSET;
+    conf->dvr = NGX_CONF_UNSET;
     conf->granularity = NGX_CONF_UNSET;
     conf->keys = NGX_CONF_UNSET;
     conf->frags_per_key = NGX_CONF_UNSET_UINT;
@@ -2476,7 +2476,6 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_msec_value(conf->sync, prev->sync, 2);
     ngx_conf_merge_msec_value(conf->playlen, prev->playlen, 30000);
     ngx_conf_merge_value(conf->continuous, prev->continuous, 1);
-    ngx_conf_merge_value(conf->dvr, prev->dvr, 0);
     ngx_conf_merge_value(conf->nested, prev->nested, 0);
     ngx_conf_merge_uint_value(conf->naming, prev->naming,
                               NGX_RTMP_HLS_NAMING_SEQUENTIAL);
@@ -2491,6 +2490,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->audio_buffer_size, prev->audio_buffer_size,
                               NGX_RTMP_HLS_BUFSIZE);
     ngx_conf_merge_value(conf->cleanup, prev->cleanup, 1);
+    ngx_conf_merge_value(conf->dvr, prev->dvr, 0);
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);


### PR DESCRIPTION
Thanks for all your work on this project, it deserves to be maintained.

This flag adds a header to the index file to allow supported players (e.g. JWPlayer's premium player) to cache segments and allow seeking within the live window.  In short, it strips in the following tag into the playlist:

`#EXT-X-ALLOW-CACHE:1`

Sample config stanza:

```
application hls_dvr {
    live on;
    hls on;
    hls_dvr on;
    hls_path /tmp/hls_dvr;
    hls_fragment_naming system;
    hls_fragment 15s;
    hls_playlist_length 700s;
    allow publish 127.0.0.1;
}
```

Please note, a player that supports this feature is required to actually seek within the sliding window.