### PR TITLE
dash: Ensure directory exists before opening fragments

### DIFF
--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -20,6 +20,7 @@ static void * ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf);
 static char * ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf,
        void *parent, void *child);
 static ngx_int_t ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s);
+static ngx_int_t ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s);
 
 
 #define NGX_RTMP_DASH_BUFSIZE           (1024*1024)
@@ -771,6 +772,10 @@ ngx_rtmp_dash_open_fragments(ngx_rtmp_session_t *s)
 
     if (ctx->opened) {
         return NGX_OK;
+    }
+
+    if (ngx_rtmp_dash_ensure_directory(s) != NGX_OK) {
+        return NGX_ERROR;
     }
 
     ngx_rtmp_dash_open_fragment(s, &ctx->video, ctx->id, 'v');


### PR DESCRIPTION
Streams that take a long time from initial Publish to
actually sending data might get their directories reaped.

Testcase: Xsplit Encoder with stream delay set to a value larger
than the playlist length.

Fixes #115.