### PR TITLE
bugfix of stream_buckets

### DIFF
--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -40,7 +40,7 @@ static ngx_command_t  ngx_rtmp_live_commands[] = {
 
     { ngx_string("stream_buckets"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_str_slot,
+      ngx_conf_set_num_slot,
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_live_app_conf_t, nbuckets),
       NULL },


### PR DESCRIPTION
This bug will lead to the failure of setting ngx_rtmp_live_app_conf_t->nbuckets.

by default it is 1024,but if you set it specificly, it will be wrong.