### PR TITLE
move ngx_events_module and ngx_event_core module to the posion before…

### DIFF
--- a/config
+++ b/config
@@ -88,7 +88,7 @@ if [ "$ngx_module_link" = "" ] ; then
 	# Old nginx version
 	ngx_module_link=NONE
 
-	CORE_MODULES="$CORE_MODULES $RTMP_CORE_MODULES"
+	EVENT_MODULES="$EVENT_MODULES $RTMP_CORE_MODULES"
 	HTTP_MODULES="$HTTP_MODULES $RTMP_HTTP_MODULES"
 	NGX_ADDON_DEPS="$NGX_ADDON_DEPS $RTMP_DEPS"
 	NGX_ADDON_SRCS="$NGX_ADDON_SRCS $RTMP_CORE_SRCS $RTMP_HTTP_SRCS"
@@ -99,7 +99,7 @@ if [ $ngx_module_link = DYNAMIC ] ; then
     ngx_module_srcs="$RTMP_CORE_SRCS $RTMP_HTTP_SRCS"
     . auto/module
 elif [ $ngx_module_link = ADDON ] ; then
-    ngx_module_type=CORE
+    ngx_module_type=EVENT
     ngx_module_name=$RTMP_CORE_MODULES
     ngx_module_srcs=$RTMP_CORE_SRCS
     . auto/module


### PR DESCRIPTION
Hello, sergey,

I suggest to make a little change to the config file. For the reason list below:

The  current config file makes all rtmp modules (including the core type module ngx_rtmp_module)  come before ngx_events_module and ngx_event_core_module in the ngx_modules array.

The order of modules in ngx_modules array has an effect on the order of executing of their init_process hook.

So, it's impossible to add  a per-worker timer by  ngx_add_timer in init_process hook of existing rtmp module or a new rtmp module by your own. Because the init_process hook of ngx_event_core_module, namely ngx_event_module_init, will clear all the timers by  calling ngx_event_timer_init.

I can't guess why arut made it this way,  Please have a check. Thanks.