### PR TITLE
clang-fomat codestyle

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: "LLVM"
+Language: Cpp
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+ColumnLimit: 80
+IndentWidth: 4
+UseTab: Never

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -1,198 +1,172 @@
 
 
+#include "ngx_rtmp_live_module.h"
+#include "ngx_rtmp_mp4.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_rtmp.h>
 #include <ngx_rtmp_codec_module.h>
-#include "ngx_rtmp_live_module.h"
-#include "ngx_rtmp_mp4.h"
 
-
-static ngx_rtmp_publish_pt              next_publish;
-static ngx_rtmp_close_stream_pt         next_close_stream;
-static ngx_rtmp_stream_begin_pt         next_stream_begin;
-static ngx_rtmp_stream_eof_pt           next_stream_eof;
-static ngx_rtmp_playlist_pt             next_playlist;
-
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_close_stream_pt next_close_stream;
+static ngx_rtmp_stream_begin_pt next_stream_begin;
+static ngx_rtmp_stream_eof_pt next_stream_eof;
+static ngx_rtmp_playlist_pt next_playlist;
 
 static ngx_int_t ngx_rtmp_dash_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
+static void *ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                          void *child);
 static ngx_int_t ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s);
 static ngx_int_t ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s);
 
+#define NGX_RTMP_DASH_BUFSIZE (1024 * 1024)
+#define NGX_RTMP_DASH_MAX_MDAT (10 * 1024 * 1024)
+#define NGX_RTMP_DASH_MAX_SAMPLES 1024
+#define NGX_RTMP_DASH_DIR_ACCESS 0744
 
-#define NGX_RTMP_DASH_BUFSIZE           (1024*1024)
-#define NGX_RTMP_DASH_MAX_MDAT          (10*1024*1024)
-#define NGX_RTMP_DASH_MAX_SAMPLES       1024
-#define NGX_RTMP_DASH_DIR_ACCESS        0744
-
-#define NGX_RTMP_DASH_GMT_LENGTH        sizeof("1970-09-28T12:00:00+06:00")
+#define NGX_RTMP_DASH_GMT_LENGTH sizeof("1970-09-28T12:00:00+06:00")
 
 typedef struct {
-    uint32_t                            timestamp;
-    uint32_t                            duration;
+    uint32_t timestamp;
+    uint32_t duration;
 } ngx_rtmp_dash_frag_t;
 
-
 typedef struct {
-    ngx_uint_t                          id;
-    ngx_uint_t                          opened;
-    ngx_uint_t                          mdat_size;
-    ngx_uint_t                          sample_count;
-    ngx_uint_t                          sample_mask;
-    ngx_fd_t                            fd;
-    char                                type;
-    uint32_t                            earliest_pres_time;
-    uint32_t                            latest_pres_time;
-    ngx_rtmp_mp4_sample_t               samples[NGX_RTMP_DASH_MAX_SAMPLES];
+    ngx_uint_t id;
+    ngx_uint_t opened;
+    ngx_uint_t mdat_size;
+    ngx_uint_t sample_count;
+    ngx_uint_t sample_mask;
+    ngx_fd_t fd;
+    char type;
+    uint32_t earliest_pres_time;
+    uint32_t latest_pres_time;
+    ngx_rtmp_mp4_sample_t samples[NGX_RTMP_DASH_MAX_SAMPLES];
 } ngx_rtmp_dash_track_t;
 
-
 typedef struct {
-    ngx_str_t                           playlist;
-    ngx_str_t                           playlist_bak;
-    ngx_str_t                           name;
-    ngx_str_t                           stream;
-    ngx_time_t                          start_time;
+    ngx_str_t playlist;
+    ngx_str_t playlist_bak;
+    ngx_str_t name;
+    ngx_str_t stream;
+    ngx_time_t start_time;
 
-    ngx_uint_t                          nfrags;
-    ngx_uint_t                          frag;
-    ngx_rtmp_dash_frag_t               *frags; /* circular 2 * winfrags + 1 */
+    ngx_uint_t nfrags;
+    ngx_uint_t frag;
+    ngx_rtmp_dash_frag_t *frags; /* circular 2 * winfrags + 1 */
 
-    unsigned                            opened:1;
-    unsigned                            has_video:1;
-    unsigned                            has_audio:1;
+    unsigned opened : 1;
+    unsigned has_video : 1;
+    unsigned has_audio : 1;
 
-    ngx_file_t                          video_file;
-    ngx_file_t                          audio_file;
+    ngx_file_t video_file;
+    ngx_file_t audio_file;
 
-    ngx_uint_t                          id;
+    ngx_uint_t id;
 
-    ngx_rtmp_dash_track_t               audio;
-    ngx_rtmp_dash_track_t               video;
+    ngx_rtmp_dash_track_t audio;
+    ngx_rtmp_dash_track_t video;
 } ngx_rtmp_dash_ctx_t;
 
-
 typedef struct {
-    ngx_str_t                           path;
-    ngx_msec_t                          playlen;
+    ngx_str_t path;
+    ngx_msec_t playlen;
 } ngx_rtmp_dash_cleanup_t;
 
-
 typedef struct {
-    ngx_flag_t                          dash;
-    ngx_msec_t                          fraglen;
-    ngx_msec_t                          playlen;
-    ngx_flag_t                          nested;
-    ngx_str_t                           path;
-    ngx_uint_t                          winfrags;
-    ngx_flag_t                          cleanup;
-    ngx_path_t                         *slot;
+    ngx_flag_t dash;
+    ngx_msec_t fraglen;
+    ngx_msec_t playlen;
+    ngx_flag_t nested;
+    ngx_str_t path;
+    ngx_uint_t winfrags;
+    ngx_flag_t cleanup;
+    ngx_path_t *slot;
 } ngx_rtmp_dash_app_conf_t;
-
 
 static ngx_command_t ngx_rtmp_dash_commands[] = {
 
-    { ngx_string("dash"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, dash),
-      NULL },
+    {ngx_string("dash"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                             NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, dash), NULL},
 
-    { ngx_string("dash_fragment"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, fraglen),
-      NULL },
+    {ngx_string("dash_fragment"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                      NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, fraglen), NULL},
 
-    { ngx_string("dash_path"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_str_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, path),
-      NULL },
+    {ngx_string("dash_path"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                  NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, path), NULL},
 
-    { ngx_string("dash_playlist_length"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, playlen),
-      NULL },
+    {ngx_string("dash_playlist_length"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, playlen), NULL},
 
-    { ngx_string("dash_cleanup"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, cleanup),
-      NULL },
+    {ngx_string("dash_cleanup"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                     NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, cleanup), NULL},
 
-    { ngx_string("dash_nested"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_dash_app_conf_t, nested),
-      NULL },
+    {ngx_string("dash_nested"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                    NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_dash_app_conf_t, nested), NULL},
 
-    ngx_null_command
+    ngx_null_command};
+
+static ngx_rtmp_module_t ngx_rtmp_dash_module_ctx = {
+    NULL,                            /* preconfiguration */
+    ngx_rtmp_dash_postconfiguration, /* postconfiguration */
+
+    NULL, /* create main configuration */
+    NULL, /* init main configuration */
+
+    NULL, /* create server configuration */
+    NULL, /* merge server configuration */
+
+    ngx_rtmp_dash_create_app_conf, /* create location configuration */
+    ngx_rtmp_dash_merge_app_conf,  /* merge location configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_dash_module_ctx = {
-    NULL,                               /* preconfiguration */
-    ngx_rtmp_dash_postconfiguration,    /* postconfiguration */
-
-    NULL,                               /* create main configuration */
-    NULL,                               /* init main configuration */
-
-    NULL,                               /* create server configuration */
-    NULL,                               /* merge server configuration */
-
-    ngx_rtmp_dash_create_app_conf,      /* create location configuration */
-    ngx_rtmp_dash_merge_app_conf,       /* merge location configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_dash_module = {
+ngx_module_t ngx_rtmp_dash_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_dash_module_ctx,          /* module context */
-    ngx_rtmp_dash_commands,             /* module directives */
-    NGX_RTMP_MODULE,                    /* module type */
-    NULL,                               /* init master */
-    NULL,                               /* init module */
-    NULL,                               /* init process */
-    NULL,                               /* init thread */
-    NULL,                               /* exit thread */
-    NULL,                               /* exit process */
-    NULL,                               /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_dash_module_ctx, /* module context */
+    ngx_rtmp_dash_commands,    /* module directives */
+    NGX_RTMP_MODULE,           /* module type */
+    NULL,                      /* init master */
+    NULL,                      /* init module */
+    NULL,                      /* init process */
+    NULL,                      /* init thread */
+    NULL,                      /* exit thread */
+    NULL,                      /* exit process */
+    NULL,                      /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static ngx_rtmp_dash_frag_t *
-ngx_rtmp_dash_get_frag(ngx_rtmp_session_t *s, ngx_int_t n)
+static ngx_rtmp_dash_frag_t *ngx_rtmp_dash_get_frag(ngx_rtmp_session_t *s,
+                                                    ngx_int_t n)
 {
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
 
     return &ctx->frags[(ctx->frag + n) % (dacf->winfrags * 2 + 1)];
 }
 
-
-static void
-ngx_rtmp_dash_next_frag(ngx_rtmp_session_t *s)
+static void ngx_rtmp_dash_next_frag(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
 
     if (ctx->nfrags == dacf->winfrags) {
         ctx->frag++;
@@ -201,46 +175,42 @@ ngx_rtmp_dash_next_frag(ngx_rtmp_session_t *s)
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_rename_file(u_char *src, u_char *dst)
+static ngx_int_t ngx_rtmp_dash_rename_file(u_char *src, u_char *dst)
 {
-    /* rename file with overwrite */
+/* rename file with overwrite */
 
 #if (NGX_WIN32)
-    return MoveFileEx((LPCTSTR) src, (LPCTSTR) dst, MOVEFILE_REPLACE_EXISTING);
+    return MoveFileEx((LPCTSTR)src, (LPCTSTR)dst, MOVEFILE_REPLACE_EXISTING);
 #else
     return ngx_rename_file(src, dst);
 #endif
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
 {
-    char                      *sep;
-    u_char                    *p, *last;
-    ssize_t                    n;
-    ngx_fd_t                   fd;
-    struct tm                  tm;
-    ngx_str_t                  noname, *name;
-    ngx_uint_t                 i, frame_rate_num, frame_rate_denom;
-    ngx_uint_t                 depth_msec;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_codec_ctx_t      *codec_ctx;
-    ngx_rtmp_dash_frag_t      *f;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    char *sep;
+    u_char *p, *last;
+    ssize_t n;
+    ngx_fd_t fd;
+    struct tm tm;
+    ngx_str_t noname, *name;
+    ngx_uint_t i, frame_rate_num, frame_rate_denom;
+    ngx_uint_t depth_msec;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
+    ngx_rtmp_dash_frag_t *f;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
-    ngx_rtmp_playlist_t        v;
+    ngx_rtmp_playlist_t v;
 
-    static u_char              buffer[NGX_RTMP_DASH_BUFSIZE];
-    static u_char              avaliable_time[NGX_RTMP_DASH_GMT_LENGTH];
-    static u_char              publish_time[NGX_RTMP_DASH_GMT_LENGTH];
-    static u_char              buffer_depth[sizeof("P00Y00M00DT00H00M00.00S")];
-    static u_char              frame_rate[(NGX_INT_T_LEN * 2) + 2];
+    static u_char buffer[NGX_RTMP_DASH_BUFSIZE];
+    static u_char avaliable_time[NGX_RTMP_DASH_GMT_LENGTH];
+    static u_char publish_time[NGX_RTMP_DASH_GMT_LENGTH];
+    static u_char buffer_depth[sizeof("P00Y00M00DT00H00M00.00S")];
+    static u_char frame_rate[(NGX_INT_T_LEN * 2) + 2];
 
-    dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    dacf      = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
+    ctx       = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
     if (dacf == NULL || ctx == NULL || codec_ctx == NULL) {
@@ -260,26 +230,24 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
         return NGX_ERROR;
     }
 
-
 #define NGX_RTMP_DASH_MANIFEST_HEADER                                          \
     "<?xml version=\"1.0\"?>\n"                                                \
     "<MPD\n"                                                                   \
     "    type=\"dynamic\"\n"                                                   \
     "    xmlns=\"urn:mpeg:dash:schema:mpd:2011\"\n"                            \
     "    availabilityStartTime=\"%s\"\n"                                       \
-    "    publishTime=\"%s\"\n"                                         \
+    "    publishTime=\"%s\"\n"                                                 \
     "    minimumUpdatePeriod=\"PT%uiS\"\n"                                     \
     "    minBufferTime=\"PT%uiS\"\n"                                           \
     "    timeShiftBufferDepth=\"%s\"\n"                                        \
     "    suggestedPresentationDelay=\"PT%uiS\"\n"                              \
     "    profiles=\"urn:hbbtv:dash:profile:isoff-live:2012,"                   \
-                   "urn:mpeg:dash:profile:isoff-live:2011\"\n"                 \
+    "urn:mpeg:dash:profile:isoff-live:2011\"\n"                                \
     "    xmlns:xsi=\"http://www.w3.org/2011/XMLSchema-instance\"\n"            \
     "    xsi:schemaLocation=\"urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd\">\n" \
     "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-head:2014\"\n"          \
     "       value=\"http://vm2.dashif.org/dash/time.txt\" />"                  \
     "  <Period start=\"PT0S\" id=\"dash\">\n"
-
 
 #define NGX_RTMP_DASH_MANIFEST_VIDEO                                           \
     "    <AdaptationSet\n"                                                     \
@@ -305,17 +273,13 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "            initialization=\"%V%sinit.m4v\">\n"                           \
     "          <SegmentTimeline>\n"
 
-
 #define NGX_RTMP_DASH_MANIFEST_VIDEO_FOOTER                                    \
     "          </SegmentTimeline>\n"                                           \
     "        </SegmentTemplate>\n"                                             \
     "      </Representation>\n"                                                \
     "    </AdaptationSet>\n"
 
-
-#define NGX_RTMP_DASH_MANIFEST_TIME                                            \
-    "             <S t=\"%uD\" d=\"%uD\"/>\n"
-
+#define NGX_RTMP_DASH_MANIFEST_TIME "             <S t=\"%uD\" d=\"%uD\"/>\n"
 
 #define NGX_RTMP_DASH_MANIFEST_AUDIO                                           \
     "    <AdaptationSet\n"                                                     \
@@ -323,7 +287,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "        segmentAlignment=\"true\">\n"                                     \
     "      <AudioChannelConfiguration\n"                                       \
     "          schemeIdUri=\"urn:mpeg:dash:"                                   \
-                                "23003:3:audio_channel_configuration:2011\"\n" \
+    "23003:3:audio_channel_configuration:2011\"\n"                             \
     "          value=\"1\"/>\n"                                                \
     "      <Representation\n"                                                  \
     "          id=\"%V_AAC\"\n"                                                \
@@ -339,13 +303,11 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "            initialization=\"%V%sinit.m4a\">\n"                           \
     "          <SegmentTimeline>\n"
 
-
 #define NGX_RTMP_DASH_MANIFEST_AUDIO_FOOTER                                    \
     "          </SegmentTimeline>\n"                                           \
     "        </SegmentTemplate>\n"                                             \
     "      </Representation>\n"                                                \
     "    </AdaptationSet>\n"
-
 
 #define NGX_RTMP_DASH_MANIFEST_FOOTER                                          \
     "  </Period>\n"                                                            \
@@ -354,97 +316,88 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     ngx_libc_localtime(ctx->start_time.sec, &tm);
 
     *ngx_sprintf(avaliable_time, "%4d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d",
-                 tm.tm_year + 1900, tm.tm_mon + 1,
-                 tm.tm_mday, tm.tm_hour,
-                 tm.tm_min, tm.tm_sec,
-                 ctx->start_time.gmtoff < 0 ? '-' : '+',
+                 tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour,
+                 tm.tm_min, tm.tm_sec, ctx->start_time.gmtoff < 0 ? '-' : '+',
                  ngx_abs(ctx->start_time.gmtoff / 60),
                  ngx_abs(ctx->start_time.gmtoff % 60)) = 0;
-    
-    if (publish_time[0] == '\0'){
+
+    if (publish_time[0] == '\0') {
         *ngx_sprintf(publish_time, "%s", avaliable_time) = 0;
     }
-    
-    ngx_libc_localtime(ctx->start_time.sec +
-                       (ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
-                        ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->duration) /
-                       1000, &tm);
 
-    depth_msec = (ngx_uint_t) (
-                 ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
-                 ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->duration - 
-                 ngx_rtmp_dash_get_frag(s, 0)->timestamp);
+    ngx_libc_localtime(
+        ctx->start_time.sec +
+            (ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
+             ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->duration) /
+                1000,
+        &tm);
 
-    ngx_libc_gmtime((ngx_uint_t) (depth_msec / 1000), &tm);
+    depth_msec =
+        (ngx_uint_t)(ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
+                     ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->duration -
+                     ngx_rtmp_dash_get_frag(s, 0)->timestamp);
+
+    ngx_libc_gmtime((ngx_uint_t)(depth_msec / 1000), &tm);
 
     *ngx_sprintf(buffer_depth, "P%dY%02dM%02dDT%dH%02dM%02d.%02dS",
-                 tm.tm_year - 70, tm.tm_mon,
-                 tm.tm_mday - 1, tm.tm_hour,
-                 tm.tm_min, tm.tm_sec,
-                 (ngx_uint_t) ((depth_msec % 1000) / 10)) = 0;
+                 tm.tm_year - 70, tm.tm_mon, tm.tm_mday - 1, tm.tm_hour,
+                 tm.tm_min, tm.tm_sec, (ngx_uint_t)((depth_msec % 1000) / 10)) =
+        0;
 
     last = buffer + sizeof(buffer);
 
     p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_HEADER,
-                     avaliable_time,
-                     publish_time,
-                     (ngx_uint_t) (dacf->fraglen / 1000),
-                     (ngx_uint_t) (dacf->fraglen / 1000),
-                     buffer_depth,
-                     (ngx_uint_t) (dacf->fraglen / 500),
-                     avaliable_time);   /* UTCTiming value for shaka-player */
+                     avaliable_time, publish_time,
+                     (ngx_uint_t)(dacf->fraglen / 1000),
+                     (ngx_uint_t)(dacf->fraglen / 1000), buffer_depth,
+                     (ngx_uint_t)(dacf->fraglen / 500),
+                     avaliable_time); /* UTCTiming value for shaka-player */
 
     n = ngx_write_fd(fd, buffer, p - buffer);
 
     ngx_str_null(&noname);
 
     name = (dacf->nested ? &noname : &ctx->name);
-    sep = (dacf->nested ? "" : "-");
+    sep  = (dacf->nested ? "" : "-");
 
     if (ctx->has_video) {
-        frame_rate_num = (ngx_uint_t) (codec_ctx->frame_rate * 1000.);
+        frame_rate_num = (ngx_uint_t)(codec_ctx->frame_rate * 1000.);
 
         if (frame_rate_num % 1000 == 0) {
             *ngx_sprintf(frame_rate, "%ui", frame_rate_num / 1000) = 0;
         } else {
             frame_rate_denom = 1000;
             switch (frame_rate_num) {
-                case 23976:
-                    frame_rate_num = 24000;
-                    frame_rate_denom = 1001;
-                    break;
-                case 29970:
-                    frame_rate_num = 30000;
-                    frame_rate_denom = 1001;
-                    break;
-                case 59940:
-                    frame_rate_num = 60000;
-                    frame_rate_denom = 1001;
-                    break;
+            case 23976:
+                frame_rate_num   = 24000;
+                frame_rate_denom = 1001;
+                break;
+            case 29970:
+                frame_rate_num   = 30000;
+                frame_rate_denom = 1001;
+                break;
+            case 59940:
+                frame_rate_num   = 60000;
+                frame_rate_denom = 1001;
+                break;
             }
 
-            *ngx_sprintf(frame_rate, "%ui/%ui", frame_rate_num, frame_rate_denom) = 0;
+            *ngx_sprintf(frame_rate, "%ui/%ui", frame_rate_num,
+                         frame_rate_denom) = 0;
         }
 
         p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_VIDEO,
-                         codec_ctx->width,
-                         codec_ctx->height,
-                         frame_rate,
-                         &ctx->name,
-                         codec_ctx->avc_profile,
-                         codec_ctx->avc_compat,
-                         codec_ctx->avc_level,
-                         codec_ctx->width,
-                         codec_ctx->height,
-                         frame_rate,
-                         (ngx_uint_t) (codec_ctx->video_data_rate * 1000),
-                         name, sep,
-                         name, sep);
+                         codec_ctx->width, codec_ctx->height, frame_rate,
+                         &ctx->name, codec_ctx->avc_profile,
+                         codec_ctx->avc_compat, codec_ctx->avc_level,
+                         codec_ctx->width, codec_ctx->height, frame_rate,
+                         (ngx_uint_t)(codec_ctx->video_data_rate * 1000), name,
+                         sep, name, sep);
 
         for (i = 0; i < ctx->nfrags; i++) {
             f = ngx_rtmp_dash_get_frag(s, i);
-            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME,
-                             f->timestamp, f->duration);
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME, f->timestamp,
+                             f->duration);
         }
 
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_VIDEO_FOOTER);
@@ -453,19 +406,18 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     }
 
     if (ctx->has_audio) {
-        p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_AUDIO,
-                         &ctx->name,
-                         codec_ctx->audio_codec_id == NGX_RTMP_AUDIO_AAC ?
-                         (codec_ctx->aac_sbr ? "40.5" : "40.2") : "6b",
+        p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_AUDIO, &ctx->name,
+                         codec_ctx->audio_codec_id == NGX_RTMP_AUDIO_AAC
+                             ? (codec_ctx->aac_sbr ? "40.5" : "40.2")
+                             : "6b",
                          codec_ctx->sample_rate,
-                         (ngx_uint_t) (codec_ctx->audio_data_rate * 1000),
-                         name, sep,
-                         name, sep);
+                         (ngx_uint_t)(codec_ctx->audio_data_rate * 1000), name,
+                         sep, name, sep);
 
         for (i = 0; i < ctx->nfrags; i++) {
             f = ngx_rtmp_dash_get_frag(s, i);
-            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME,
-                             f->timestamp, f->duration);
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME, f->timestamp,
+                             f->duration);
         }
 
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_AUDIO_FOOTER);
@@ -485,35 +437,32 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
 
     ngx_close_file(fd);
 
-    if (ngx_rtmp_dash_rename_file(ctx->playlist_bak.data, ctx->playlist.data)
-        == NGX_FILE_ERROR)
-    {
+    if (ngx_rtmp_dash_rename_file(ctx->playlist_bak.data, ctx->playlist.data) ==
+        NGX_FILE_ERROR) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
-                      "dash: rename failed: '%V'->'%V'",
-                      &ctx->playlist_bak, &ctx->playlist);
+                      "dash: rename failed: '%V'->'%V'", &ctx->playlist_bak,
+                      &ctx->playlist);
         return NGX_ERROR;
     }
 
     ngx_memzero(&v, sizeof(v));
     ngx_str_set(&(v.module), "dash");
     v.playlist.data = ctx->playlist.data;
-    v.playlist.len = ctx->playlist.len;
+    v.playlist.len  = ctx->playlist.len;
     return next_playlist(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s)
 {
-    ngx_fd_t               fd;
-    ngx_int_t              rc;
-    ngx_buf_t              b;
-    ngx_rtmp_dash_ctx_t   *ctx;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    ngx_fd_t fd;
+    ngx_int_t rc;
+    ngx_buf_t b;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
-    static u_char          buffer[NGX_RTMP_DASH_BUFSIZE];
+    static u_char buffer[NGX_RTMP_DASH_BUFSIZE];
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    ctx       = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
     if (ctx == NULL || codec_ctx == NULL) {
@@ -534,13 +483,13 @@ ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s)
     }
 
     b.start = buffer;
-    b.end = b.start + sizeof(buffer);
+    b.end   = b.start + sizeof(buffer);
     b.pos = b.last = b.start;
 
     ngx_rtmp_mp4_write_ftyp(&b);
     ngx_rtmp_mp4_write_moov(s, &b, NGX_RTMP_MP4_VIDEO_TRACK);
 
-    rc = ngx_write_fd(fd, b.start, (size_t) (b.last - b.start));
+    rc = ngx_write_fd(fd, b.start, (size_t)(b.last - b.start));
     if (rc == NGX_ERROR) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                       "dash: writing video init failed");
@@ -566,7 +515,7 @@ ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s)
     ngx_rtmp_mp4_write_ftyp(&b);
     ngx_rtmp_mp4_write_moov(s, &b, NGX_RTMP_MP4_AUDIO_TRACK);
 
-    rc = ngx_write_fd(fd, b.start, (size_t) (b.last - b.start));
+    rc = ngx_write_fd(fd, b.start, (size_t)(b.last - b.start));
     if (rc == NGX_ERROR) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                       "dash: writing audio init failed");
@@ -577,32 +526,31 @@ ngx_rtmp_dash_write_init_segments(ngx_rtmp_session_t *s)
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t)
+static void ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_dash_track_t *t)
 {
-    u_char                    *pos, *pos1;
-    size_t                     left;
-    ssize_t                    n;
-    ngx_fd_t                   fd;
-    ngx_buf_t                  b;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_frag_t      *f;
+    u_char *pos, *pos1;
+    size_t left;
+    ssize_t n;
+    ngx_fd_t fd;
+    ngx_buf_t b;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_frag_t *f;
 
-    static u_char              buffer[NGX_RTMP_DASH_BUFSIZE];
+    static u_char buffer[NGX_RTMP_DASH_BUFSIZE];
 
     if (!t->opened) {
         return;
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: close fragment id=%ui, type=%c, pts=%uD",
-                   t->id, t->type, t->earliest_pres_time);
+                   "dash: close fragment id=%ui, type=%c, pts=%uD", t->id,
+                   t->type, t->earliest_pres_time);
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
 
     b.start = buffer;
-    b.end = buffer + sizeof(buffer);
+    b.end   = buffer + sizeof(buffer);
     b.pos = b.last = b.start;
 
     ngx_rtmp_mp4_write_styp(&b);
@@ -612,7 +560,7 @@ ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t)
 
     ngx_rtmp_mp4_write_moof(&b, t->earliest_pres_time, t->sample_count,
                             t->samples, t->sample_mask, t->id);
-    pos1 = b.last;
+    pos1   = b.last;
     b.last = pos;
 
     ngx_rtmp_mp4_write_sidx(&b, t->mdat_size + 8 + (pos1 - (pos + 44)),
@@ -624,11 +572,11 @@ ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t)
 
     f = ngx_rtmp_dash_get_frag(s, ctx->nfrags);
 
-    *ngx_sprintf(ctx->stream.data + ctx->stream.len, "%uD.m4%c",
-                 f->timestamp, t->type) = 0;
+    *ngx_sprintf(ctx->stream.data + ctx->stream.len, "%uD.m4%c", f->timestamp,
+                 t->type) = 0;
 
-    fd = ngx_open_file(ctx->stream.data, NGX_FILE_RDWR,
-                       NGX_FILE_TRUNCATE, NGX_FILE_DEFAULT_ACCESS);
+    fd = ngx_open_file(ctx->stream.data, NGX_FILE_RDWR, NGX_FILE_TRUNCATE,
+                       NGX_FILE_DEFAULT_ACCESS);
 
     if (fd == NGX_INVALID_FILE) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
@@ -636,11 +584,11 @@ ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t)
         goto done;
     }
 
-    if (ngx_write_fd(fd, b.pos, (size_t) (b.last - b.pos)) == NGX_ERROR) {
+    if (ngx_write_fd(fd, b.pos, (size_t)(b.last - b.pos)) == NGX_ERROR) {
         goto done;
     }
 
-    left = (size_t) t->mdat_size;
+    left = (size_t)t->mdat_size;
 
 #if (NGX_WIN32)
     if (SetFilePointer(t->fd, 0, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER) {
@@ -657,13 +605,12 @@ ngx_rtmp_dash_close_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t)
 #endif
 
     while (left > 0) {
-
         n = ngx_read_fd(t->fd, buffer, ngx_min(sizeof(buffer), left));
         if (n == NGX_ERROR) {
             break;
         }
 
-        n = ngx_write_fd(fd, buffer, (size_t) n);
+        n = ngx_write_fd(fd, buffer, (size_t)n);
         if (n == NGX_ERROR) {
             break;
         }
@@ -679,15 +626,13 @@ done:
 
     ngx_close_file(t->fd);
 
-    t->fd = NGX_INVALID_FILE;
+    t->fd     = NGX_INVALID_FILE;
     t->opened = 0;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_close_fragments(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_dash_close_fragments(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_dash_ctx_t  *ctx;
+    ngx_rtmp_dash_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
     if (ctx == NULL || !ctx->opened) {
@@ -710,12 +655,11 @@ ngx_rtmp_dash_close_fragments(ngx_rtmp_session_t *s)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_open_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t,
-    ngx_uint_t id, char type)
+static ngx_int_t ngx_rtmp_dash_open_fragment(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_dash_track_t *t,
+                                             ngx_uint_t id, char type)
 {
-    ngx_rtmp_dash_ctx_t   *ctx;
+    ngx_rtmp_dash_ctx_t *ctx;
 
     if (t->opened) {
         return NGX_OK;
@@ -728,8 +672,8 @@ ngx_rtmp_dash_open_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t,
 
     *ngx_sprintf(ctx->stream.data + ctx->stream.len, "raw.m4%c", type) = 0;
 
-    t->fd = ngx_open_file(ctx->stream.data, NGX_FILE_RDWR,
-                          NGX_FILE_TRUNCATE, NGX_FILE_DEFAULT_ACCESS);
+    t->fd = ngx_open_file(ctx->stream.data, NGX_FILE_RDWR, NGX_FILE_TRUNCATE,
+                          NGX_FILE_DEFAULT_ACCESS);
 
     if (t->fd == NGX_INVALID_FILE) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
@@ -737,32 +681,29 @@ ngx_rtmp_dash_open_fragment(ngx_rtmp_session_t *s, ngx_rtmp_dash_track_t *t,
         return NGX_ERROR;
     }
 
-    t->id = id;
-    t->type = type;
-    t->sample_count = 0;
+    t->id                 = id;
+    t->type               = type;
+    t->sample_count       = 0;
     t->earliest_pres_time = 0;
-    t->latest_pres_time = 0;
-    t->mdat_size = 0;
-    t->opened = 1;
+    t->latest_pres_time   = 0;
+    t->mdat_size          = 0;
+    t->opened             = 1;
 
     if (type == 'v') {
-        t->sample_mask = NGX_RTMP_MP4_SAMPLE_SIZE|
-                         NGX_RTMP_MP4_SAMPLE_DURATION|
-                         NGX_RTMP_MP4_SAMPLE_DELAY|
-                         NGX_RTMP_MP4_SAMPLE_KEY;
+        t->sample_mask = NGX_RTMP_MP4_SAMPLE_SIZE |
+                         NGX_RTMP_MP4_SAMPLE_DURATION |
+                         NGX_RTMP_MP4_SAMPLE_DELAY | NGX_RTMP_MP4_SAMPLE_KEY;
     } else {
-        t->sample_mask = NGX_RTMP_MP4_SAMPLE_SIZE|
-                         NGX_RTMP_MP4_SAMPLE_DURATION;
+        t->sample_mask =
+            NGX_RTMP_MP4_SAMPLE_SIZE | NGX_RTMP_MP4_SAMPLE_DURATION;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_open_fragments(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_dash_open_fragments(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_dash_ctx_t  *ctx;
+    ngx_rtmp_dash_ctx_t *ctx;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "dash: open fragments");
@@ -786,23 +727,20 @@ ngx_rtmp_dash_open_fragments(ngx_rtmp_session_t *s)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
 {
-    size_t                     len;
-    ngx_file_info_t            fi;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    size_t len;
+    ngx_file_info_t fi;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
-    static u_char              path[NGX_MAX_PATH + 1];
+    static u_char path[NGX_MAX_PATH + 1];
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
 
     *ngx_snprintf(path, sizeof(path) - 1, "%V", &dacf->path) = 0;
 
     if (ngx_file_info(path, &fi) == NGX_FILE_ERROR) {
-
         if (ngx_errno != NGX_ENOENT) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                           "dash: " ngx_file_info_n " failed on '%V'",
@@ -823,12 +761,11 @@ ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
                        "dash: directory '%V' created", &dacf->path);
 
     } else {
-
         if (!ngx_is_dir(&fi)) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                           "dash: '%V' exists and is not a directory",
                           &dacf->path);
-            return  NGX_ERROR;
+            return NGX_ERROR;
         }
 
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
@@ -850,7 +787,6 @@ ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
                   &ctx->name) = 0;
 
     if (ngx_file_info(path, &fi) != NGX_FILE_ERROR) {
-
         if (ngx_is_dir(&fi)) {
             ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                            "dash: directory '%s' exists", path);
@@ -860,7 +796,7 @@ ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                       "dash: '%s' exists and is not a directory", path);
 
-        return  NGX_ERROR;
+        return NGX_ERROR;
     }
 
     if (ngx_errno != NGX_ENOENT) {
@@ -883,15 +819,14 @@ ngx_rtmp_dash_ensure_directory(ngx_rtmp_session_t *s)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_dash_publish(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_publish_t *v)
 {
-    u_char                    *p;
-    size_t                     len;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_frag_t      *f;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    u_char *p;
+    size_t len;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_frag_t *f;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
     if (dacf == NULL || !dacf->dash || dacf->path.len == 0) {
@@ -925,9 +860,9 @@ ngx_rtmp_dash_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
     }
 
     if (ctx->frags == NULL) {
-        ctx->frags = ngx_pcalloc(s->connection->pool,
-                                 sizeof(ngx_rtmp_dash_frag_t) *
-                                 (dacf->winfrags * 2 + 1));
+        ctx->frags =
+            ngx_pcalloc(s->connection->pool, sizeof(ngx_rtmp_dash_frag_t) *
+                                                 (dacf->winfrags * 2 + 1));
         if (ctx->frags == NULL) {
             return NGX_ERROR;
         }
@@ -941,7 +876,7 @@ ngx_rtmp_dash_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         return NGX_ERROR;
     }
 
-    ctx->name.len = ngx_strlen(v->name);
+    ctx->name.len  = ngx_strlen(v->name);
     ctx->name.data = ngx_palloc(s->connection->pool, ctx->name.len + 1);
 
     if (ctx->name.data == NULL) {
@@ -970,10 +905,9 @@ ngx_rtmp_dash_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
      * is allocated
      */
 
-    ctx->stream.len = p - ctx->playlist.data + 1;
-    ctx->stream.data = ngx_palloc(s->connection->pool,
-                                  ctx->stream.len + NGX_INT32_LEN +
-                                  sizeof(".m4x"));
+    ctx->stream.len  = p - ctx->playlist.data + 1;
+    ctx->stream.data = ngx_palloc(
+        s->connection->pool, ctx->stream.len + NGX_INT32_LEN + sizeof(".m4x"));
 
     ngx_memcpy(ctx->stream.data, ctx->playlist.data, ctx->stream.len - 1);
     ctx->stream.data[ctx->stream.len - 1] = (dacf->nested ? '/' : '-');
@@ -990,8 +924,8 @@ ngx_rtmp_dash_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
 
     /* playlist bak (new playlist) path */
 
-    ctx->playlist_bak.data = ngx_palloc(s->connection->pool,
-                                        ctx->playlist.len + sizeof(".bak"));
+    ctx->playlist_bak.data =
+        ngx_palloc(s->connection->pool, ctx->playlist.len + sizeof(".bak"));
     p = ngx_cpymem(ctx->playlist_bak.data, ctx->playlist.data,
                    ctx->playlist.len);
     p = ngx_cpymem(p, ".bak", sizeof(".bak") - 1);
@@ -1014,12 +948,11 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_close_stream(ngx_rtmp_session_t *s, ngx_rtmp_close_stream_t *v)
+static ngx_int_t ngx_rtmp_dash_close_stream(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_close_stream_t *v)
 {
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
 
@@ -1038,105 +971,102 @@ next:
     return next_close_stream(s, v);
 }
 
-
-static void
-ngx_rtmp_dash_update_fragments(ngx_rtmp_session_t *s, ngx_int_t boundary,
-    uint32_t timestamp)
+static void ngx_rtmp_dash_update_fragments(ngx_rtmp_session_t *s,
+                                           ngx_int_t boundary,
+                                           uint32_t timestamp)
 {
-    int32_t                    d;
-    ngx_int_t                  hit;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_dash_frag_t      *f;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    int32_t d;
+    ngx_int_t hit;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_dash_frag_t *f;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
     dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
-    f = ngx_rtmp_dash_get_frag(s, ctx->nfrags);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    f    = ngx_rtmp_dash_get_frag(s, ctx->nfrags);
 
     ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: timestamp=%ui, f-timestamp=%ui, boundary=%i, dacf-fraglen=%ui",
+                   "dash: update_fragments: timestamp=%ui, f-timestamp=%ui, "
+                   "boundary=%i, dacf-fraglen=%ui",
                    timestamp, f->timestamp, boundary, dacf->fraglen);
 
-    d = (int32_t) (timestamp - f->timestamp);
+    d = (int32_t)(timestamp - f->timestamp);
 
     if (d >= 0) {
-
         f->duration = timestamp - f->timestamp;
-        hit = (f->duration >= dacf->fraglen);
+        hit         = (f->duration >= dacf->fraglen);
 
     } else {
-
         /* sometimes clients generate slightly unordered frames */
 
         hit = (-d > 1000);
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: d=%i, f-duration=%ui, hit=%i",
-                   d, f->duration, hit);
+                   "dash: update_fragments: d=%i, f-duration=%ui, hit=%i", d,
+                   f->duration, hit);
 
     if (ctx->has_video && !hit) {
         boundary = 0;
-        ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=0 cos has_video && !hit");
+        ngx_log_debug0(
+            NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+            "dash: update_fragments: boundary=0 cos has_video && !hit");
     }
 
     if (!ctx->has_video && ctx->has_audio) {
         boundary = hit;
-        ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=hit cos !has_video && has_audio");
+        ngx_log_debug0(
+            NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+            "dash: update_fragments: boundary=hit cos !has_video && has_audio");
     }
 
     if (ctx->audio.mdat_size >= NGX_RTMP_DASH_MAX_MDAT) {
         boundary = 1;
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=1 cos audio max mdat");
+                       "dash: update_fragments: boundary=1 cos audio max mdat");
     }
 
     if (ctx->video.mdat_size >= NGX_RTMP_DASH_MAX_MDAT) {
         boundary = 1;
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=1 cos video max mdat");
+                       "dash: update_fragments: boundary=1 cos video max mdat");
     }
 
     if (!ctx->opened) {
         boundary = 1;
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=1 cos !opened");
+                       "dash: update_fragments: boundary=1 cos !opened");
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "dash: update_fragments: boundary=%i",
-                   boundary);
+                   "dash: update_fragments: boundary=%i", boundary);
 
     if (boundary) {
         ngx_rtmp_dash_close_fragments(s);
         ngx_rtmp_dash_open_fragments(s);
 
-        f = ngx_rtmp_dash_get_frag(s, ctx->nfrags);
+        f            = ngx_rtmp_dash_get_frag(s, ctx->nfrags);
         f->timestamp = timestamp;
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_append(ngx_rtmp_session_t *s, ngx_chain_t *in,
-    ngx_rtmp_dash_track_t *t, ngx_int_t key, uint32_t timestamp, uint32_t delay)
+static ngx_int_t ngx_rtmp_dash_append(ngx_rtmp_session_t *s, ngx_chain_t *in,
+                                      ngx_rtmp_dash_track_t *t, ngx_int_t key,
+                                      uint32_t timestamp, uint32_t delay)
 {
-    u_char                 *p;
-    size_t                  size, bsize;
-    ngx_rtmp_mp4_sample_t  *smpl;
+    u_char *p;
+    size_t size, bsize;
+    ngx_rtmp_mp4_sample_t *smpl;
 
-    static u_char           buffer[NGX_RTMP_DASH_BUFSIZE];
+    static u_char buffer[NGX_RTMP_DASH_BUFSIZE];
 
-    p = buffer;
+    p    = buffer;
     size = 0;
 
     for (; in && size < sizeof(buffer); in = in->next) {
-
-        bsize = (size_t) (in->buf->last - in->buf->pos);
+        bsize = (size_t)(in->buf->last - in->buf->pos);
         if (size + bsize > sizeof(buffer)) {
-            bsize = (size_t) (sizeof(buffer) - size);
+            bsize = (size_t)(sizeof(buffer) - size);
         }
 
         p = ngx_cpymem(p, in->buf->pos, bsize);
@@ -1152,7 +1082,6 @@ ngx_rtmp_dash_append(ngx_rtmp_session_t *s, ngx_chain_t *in,
     t->latest_pres_time = timestamp;
 
     if (t->sample_count < NGX_RTMP_DASH_MAX_SAMPLES) {
-
         if (ngx_write_fd(t->fd, buffer, size) == NGX_ERROR) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                           "dash: " ngx_write_fd_n " failed");
@@ -1161,49 +1090,45 @@ ngx_rtmp_dash_append(ngx_rtmp_session_t *s, ngx_chain_t *in,
 
         smpl = &t->samples[t->sample_count];
 
-        smpl->delay = delay;
-        smpl->size = (uint32_t) size;
-        smpl->duration = 0;
+        smpl->delay     = delay;
+        smpl->size      = (uint32_t)size;
+        smpl->duration  = 0;
         smpl->timestamp = timestamp;
-        smpl->key = (key ? 1 : 0);
+        smpl->key       = (key ? 1 : 0);
 
         if (t->sample_count > 0) {
-            smpl = &t->samples[t->sample_count - 1];
+            smpl           = &t->samples[t->sample_count - 1];
             smpl->duration = timestamp - smpl->timestamp;
         }
 
         t->sample_count++;
-        t->mdat_size += (ngx_uint_t) size;
+        t->mdat_size += (ngx_uint_t)size;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_audio(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-    ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_dash_audio(ngx_rtmp_session_t *s,
+                                     ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    u_char                     htype;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_codec_ctx_t      *codec_ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    u_char htype;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
-    dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    dacf      = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
+    ctx       = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
-    if (dacf == NULL || !dacf->dash || ctx == NULL ||
-        codec_ctx == NULL || h->mlen < 2)
-    {
+    if (dacf == NULL || !dacf->dash || ctx == NULL || codec_ctx == NULL ||
+        h->mlen < 2) {
         return NGX_OK;
     }
 
     /* Only AAC is supported */
 
     if (codec_ctx->audio_codec_id != NGX_RTMP_AUDIO_AAC ||
-        codec_ctx->aac_header == NULL)
-    {
+        codec_ctx->aac_header == NULL) {
         return NGX_OK;
     }
 
@@ -1227,25 +1152,22 @@ ngx_rtmp_dash_audio(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_dash_append(s, in, &ctx->audio, 0, h->timestamp, 0);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-    ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_dash_video(ngx_rtmp_session_t *s,
+                                     ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    u_char                    *p;
-    uint8_t                    ftype, htype;
-    uint32_t                   delay;
-    ngx_rtmp_dash_ctx_t       *ctx;
-    ngx_rtmp_codec_ctx_t      *codec_ctx;
-    ngx_rtmp_dash_app_conf_t  *dacf;
+    u_char *p;
+    uint8_t ftype, htype;
+    uint32_t delay;
+    ngx_rtmp_dash_ctx_t *ctx;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
+    ngx_rtmp_dash_app_conf_t *dacf;
 
-    dacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
+    dacf      = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_dash_module);
+    ctx       = ngx_rtmp_get_module_ctx(s, ngx_rtmp_dash_module);
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
     if (dacf == NULL || !dacf->dash || ctx == NULL || codec_ctx == NULL ||
-        codec_ctx->avc_header == NULL || h->mlen < 5)
-    {
+        codec_ctx->avc_header == NULL || h->mlen < 5) {
         return NGX_OK;
     }
 
@@ -1268,7 +1190,7 @@ ngx_rtmp_dash_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         return NGX_OK;
     }
 
-    p = (u_char *) &delay;
+    p = (u_char *)&delay;
 
     p[0] = in->buf->pos[4];
     p[1] = in->buf->pos[3];
@@ -1285,34 +1207,30 @@ ngx_rtmp_dash_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                                 delay);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_stream_begin(ngx_rtmp_session_t *s, ngx_rtmp_stream_begin_t *v)
+static ngx_int_t ngx_rtmp_dash_stream_begin(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_stream_begin_t *v)
 {
     return next_stream_begin(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_stream_eof(ngx_rtmp_session_t *s, ngx_rtmp_stream_eof_t *v)
+static ngx_int_t ngx_rtmp_dash_stream_eof(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_stream_eof_t *v)
 {
     ngx_rtmp_dash_close_fragments(s);
 
     return next_stream_eof(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
+static ngx_int_t ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
 {
-    time_t           mtime, max_age;
-    u_char          *p;
-    u_char           path[NGX_MAX_PATH + 1], mpd_path[NGX_MAX_PATH + 1];
-    ngx_dir_t        dir;
-    ngx_err_t        err;
-    ngx_str_t        name, spath, mpd;
-    ngx_int_t        nentries, nerased;
-    ngx_file_info_t  fi;
+    time_t mtime, max_age;
+    u_char *p;
+    u_char path[NGX_MAX_PATH + 1], mpd_path[NGX_MAX_PATH + 1];
+    ngx_dir_t dir;
+    ngx_err_t err;
+    ngx_str_t name, spath, mpd;
+    ngx_int_t nentries, nerased;
+    ngx_file_info_t fi;
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, ngx_cycle->log, 0,
                    "dash: cleanup path='%V' playlen=%M", ppath, playlen);
@@ -1324,9 +1242,9 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
     }
 
     nentries = 0;
-    nerased = 0;
+    nerased  = 0;
 
-    for ( ;; ) {
+    for (;;) {
         ngx_set_errno(0);
 
         if (ngx_read_dir(&dir) == NGX_ERROR) {
@@ -1343,8 +1261,8 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
             }
 
             ngx_log_error(NGX_LOG_CRIT, ngx_cycle->log, err,
-                          "dash: cleanup " ngx_read_dir_n
-                          " '%V' failed", ppath);
+                          "dash: cleanup " ngx_read_dir_n " '%V' failed",
+                          ppath);
             return NGX_ERROR;
         }
 
@@ -1355,11 +1273,11 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
 
         name.len = ngx_de_namelen(&dir);
 
-        p = ngx_snprintf(path, sizeof(path) - 1, "%V/%V", ppath, &name);
+        p  = ngx_snprintf(path, sizeof(path) - 1, "%V/%V", ppath, &name);
         *p = 0;
 
         spath.data = path;
-        spath.len = p - path;
+        spath.len  = p - path;
 
         nentries++;
 
@@ -1372,7 +1290,6 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
         }
 
         if (ngx_de_is_dir(&dir)) {
-
             if (ngx_rtmp_dash_cleanup_dir(&spath, playlen) == 0) {
                 ngx_log_debug1(NGX_LOG_DEBUG_RTMP, ngx_cycle->log, 0,
                                "dash: cleanup dir '%V'", &name);
@@ -1387,7 +1304,8 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
                 if (ngx_delete_dir(path) == NGX_FILE_ERROR) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_errno,
                                   "dash: cleanup " ngx_delete_dir_n
-                                  " failed on '%V'", &spath);
+                                  " failed on '%V'",
+                                  &spath);
                 } else {
                     nerased++;
                 }
@@ -1401,22 +1319,18 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
         }
 
         if (name.len >= 8 && name.data[name.len - 8] == 'i' &&
-                             name.data[name.len - 7] == 'n' &&
-                             name.data[name.len - 6] == 'i' &&
-                             name.data[name.len - 5] == 't' &&
-                             name.data[name.len - 4] == '.' &&
-                             name.data[name.len - 3] == 'm' &&
-                             name.data[name.len - 2] == '4')
-        {
+            name.data[name.len - 7] == 'n' && name.data[name.len - 6] == 'i' &&
+            name.data[name.len - 5] == 't' && name.data[name.len - 4] == '.' &&
+            name.data[name.len - 3] == 'm' && name.data[name.len - 2] == '4') {
             if (name.len == 8) {
                 ngx_str_set(&mpd, "index");
             } else {
                 mpd.data = name.data;
-                mpd.len = name.len - 9;
+                mpd.len  = name.len - 9;
             }
 
-            p = ngx_snprintf(mpd_path, sizeof(mpd_path) - 1, "%V/%V.mpd",
-                             ppath, &mpd);
+            p = ngx_snprintf(mpd_path, sizeof(mpd_path) - 1, "%V/%V.mpd", ppath,
+                             &mpd);
             *p = 0;
 
             if (ngx_file_info(mpd_path, &fi) != NGX_FILE_ERROR) {
@@ -1433,31 +1347,27 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
             max_age = 0;
 
         } else if (name.len >= 4 && name.data[name.len - 4] == '.' &&
-                                    name.data[name.len - 3] == 'm' &&
-                                    name.data[name.len - 2] == '4' &&
-                                    name.data[name.len - 1] == 'v')
-        {
+                   name.data[name.len - 3] == 'm' &&
+                   name.data[name.len - 2] == '4' &&
+                   name.data[name.len - 1] == 'v') {
             max_age = playlen / 500;
 
         } else if (name.len >= 4 && name.data[name.len - 4] == '.' &&
-                                    name.data[name.len - 3] == 'm' &&
-                                    name.data[name.len - 2] == '4' &&
-                                    name.data[name.len - 1] == 'a')
-        {
+                   name.data[name.len - 3] == 'm' &&
+                   name.data[name.len - 2] == '4' &&
+                   name.data[name.len - 1] == 'a') {
             max_age = playlen / 500;
 
         } else if (name.len >= 4 && name.data[name.len - 4] == '.' &&
-                                    name.data[name.len - 3] == 'm' &&
-                                    name.data[name.len - 2] == 'p' &&
-                                    name.data[name.len - 1] == 'd')
-        {
+                   name.data[name.len - 3] == 'm' &&
+                   name.data[name.len - 2] == 'p' &&
+                   name.data[name.len - 1] == 'd') {
             max_age = playlen / 500;
 
         } else if (name.len >= 4 && name.data[name.len - 4] == '.' &&
-                                    name.data[name.len - 3] == 'r' &&
-                                    name.data[name.len - 2] == 'a' &&
-                                    name.data[name.len - 1] == 'w')
-        {
+                   name.data[name.len - 3] == 'r' &&
+                   name.data[name.len - 2] == 'a' &&
+                   name.data[name.len - 1] == 'w') {
             max_age = playlen / 500;
 
         } else {
@@ -1472,8 +1382,8 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
         }
 
         ngx_log_debug3(NGX_LOG_DEBUG_RTMP, ngx_cycle->log, 0,
-                       "dash: cleanup '%V' mtime=%T age=%T",
-                       &name, mtime, ngx_cached_time->sec - mtime);
+                       "dash: cleanup '%V' mtime=%T age=%T", &name, mtime,
+                       ngx_cached_time->sec - mtime);
 
         if (ngx_delete_file(path) == NGX_FILE_ERROR) {
             ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_errno,
@@ -1486,27 +1396,24 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
     }
 }
 
-
-static time_t
-ngx_rtmp_dash_cleanup(void *data)
+static time_t ngx_rtmp_dash_cleanup(void *data)
 {
     ngx_rtmp_dash_cleanup_t *cleanup = data;
 
     ngx_rtmp_dash_cleanup_dir(&cleanup->path, cleanup->playlen);
 
-    // Next callback in doubled playlist length time to make sure what all 
+    // Next callback in doubled playlist length time to make sure what all
     // players read all segments
     return cleanup->playlen / 500;
 }
 
-static ngx_int_t
-ngx_rtmp_dash_playlist(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v)
+static ngx_int_t ngx_rtmp_dash_playlist(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_playlist_t *v)
 {
     return next_playlist(s, v);
 }
 
-static void *
-ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf)
 {
     ngx_rtmp_dash_app_conf_t *conf;
 
@@ -1515,22 +1422,21 @@ ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf)
         return NULL;
     }
 
-    conf->dash = NGX_CONF_UNSET;
+    conf->dash    = NGX_CONF_UNSET;
     conf->fraglen = NGX_CONF_UNSET_MSEC;
     conf->playlen = NGX_CONF_UNSET_MSEC;
     conf->cleanup = NGX_CONF_UNSET;
-    conf->nested = NGX_CONF_UNSET;
+    conf->nested  = NGX_CONF_UNSET;
 
     return conf;
 }
 
-
-static char *
-ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                          void *child)
 {
-    ngx_rtmp_dash_app_conf_t    *prev = parent;
-    ngx_rtmp_dash_app_conf_t    *conf = child;
-    ngx_rtmp_dash_cleanup_t     *cleanup;
+    ngx_rtmp_dash_app_conf_t *prev = parent;
+    ngx_rtmp_dash_app_conf_t *conf = child;
+    ngx_rtmp_dash_cleanup_t *cleanup;
 
     ngx_conf_merge_value(conf->dash, prev->dash, 0);
     ngx_conf_merge_msec_value(conf->fraglen, prev->fraglen, 5000);
@@ -1554,7 +1460,7 @@ ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
-        cleanup->path = conf->path;
+        cleanup->path    = conf->path;
         cleanup->playlen = conf->playlen;
 
         conf->slot = ngx_pcalloc(cf->pool, sizeof(*conf->slot));
@@ -1562,11 +1468,11 @@ ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
-        conf->slot->manager = ngx_rtmp_dash_cleanup;
-        conf->slot->name = conf->path;
-        conf->slot->data = cleanup;
+        conf->slot->manager   = ngx_rtmp_dash_cleanup;
+        conf->slot->name      = conf->path;
+        conf->slot->data      = cleanup;
         conf->slot->conf_file = cf->conf_file->file.name.data;
-        conf->slot->line = cf->conf_file->line;
+        conf->slot->line      = cf->conf_file->line;
 
         if (ngx_add_path(cf, &conf->slot) != NGX_OK) {
             return NGX_CONF_ERROR;
@@ -1578,34 +1484,32 @@ ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_dash_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_dash_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_handler_pt        *h;
-    ngx_rtmp_core_main_conf_t  *cmcf;
+    ngx_rtmp_handler_pt *h;
+    ngx_rtmp_core_main_conf_t *cmcf;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
     *h = ngx_rtmp_dash_video;
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AUDIO]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AUDIO]);
     *h = ngx_rtmp_dash_audio;
 
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_dash_publish;
 
-    next_close_stream = ngx_rtmp_close_stream;
+    next_close_stream     = ngx_rtmp_close_stream;
     ngx_rtmp_close_stream = ngx_rtmp_dash_close_stream;
 
-    next_stream_begin = ngx_rtmp_stream_begin;
+    next_stream_begin     = ngx_rtmp_stream_begin;
     ngx_rtmp_stream_begin = ngx_rtmp_dash_stream_begin;
 
-    next_stream_eof = ngx_rtmp_stream_eof;
+    next_stream_eof     = ngx_rtmp_stream_eof;
     ngx_rtmp_stream_eof = ngx_rtmp_dash_stream_eof;
 
-    next_playlist = ngx_rtmp_playlist;
+    next_playlist     = ngx_rtmp_playlist;
     ngx_rtmp_playlist = ngx_rtmp_dash_playlist;
 
     return NGX_OK;

--- a/dash/ngx_rtmp_mp4.c
+++ b/dash/ngx_rtmp_mp4.c
@@ -1,20 +1,18 @@
 
 
+#include "ngx_rtmp_mp4.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_mp4.h"
 #include <ngx_rtmp_codec_module.h>
 
-
-static ngx_int_t
-ngx_rtmp_mp4_field_32(ngx_buf_t *b, uint32_t n)
+static ngx_int_t ngx_rtmp_mp4_field_32(ngx_buf_t *b, uint32_t n)
 {
-    u_char  bytes[4];
+    u_char bytes[4];
 
-    bytes[0] = ((uint32_t) n >> 24) & 0xFF;
-    bytes[1] = ((uint32_t) n >> 16) & 0xFF;
-    bytes[2] = ((uint32_t) n >> 8) & 0xFF;
-    bytes[3] = (uint32_t) n & 0xFF;
+    bytes[0] = ((uint32_t)n >> 24) & 0xFF;
+    bytes[1] = ((uint32_t)n >> 16) & 0xFF;
+    bytes[2] = ((uint32_t)n >> 8) & 0xFF;
+    bytes[3] = (uint32_t)n & 0xFF;
 
     if (b->last + sizeof(bytes) > b->end) {
         return NGX_ERROR;
@@ -25,15 +23,13 @@ ngx_rtmp_mp4_field_32(ngx_buf_t *b, uint32_t n)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_field_24(ngx_buf_t *b, uint32_t n)
+static ngx_int_t ngx_rtmp_mp4_field_24(ngx_buf_t *b, uint32_t n)
 {
-    u_char  bytes[3];
+    u_char bytes[3];
 
-    bytes[0] = ((uint32_t) n >> 16) & 0xFF;
-    bytes[1] = ((uint32_t) n >> 8) & 0xFF;
-    bytes[2] = (uint32_t) n & 0xFF;
+    bytes[0] = ((uint32_t)n >> 16) & 0xFF;
+    bytes[1] = ((uint32_t)n >> 8) & 0xFF;
+    bytes[2] = (uint32_t)n & 0xFF;
 
     if (b->last + sizeof(bytes) > b->end) {
         return NGX_ERROR;
@@ -44,14 +40,12 @@ ngx_rtmp_mp4_field_24(ngx_buf_t *b, uint32_t n)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_field_16(ngx_buf_t *b, uint16_t n)
+static ngx_int_t ngx_rtmp_mp4_field_16(ngx_buf_t *b, uint16_t n)
 {
-    u_char  bytes[2];
+    u_char bytes[2];
 
-    bytes[0] = ((uint32_t) n >> 8) & 0xFF;
-    bytes[1] = (uint32_t) n & 0xFF;
+    bytes[0] = ((uint32_t)n >> 8) & 0xFF;
+    bytes[1] = (uint32_t)n & 0xFF;
 
     if (b->last + sizeof(bytes) > b->end) {
         return NGX_ERROR;
@@ -62,11 +56,9 @@ ngx_rtmp_mp4_field_16(ngx_buf_t *b, uint16_t n)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_field_8(ngx_buf_t *b, uint8_t n)
+static ngx_int_t ngx_rtmp_mp4_field_8(ngx_buf_t *b, uint8_t n)
 {
-    u_char  bytes[1];
+    u_char bytes[1];
 
     bytes[0] = n & 0xFF;
 
@@ -79,47 +71,39 @@ ngx_rtmp_mp4_field_8(ngx_buf_t *b, uint8_t n)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_put_descr(ngx_buf_t *b, int tag, size_t size)
+static ngx_int_t ngx_rtmp_mp4_put_descr(ngx_buf_t *b, int tag, size_t size)
 {
-    ngx_rtmp_mp4_field_8(b, (uint8_t) tag);
+    ngx_rtmp_mp4_field_8(b, (uint8_t)tag);
     ngx_rtmp_mp4_field_8(b, size & 0x7F);
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_data(ngx_buf_t *b, void *data, size_t n)
+static ngx_int_t ngx_rtmp_mp4_data(ngx_buf_t *b, void *data, size_t n)
 {
     if (b->last + n > b->end) {
         return NGX_ERROR;
     }
 
-    b->last = ngx_cpymem(b->last, (u_char *) data, n);
+    b->last = ngx_cpymem(b->last, (u_char *)data, n);
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_box(ngx_buf_t *b, const char box[4])
+static ngx_int_t ngx_rtmp_mp4_box(ngx_buf_t *b, const char box[4])
 {
     if (b->last + 4 > b->end) {
         return NGX_ERROR;
     }
 
-    b->last = ngx_cpymem(b->last, (u_char *) box, 4);
+    b->last = ngx_cpymem(b->last, (u_char *)box, 4);
 
     return NGX_OK;
 }
 
-
-static u_char *
-ngx_rtmp_mp4_start_box(ngx_buf_t *b, const char box[4])
+static u_char *ngx_rtmp_mp4_start_box(ngx_buf_t *b, const char box[4])
 {
-    u_char  *p;
+    u_char *p;
 
     p = b->last;
 
@@ -134,11 +118,9 @@ ngx_rtmp_mp4_start_box(ngx_buf_t *b, const char box[4])
     return p;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_update_box_size(ngx_buf_t *b, u_char *p)
+static ngx_int_t ngx_rtmp_mp4_update_box_size(ngx_buf_t *b, u_char *p)
 {
-    u_char  *curpos;
+    u_char *curpos;
 
     if (p == NULL) {
         return NGX_ERROR;
@@ -148,25 +130,23 @@ ngx_rtmp_mp4_update_box_size(ngx_buf_t *b, u_char *p)
 
     b->last = p;
 
-    ngx_rtmp_mp4_field_32(b, (uint32_t) (curpos - p));
+    ngx_rtmp_mp4_field_32(b, (uint32_t)(curpos - p));
 
     b->last = curpos;
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_matrix(ngx_buf_t *buf, uint32_t a, uint32_t b, uint32_t c,
-    uint32_t d, uint32_t tx, uint32_t ty)
+static ngx_int_t ngx_rtmp_mp4_write_matrix(ngx_buf_t *buf, uint32_t a,
+                                           uint32_t b, uint32_t c, uint32_t d,
+                                           uint32_t tx, uint32_t ty)
 {
-
-/*
- * transformation matrix
- * |a  b  u|
- * |c  d  v|
- * |tx ty w|
- */
+    /*
+     * transformation matrix
+     * |a  b  u|
+     * |c  d  v|
+     * |tx ty w|
+     */
 
     ngx_rtmp_mp4_field_32(buf, a << 16);  /* 16.16 format */
     ngx_rtmp_mp4_field_32(buf, b << 16);  /* 16.16 format */
@@ -181,11 +161,9 @@ ngx_rtmp_mp4_write_matrix(ngx_buf_t *buf, uint32_t a, uint32_t b, uint32_t c,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mp4_write_ftyp(ngx_buf_t *b)
+ngx_int_t ngx_rtmp_mp4_write_ftyp(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "ftyp");
 
@@ -205,11 +183,9 @@ ngx_rtmp_mp4_write_ftyp(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mp4_write_styp(ngx_buf_t *b)
+ngx_int_t ngx_rtmp_mp4_write_styp(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "styp");
 
@@ -229,11 +205,9 @@ ngx_rtmp_mp4_write_styp(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_mvhd(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_mvhd(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "mvhd");
 
@@ -277,13 +251,11 @@ ngx_rtmp_mp4_write_mvhd(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_tkhd(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_tkhd(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char                *pos;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    u_char *pos;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -316,7 +288,7 @@ ngx_rtmp_mp4_write_tkhd(ngx_rtmp_session_t *s, ngx_buf_t *b,
     ngx_rtmp_mp4_field_32(b, 0);
 
     /* reserved */
-    ngx_rtmp_mp4_field_16(b, ttype == NGX_RTMP_MP4_VIDEO_TRACK ?  0 : 0x0100);
+    ngx_rtmp_mp4_field_16(b, ttype == NGX_RTMP_MP4_VIDEO_TRACK ? 0 : 0x0100);
 
     /* reserved */
     ngx_rtmp_mp4_field_16(b, 0);
@@ -324,8 +296,8 @@ ngx_rtmp_mp4_write_tkhd(ngx_rtmp_session_t *s, ngx_buf_t *b,
     ngx_rtmp_mp4_write_matrix(b, 1, 0, 0, 1, 0, 0);
 
     if (ttype == NGX_RTMP_MP4_VIDEO_TRACK) {
-        ngx_rtmp_mp4_field_32(b, (uint32_t) codec_ctx->width << 16);
-        ngx_rtmp_mp4_field_32(b, (uint32_t) codec_ctx->height << 16);
+        ngx_rtmp_mp4_field_32(b, (uint32_t)codec_ctx->width << 16);
+        ngx_rtmp_mp4_field_32(b, (uint32_t)codec_ctx->height << 16);
     } else {
         ngx_rtmp_mp4_field_32(b, 0);
         ngx_rtmp_mp4_field_32(b, 0);
@@ -336,11 +308,9 @@ ngx_rtmp_mp4_write_tkhd(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_mdhd(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_mdhd(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "mdhd");
 
@@ -370,11 +340,10 @@ ngx_rtmp_mp4_write_mdhd(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_hdlr(ngx_buf_t *b, ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_hdlr(ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "hdlr");
 
@@ -408,9 +377,7 @@ ngx_rtmp_mp4_write_hdlr(ngx_buf_t *b, ngx_rtmp_mp4_track_type_t ttype)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_vmhd(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_vmhd(ngx_buf_t *b)
 {
     /* size is always 20, apparently */
     ngx_rtmp_mp4_field_32(b, 20);
@@ -427,9 +394,7 @@ ngx_rtmp_mp4_write_vmhd(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_smhd(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_smhd(ngx_buf_t *b)
 {
     /* size is always 16, apparently */
     ngx_rtmp_mp4_field_32(b, 16);
@@ -446,11 +411,9 @@ ngx_rtmp_mp4_write_smhd(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_dref(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_dref(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "dref");
 
@@ -473,11 +436,9 @@ ngx_rtmp_mp4_write_dref(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_dinf(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_dinf(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "dinf");
 
@@ -488,13 +449,11 @@ ngx_rtmp_mp4_write_dinf(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_avcc(ngx_rtmp_session_t *s, ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_avcc(ngx_rtmp_session_t *s, ngx_buf_t *b)
 {
-    u_char                *pos, *p;
-    ngx_chain_t           *in;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    u_char *pos, *p;
+    ngx_chain_t *in;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -523,7 +482,7 @@ ngx_rtmp_mp4_write_avcc(ngx_rtmp_session_t *s, ngx_buf_t *b)
     p = in->buf->pos + 5;
 
     if (p < in->buf->last) {
-        ngx_rtmp_mp4_data(b, p, (size_t) (in->buf->last - p));
+        ngx_rtmp_mp4_data(b, p, (size_t)(in->buf->last - p));
     } else {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                       "dash: invalid avcc received");
@@ -534,12 +493,10 @@ ngx_rtmp_mp4_write_avcc(ngx_rtmp_session_t *s, ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_video(ngx_rtmp_session_t *s, ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_video(ngx_rtmp_session_t *s, ngx_buf_t *b)
 {
-    u_char                *pos;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    u_char *pos;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -562,8 +519,8 @@ ngx_rtmp_mp4_write_video(ngx_rtmp_session_t *s, ngx_buf_t *b)
     ngx_rtmp_mp4_field_32(b, 0);
 
     /* width & height */
-    ngx_rtmp_mp4_field_16(b, (uint16_t) codec_ctx->width);
-    ngx_rtmp_mp4_field_16(b, (uint16_t) codec_ctx->height);
+    ngx_rtmp_mp4_field_16(b, (uint16_t)codec_ctx->width);
+    ngx_rtmp_mp4_field_16(b, (uint16_t)codec_ctx->height);
 
     /* horizontal & vertical resolutions 72 dpi */
     ngx_rtmp_mp4_field_32(b, 0x00480000);
@@ -596,14 +553,12 @@ ngx_rtmp_mp4_write_video(ngx_rtmp_session_t *s, ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
 {
-    size_t                 dsi_len;
-    u_char                *pos, *dsi;
-    ngx_buf_t             *db;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    size_t dsi_len;
+    u_char *pos, *dsi;
+    ngx_buf_t *db;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -628,7 +583,6 @@ ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
     /* version */
     ngx_rtmp_mp4_field_32(b, 0);
 
-
     /* ES Descriptor */
 
     ngx_rtmp_mp4_put_descr(b, 0x03, 23 + dsi_len);
@@ -638,7 +592,6 @@ ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
 
     /* flags */
     ngx_rtmp_mp4_field_8(b, 0);
-
 
     /* DecoderConfig Descriptor */
 
@@ -659,12 +612,10 @@ ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
     /* avgBitrate */
     ngx_rtmp_mp4_field_32(b, 0x0001F14D);
 
-
     /* DecoderSpecificInfo Descriptor */
 
     ngx_rtmp_mp4_put_descr(b, 0x05, dsi_len);
     ngx_rtmp_mp4_data(b, dsi, dsi_len);
-
 
     /* SL Descriptor */
 
@@ -676,12 +627,10 @@ ngx_rtmp_mp4_write_esds(ngx_rtmp_session_t *s, ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_audio(ngx_rtmp_session_t *s, ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_audio(ngx_rtmp_session_t *s, ngx_buf_t *b)
 {
-    u_char                *pos;
-    ngx_rtmp_codec_ctx_t  *codec_ctx;
+    u_char *pos;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
 
     codec_ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -699,10 +648,10 @@ ngx_rtmp_mp4_write_audio(ngx_rtmp_session_t *s, ngx_buf_t *b)
     ngx_rtmp_mp4_field_32(b, 0);
 
     /* channel count */
-    ngx_rtmp_mp4_field_16(b, (uint16_t) codec_ctx->audio_channels);
+    ngx_rtmp_mp4_field_16(b, (uint16_t)codec_ctx->audio_channels);
 
     /* sample size */
-    ngx_rtmp_mp4_field_16(b, (uint16_t) (codec_ctx->sample_size * 8));
+    ngx_rtmp_mp4_field_16(b, (uint16_t)(codec_ctx->sample_size * 8));
 
     /* reserved */
     ngx_rtmp_mp4_field_32(b, 0);
@@ -711,7 +660,7 @@ ngx_rtmp_mp4_write_audio(ngx_rtmp_session_t *s, ngx_buf_t *b)
     ngx_rtmp_mp4_field_16(b, 1000);
 
     /* sample rate */
-    ngx_rtmp_mp4_field_16(b, (uint16_t) codec_ctx->sample_rate);
+    ngx_rtmp_mp4_field_16(b, (uint16_t)codec_ctx->sample_rate);
 
     ngx_rtmp_mp4_write_esds(s, b);
 #if 0
@@ -726,12 +675,10 @@ ngx_rtmp_mp4_write_audio(ngx_rtmp_session_t *s, ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stsd(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_stsd(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stsd");
 
@@ -752,11 +699,9 @@ ngx_rtmp_mp4_write_stsd(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stts(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_stts(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stts");
 
@@ -768,11 +713,9 @@ ngx_rtmp_mp4_write_stts(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stsc(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_stsc(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stsc");
 
@@ -784,11 +727,9 @@ ngx_rtmp_mp4_write_stsc(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stsz(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_stsz(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stsz");
 
@@ -801,11 +742,9 @@ ngx_rtmp_mp4_write_stsz(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stco(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_stco(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stco");
 
@@ -817,12 +756,10 @@ ngx_rtmp_mp4_write_stco(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_stbl(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_stbl(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "stbl");
 
@@ -837,12 +774,10 @@ ngx_rtmp_mp4_write_stbl(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_minf(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_minf(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "minf");
 
@@ -860,12 +795,10 @@ ngx_rtmp_mp4_write_minf(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_mdia(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_mdia(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "mdia");
 
@@ -878,11 +811,10 @@ ngx_rtmp_mp4_write_mdia(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_mp4_write_trak(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+static ngx_int_t ngx_rtmp_mp4_write_trak(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                         ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "trak");
 
@@ -894,11 +826,9 @@ ngx_rtmp_mp4_write_trak(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_mvex(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_mvex(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "mvex");
 
@@ -929,12 +859,10 @@ ngx_rtmp_mp4_write_mvex(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mp4_write_moov(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype)
+ngx_int_t ngx_rtmp_mp4_write_moov(ngx_rtmp_session_t *s, ngx_buf_t *b,
+                                  ngx_rtmp_mp4_track_type_t ttype)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "moov");
 
@@ -947,11 +875,9 @@ ngx_rtmp_mp4_write_moov(ngx_rtmp_session_t *s, ngx_buf_t *b,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_tfhd(ngx_buf_t *b)
+static ngx_int_t ngx_rtmp_mp4_write_tfhd(ngx_buf_t *b)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "tfhd");
 
@@ -966,11 +892,10 @@ ngx_rtmp_mp4_write_tfhd(ngx_buf_t *b)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_tfdt(ngx_buf_t *b, uint32_t earliest_pres_time)
+static ngx_int_t ngx_rtmp_mp4_write_tfdt(ngx_buf_t *b,
+                                         uint32_t earliest_pres_time)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "tfdt");
 
@@ -983,13 +908,13 @@ ngx_rtmp_mp4_write_tfdt(ngx_buf_t *b, uint32_t earliest_pres_time)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_trun(ngx_buf_t *b, uint32_t sample_count,
-    ngx_rtmp_mp4_sample_t *samples, ngx_uint_t sample_mask, u_char *moof_pos)
+static ngx_int_t ngx_rtmp_mp4_write_trun(ngx_buf_t *b, uint32_t sample_count,
+                                         ngx_rtmp_mp4_sample_t *samples,
+                                         ngx_uint_t sample_mask,
+                                         u_char *moof_pos)
 {
-    u_char    *pos;
-    uint32_t   i, offset, nitems, flags;
+    u_char *pos;
+    uint32_t i, offset, nitems, flags;
 
     pos = ngx_rtmp_mp4_start_box(b, "trun");
 
@@ -1025,7 +950,6 @@ ngx_rtmp_mp4_write_trun(ngx_buf_t *b, uint32_t sample_count,
     ngx_rtmp_mp4_field_32(b, offset);
 
     for (i = 0; i < sample_count; i++, samples++) {
-
         if (sample_mask & NGX_RTMP_MP4_SAMPLE_DURATION) {
             ngx_rtmp_mp4_field_32(b, samples->duration);
         }
@@ -1048,13 +972,12 @@ ngx_rtmp_mp4_write_trun(ngx_buf_t *b, uint32_t sample_count,
     return NGX_OK;
 }
 
-
 static ngx_int_t
 ngx_rtmp_mp4_write_traf(ngx_buf_t *b, uint32_t earliest_pres_time,
-    uint32_t sample_count, ngx_rtmp_mp4_sample_t *samples,
-    ngx_uint_t sample_mask, u_char *moof_pos)
+                        uint32_t sample_count, ngx_rtmp_mp4_sample_t *samples,
+                        ngx_uint_t sample_mask, u_char *moof_pos)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "traf");
 
@@ -1067,11 +990,9 @@ ngx_rtmp_mp4_write_traf(ngx_buf_t *b, uint32_t earliest_pres_time,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mp4_write_mfhd(ngx_buf_t *b, uint32_t index)
+static ngx_int_t ngx_rtmp_mp4_write_mfhd(ngx_buf_t *b, uint32_t index)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "mfhd");
 
@@ -1086,13 +1007,12 @@ ngx_rtmp_mp4_write_mfhd(ngx_buf_t *b, uint32_t index)
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mp4_write_sidx(ngx_buf_t *b, ngx_uint_t reference_size,
-    uint32_t earliest_pres_time, uint32_t latest_pres_time)
+ngx_int_t ngx_rtmp_mp4_write_sidx(ngx_buf_t *b, ngx_uint_t reference_size,
+                                  uint32_t earliest_pres_time,
+                                  uint32_t latest_pres_time)
 {
-    u_char    *pos;
-    uint32_t   duration;
+    u_char *pos;
+    uint32_t duration;
 
     duration = latest_pres_time - earliest_pres_time;
 
@@ -1136,13 +1056,12 @@ ngx_rtmp_mp4_write_sidx(ngx_buf_t *b, ngx_uint_t reference_size,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mp4_write_moof(ngx_buf_t *b, uint32_t earliest_pres_time,
-    uint32_t sample_count, ngx_rtmp_mp4_sample_t *samples,
-    ngx_uint_t sample_mask, uint32_t index)
+ngx_int_t ngx_rtmp_mp4_write_moof(ngx_buf_t *b, uint32_t earliest_pres_time,
+                                  uint32_t sample_count,
+                                  ngx_rtmp_mp4_sample_t *samples,
+                                  ngx_uint_t sample_mask, uint32_t index)
 {
-    u_char  *pos;
+    u_char *pos;
 
     pos = ngx_rtmp_mp4_start_box(b, "moof");
 
@@ -1155,9 +1074,7 @@ ngx_rtmp_mp4_write_moof(ngx_buf_t *b, uint32_t earliest_pres_time,
     return NGX_OK;
 }
 
-
-ngx_uint_t
-ngx_rtmp_mp4_write_mdat(ngx_buf_t *b, ngx_uint_t size)
+ngx_uint_t ngx_rtmp_mp4_write_mdat(ngx_buf_t *b, ngx_uint_t size)
 {
     ngx_rtmp_mp4_field_32(b, size);
 

--- a/dash/ngx_rtmp_mp4.h
+++ b/dash/ngx_rtmp_mp4.h
@@ -3,50 +3,44 @@
 #ifndef _NGX_RTMP_MP4_H_INCLUDED_
 #define _NGX_RTMP_MP4_H_INCLUDED_
 
-
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_rtmp.h>
 
-
-#define NGX_RTMP_MP4_SAMPLE_SIZE        0x01
-#define NGX_RTMP_MP4_SAMPLE_DURATION    0x02
-#define NGX_RTMP_MP4_SAMPLE_DELAY       0x04
-#define NGX_RTMP_MP4_SAMPLE_KEY         0x08
-
+#define NGX_RTMP_MP4_SAMPLE_SIZE 0x01
+#define NGX_RTMP_MP4_SAMPLE_DURATION 0x02
+#define NGX_RTMP_MP4_SAMPLE_DELAY 0x04
+#define NGX_RTMP_MP4_SAMPLE_KEY 0x08
 
 typedef struct {
-    uint32_t        size;
-    uint32_t        duration;
-    uint32_t        delay;
-    uint32_t        timestamp;
-    unsigned        key:1;
+    uint32_t size;
+    uint32_t duration;
+    uint32_t delay;
+    uint32_t timestamp;
+    unsigned key : 1;
 } ngx_rtmp_mp4_sample_t;
-
 
 typedef enum {
     NGX_RTMP_MP4_FILETYPE_INIT,
     NGX_RTMP_MP4_FILETYPE_SEG
 } ngx_rtmp_mp4_file_type_t;
 
-
 typedef enum {
     NGX_RTMP_MP4_VIDEO_TRACK,
     NGX_RTMP_MP4_AUDIO_TRACK
 } ngx_rtmp_mp4_track_type_t;
 
-
 ngx_int_t ngx_rtmp_mp4_write_ftyp(ngx_buf_t *b);
 ngx_int_t ngx_rtmp_mp4_write_styp(ngx_buf_t *b);
 ngx_int_t ngx_rtmp_mp4_write_moov(ngx_rtmp_session_t *s, ngx_buf_t *b,
-    ngx_rtmp_mp4_track_type_t ttype);
+                                  ngx_rtmp_mp4_track_type_t ttype);
 ngx_int_t ngx_rtmp_mp4_write_moof(ngx_buf_t *b, uint32_t earliest_pres_time,
-    uint32_t sample_count, ngx_rtmp_mp4_sample_t *samples,
-    ngx_uint_t sample_mask, uint32_t index);
-ngx_int_t ngx_rtmp_mp4_write_sidx(ngx_buf_t *b,
-    ngx_uint_t reference_size, uint32_t earliest_pres_time,
-    uint32_t latest_pres_time);
+                                  uint32_t sample_count,
+                                  ngx_rtmp_mp4_sample_t *samples,
+                                  ngx_uint_t sample_mask, uint32_t index);
+ngx_int_t ngx_rtmp_mp4_write_sidx(ngx_buf_t *b, ngx_uint_t reference_size,
+                                  uint32_t earliest_pres_time,
+                                  uint32_t latest_pres_time);
 ngx_uint_t ngx_rtmp_mp4_write_mdat(ngx_buf_t *b, ngx_uint_t size);
-
 
 #endif /* _NGX_RTMP_MP4_H_INCLUDED_ */

--- a/hls/ngx_rtmp_mpegts.c
+++ b/hls/ngx_rtmp_mpegts.c
@@ -3,21 +3,20 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_mpegts.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_mpegts.h"
 
 #include "ngx_rtmp_codec_module.h"
 
 static u_char ngx_rtmp_mpegts_header[] = {
 
-        /* https://en.wikipedia.org/wiki/MPEG_transport_stream#Packet */
+    /* https://en.wikipedia.org/wiki/MPEG_transport_stream#Packet */
 
     /* TS */
-    0x47,                                               // Sync byte
-    0x40, 0x00,                                         // TEI(1) + PUS(1) + TP(1) + PID(13)
-    0x10,                                               // SC(2) + AFF(1) + PF(1) + CC(4)
+    0x47,       // Sync byte
+    0x40, 0x00, // TEI(1) + PUS(1) + TP(1) + PID(13)
+    0x10,       // SC(2) + AFF(1) + PF(1) + CC(4)
     0x00,
     /* PSI */
     0x00, 0xb0, 0x0d, 0x00, 0x01, 0xc1, 0x00, 0x00,
@@ -26,56 +25,45 @@ static u_char ngx_rtmp_mpegts_header[] = {
     /* CRC */
     0x36, 0x90, 0xe2, 0x3d,
     /* stuffing 167 bytes */
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 
     /* TS */
-    0x47,
-    0x4f, 0xff,
-    0x10,
-    0x00,
+    0x47, 0x4f, 0xff, 0x10, 0x00,
     /* PSI */
     0x02, 0xb0, 0x17, 0x00, 0x01, 0xc1, 0x00, 0x00,
     /* PMT */
-    0xe1, 0x00,
-    0xf0, 0x00,
-    0x1b, 0xe1, 0x00, 0xf0, 0x00, /* h264 */
+    0xe1, 0x00, 0xf0, 0x00, 0x1b, 0xe1, 0x00, 0xf0, 0x00, /* h264 */
     0x00, 0x00, 0x00, 0x00, 0x00, /* audio placeholder */
-    0x00, 0x00, 0x00, 0x00, /* audio crc placeholder */
+    0x00, 0x00, 0x00, 0x00,       /* audio crc placeholder */
 
     /* stuffing 157 bytes */
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
-};
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff};
 
 static u_char ngx_rtmp_mpegts_header_mp3[] = {
     0x03, 0xe1, 0x01, 0xf0, 0x00, /* mp3 */
@@ -90,18 +78,16 @@ static u_char ngx_rtmp_mpegts_header_aac[] = {
 };
 
 /* 700 ms PCR delay */
-#define NGX_RTMP_HLS_DELAY  63000
+#define NGX_RTMP_HLS_DELAY 63000
 
-
-static ngx_int_t
-ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
-    size_t in_size)
+static ngx_int_t ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file,
+                                            u_char *in, size_t in_size)
 {
-    u_char   *out;
-    size_t    out_size, n;
-    ssize_t   rc;
+    u_char *out;
+    size_t out_size, n;
+    ssize_t rc;
 
-    static u_char  buf[1024];
+    static u_char buf[1024];
 
     if (!file->encrypt) {
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, file->log, 0,
@@ -120,7 +106,7 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
     ngx_log_debug1(NGX_LOG_DEBUG_CORE, file->log, 0,
                    "mpegts: write %uz encrypted bytes", in_size);
 
-    out = buf;
+    out      = buf;
     out_size = sizeof(buf);
 
     if (file->size > 0 && file->size + in_size >= 16) {
@@ -137,7 +123,7 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
         file->size = 0;
     }
 
-    for ( ;; ) {
+    for (;;) {
         n = in_size & ~0x0f;
 
         if (n > 0) {
@@ -159,7 +145,7 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
             return NGX_ERROR;
         }
 
-        out = buf;
+        out      = buf;
         out_size = sizeof(buf);
     }
 
@@ -171,77 +157,73 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
     return NGX_OK;
 }
 
-ngx_int_t
-ngx_rtmp_mpegts_set_audio_header(ngx_rtmp_codec_ctx_t *codec_ctx, ngx_uint_t mpegts_cc)
+ngx_int_t ngx_rtmp_mpegts_set_audio_header(ngx_rtmp_codec_ctx_t *codec_ctx,
+                                           ngx_uint_t mpegts_cc)
 {
     if (codec_ctx->audio_codec_id == NGX_RTMP_AUDIO_AAC) {
-        ngx_memcpy(ngx_rtmp_mpegts_header+210, ngx_rtmp_mpegts_header_aac, 
-                                        sizeof(ngx_rtmp_mpegts_header_aac));
+        ngx_memcpy(ngx_rtmp_mpegts_header + 210, ngx_rtmp_mpegts_header_aac,
+                   sizeof(ngx_rtmp_mpegts_header_aac));
     }
-    //if (*audio_codec_id == NGX_RTMP_AUDIO_MP3) {
+    // if (*audio_codec_id == NGX_RTMP_AUDIO_MP3) {
     else {
-        ngx_memcpy(ngx_rtmp_mpegts_header+210, ngx_rtmp_mpegts_header_mp3, 
-                                        sizeof(ngx_rtmp_mpegts_header_mp3));
+        ngx_memcpy(ngx_rtmp_mpegts_header + 210, ngx_rtmp_mpegts_header_mp3,
+                   sizeof(ngx_rtmp_mpegts_header_mp3));
     }
 
     // Truncate counter to 4 bits here
     mpegts_cc %= 0x0f;
     // And fill headers
-    ngx_rtmp_mpegts_header[3] = (ngx_rtmp_mpegts_header[3] & 0xf0) + (u_char)mpegts_cc;
-    ngx_rtmp_mpegts_header[191] = (ngx_rtmp_mpegts_header[191] & 0xf0) + (u_char)mpegts_cc;
+    ngx_rtmp_mpegts_header[3] =
+        (ngx_rtmp_mpegts_header[3] & 0xf0) + (u_char)mpegts_cc;
+    ngx_rtmp_mpegts_header[191] =
+        (ngx_rtmp_mpegts_header[191] & 0xf0) + (u_char)mpegts_cc;
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_mpegts_write_header(ngx_rtmp_mpegts_file_t *file, ngx_rtmp_codec_ctx_t *codec_ctx, ngx_uint_t mpegts_cc)
+static ngx_int_t ngx_rtmp_mpegts_write_header(ngx_rtmp_mpegts_file_t *file,
+                                              ngx_rtmp_codec_ctx_t *codec_ctx,
+                                              ngx_uint_t mpegts_cc)
 {
     ngx_int_t rc;
 
-    //If there's both audio and video present
-    if (codec_ctx->audio_codec_id && codec_ctx->video_codec_id)
-    {
+    // If there's both audio and video present
+    if (codec_ctx->audio_codec_id && codec_ctx->video_codec_id) {
         /* Write the audio headers */
         ngx_rtmp_mpegts_set_audio_header(codec_ctx, mpegts_cc);
 
         rc = ngx_rtmp_mpegts_write_file(file, ngx_rtmp_mpegts_header,
-                                          sizeof(ngx_rtmp_mpegts_header));
-    }
-    else
-    {
-        //Just video or just audio
+                                        sizeof(ngx_rtmp_mpegts_header));
+    } else {
+        // Just video or just audio
         u_char buf[sizeof(ngx_rtmp_mpegts_header)];
 
         ngx_memcpy(buf, ngx_rtmp_mpegts_header, sizeof(ngx_rtmp_mpegts_header));
-        
+
         /* Fix the section length */
         buf[195] = 0x12;
 
-        if (codec_ctx->audio_codec_id)
-        {
-          /* Set the PCR PID to the audio PID */
-          buf[202] = 0x01;
+        if (codec_ctx->audio_codec_id) {
+            /* Set the PCR PID to the audio PID */
+            buf[202] = 0x01;
 
-          /* Write the audio headers */
-          ngx_rtmp_mpegts_set_audio_header(codec_ctx, mpegts_cc);
+            /* Write the audio headers */
+            ngx_rtmp_mpegts_set_audio_header(codec_ctx, mpegts_cc);
 
-          /* Move the audio description over the video description */
-          ngx_memcpy(buf + 205, buf + 210, 5);
+            /* Move the audio description over the video description */
+            ngx_memcpy(buf + 205, buf + 210, 5);
 
-          /* Fix the CRC partially overwriting the audio description */
-          buf[210] = 0xec;
-          buf[211] = 0xe2;
-          buf[212] = 0xb0;
-          buf[213] = 0x94;
-        }
-        else
-        {
-          /* Fix the CRC partially overwriting the video description */
-          buf[210] = 0x15;
-          buf[211] = 0xbd;
-          buf[212] = 0x4d;
-          buf[213] = 0x56;
+            /* Fix the CRC partially overwriting the audio description */
+            buf[210] = 0xec;
+            buf[211] = 0xe2;
+            buf[212] = 0xb0;
+            buf[213] = 0x94;
+        } else {
+            /* Fix the CRC partially overwriting the video description */
+            buf[210] = 0x15;
+            buf[211] = 0xbd;
+            buf[212] = 0x4d;
+            buf[213] = 0x56;
         }
 
         /* Clear the last byte of the audio description and the old CRC */
@@ -251,57 +233,50 @@ ngx_rtmp_mpegts_write_header(ngx_rtmp_mpegts_file_t *file, ngx_rtmp_codec_ctx_t 
     }
 
     return rc;
-    
 }
 
-
-static u_char *
-ngx_rtmp_mpegts_write_pcr(u_char *p, uint64_t pcr)
+static u_char *ngx_rtmp_mpegts_write_pcr(u_char *p, uint64_t pcr)
 {
-    *p++ = (u_char) (pcr >> 25);
-    *p++ = (u_char) (pcr >> 17);
-    *p++ = (u_char) (pcr >> 9);
-    *p++ = (u_char) (pcr >> 1);
-    *p++ = (u_char) (pcr << 7 | 0x7e);
+    *p++ = (u_char)(pcr >> 25);
+    *p++ = (u_char)(pcr >> 17);
+    *p++ = (u_char)(pcr >> 9);
+    *p++ = (u_char)(pcr >> 1);
+    *p++ = (u_char)(pcr << 7 | 0x7e);
     *p++ = 0;
 
     return p;
 }
 
-
-static u_char *
-ngx_rtmp_mpegts_write_pts(u_char *p, ngx_uint_t fb, uint64_t pts)
+static u_char *ngx_rtmp_mpegts_write_pts(u_char *p, ngx_uint_t fb, uint64_t pts)
 {
     ngx_uint_t val;
 
-    val = fb << 4 | (((pts >> 30) & 0x07) << 1) | 1;
-    *p++ = (u_char) val;
+    val  = fb << 4 | (((pts >> 30) & 0x07) << 1) | 1;
+    *p++ = (u_char)val;
 
-    val = (((pts >> 15) & 0x7fff) << 1) | 1;
-    *p++ = (u_char) (val >> 8);
-    *p++ = (u_char) val;
+    val  = (((pts >> 15) & 0x7fff) << 1) | 1;
+    *p++ = (u_char)(val >> 8);
+    *p++ = (u_char)val;
 
-    val = (((pts) & 0x7fff) << 1) | 1;
-    *p++ = (u_char) (val >> 8);
-    *p++ = (u_char) val;
+    val  = (((pts)&0x7fff) << 1) | 1;
+    *p++ = (u_char)(val >> 8);
+    *p++ = (u_char)val;
 
     return p;
 }
 
-
-ngx_int_t
-ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
-    ngx_rtmp_mpegts_frame_t *f, ngx_buf_t *b)
+ngx_int_t ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
+                                      ngx_rtmp_mpegts_frame_t *f, ngx_buf_t *b)
 {
-    ngx_uint_t  pes_size, header_size, body_size, in_size, stuff_size, flags;
-    u_char      packet[188], *p, *base;
-    ngx_int_t   first, rc;
+    ngx_uint_t pes_size, header_size, body_size, in_size, stuff_size, flags;
+    u_char packet[188], *p, *base;
+    ngx_int_t first, rc;
 
     ngx_log_debug6(NGX_LOG_DEBUG_CORE, file->log, 0,
                    "mpegts: pid=%ui, sid=%ui, pts=%uL, "
                    "dts=%uL, key=%ui, size=%ui",
-                   f->pid, f->sid, f->pts, f->dts,
-                   (ngx_uint_t) f->key, (size_t) (b->last - b->pos));
+                   f->pid, f->sid, f->pts, f->dts, (ngx_uint_t)f->key,
+                   (size_t)(b->last - b->pos));
 
     first = 1;
 
@@ -311,17 +286,16 @@ ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
         f->cc++;
 
         *p++ = 0x47;
-        *p++ = (u_char) (f->pid >> 8);
+        *p++ = (u_char)(f->pid >> 8);
 
         if (first) {
             p[-1] |= 0x40;
         }
 
-        *p++ = (u_char) f->pid;
+        *p++ = (u_char)f->pid;
         *p++ = 0x10 | (f->cc & 0x0f); /* payload */
 
         if (first) {
-
             packet[3] |= 0x20; /* adaptation */
 
             *p++ = 7;    /* size */
@@ -334,10 +308,10 @@ ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
             *p++ = 0x00;
             *p++ = 0x00;
             *p++ = 0x01;
-            *p++ = (u_char) f->sid;
+            *p++ = (u_char)f->sid;
 
             header_size = 5;
-            flags = 0x80; /* PTS */
+            flags       = 0x80; /* PTS */
 
             if (f->dts != f->pts) {
                 header_size += 5;
@@ -349,25 +323,25 @@ ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
                 pes_size = 0;
             }
 
-            *p++ = (u_char) (pes_size >> 8);
-            *p++ = (u_char) pes_size;
+            *p++ = (u_char)(pes_size >> 8);
+            *p++ = (u_char)pes_size;
             *p++ = 0x80; /* H222 */
-            *p++ = (u_char) flags;
-            *p++ = (u_char) header_size;
+            *p++ = (u_char)flags;
+            *p++ = (u_char)header_size;
 
-            p = ngx_rtmp_mpegts_write_pts(p, flags >> 6, f->pts +
-                                                         NGX_RTMP_HLS_DELAY);
+            p = ngx_rtmp_mpegts_write_pts(p, flags >> 6,
+                                          f->pts + NGX_RTMP_HLS_DELAY);
 
             if (f->dts != f->pts) {
-                p = ngx_rtmp_mpegts_write_pts(p, 1, f->dts +
-                                                    NGX_RTMP_HLS_DELAY);
+                p = ngx_rtmp_mpegts_write_pts(p, 1,
+                                              f->dts + NGX_RTMP_HLS_DELAY);
             }
 
             first = 0;
         }
 
-        body_size = (ngx_uint_t) (packet + sizeof(packet) - p);
-        in_size = (ngx_uint_t) (b->last - b->pos);
+        body_size = (ngx_uint_t)(packet + sizeof(packet) - p);
+        in_size   = (ngx_uint_t)(b->last - b->pos);
 
         if (body_size <= in_size) {
             ngx_memcpy(p, b->pos, body_size);
@@ -377,23 +351,21 @@ ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
             stuff_size = (body_size - in_size);
 
             if (packet[3] & 0x20) {
-
                 /* has adaptation */
 
                 base = &packet[5] + packet[4];
-                p = ngx_movemem(base + stuff_size, base, p - base);
+                p    = ngx_movemem(base + stuff_size, base, p - base);
                 ngx_memset(base, 0xff, stuff_size);
-                packet[4] += (u_char) stuff_size;
+                packet[4] += (u_char)stuff_size;
 
             } else {
-
                 /* no adaptation */
 
                 packet[3] |= 0x20;
                 p = ngx_movemem(&packet[4] + stuff_size, &packet[4],
                                 p - &packet[4]);
 
-                packet[4] = (u_char) (stuff_size - 1);
+                packet[4] = (u_char)(stuff_size - 1);
                 if (stuff_size >= 2) {
                     packet[5] = 0;
                     ngx_memset(&packet[6], 0xff, stuff_size - 2);
@@ -413,10 +385,9 @@ ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
-    u_char *key, size_t key_len, uint64_t iv)
+ngx_int_t ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
+                                          u_char *key, size_t key_len,
+                                          uint64_t iv)
 {
     if (AES_set_encrypt_key(key, key_len * 8, &file->key)) {
         return NGX_ERROR;
@@ -424,24 +395,24 @@ ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
 
     ngx_memzero(file->iv, 8);
 
-    file->iv[8]  = (u_char) (iv >> 56);
-    file->iv[9]  = (u_char) (iv >> 48);
-    file->iv[10] = (u_char) (iv >> 40);
-    file->iv[11] = (u_char) (iv >> 32);
-    file->iv[12] = (u_char) (iv >> 24);
-    file->iv[13] = (u_char) (iv >> 16);
-    file->iv[14] = (u_char) (iv >> 8);
-    file->iv[15] = (u_char) (iv);
+    file->iv[8]  = (u_char)(iv >> 56);
+    file->iv[9]  = (u_char)(iv >> 48);
+    file->iv[10] = (u_char)(iv >> 40);
+    file->iv[11] = (u_char)(iv >> 32);
+    file->iv[12] = (u_char)(iv >> 24);
+    file->iv[13] = (u_char)(iv >> 16);
+    file->iv[14] = (u_char)(iv >> 8);
+    file->iv[15] = (u_char)(iv);
 
     file->encrypt = 1;
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
-    ngx_log_t *log, ngx_rtmp_codec_ctx_t *codec_ctx, ngx_uint_t mpegts_cc)
+ngx_int_t ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
+                                    ngx_log_t *log,
+                                    ngx_rtmp_codec_ctx_t *codec_ctx,
+                                    ngx_uint_t mpegts_cc)
 {
     file->log = log;
 
@@ -466,12 +437,10 @@ ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_mpegts_close_file(ngx_rtmp_mpegts_file_t *file)
+ngx_int_t ngx_rtmp_mpegts_close_file(ngx_rtmp_mpegts_file_t *file)
 {
-    u_char   buf[16];
-    ssize_t  rc;
+    u_char buf[16];
+    ssize_t rc;
 
     if (file->encrypt) {
         ngx_memset(file->buf + file->size, 16 - file->size, 16 - file->size);

--- a/hls/ngx_rtmp_mpegts.h
+++ b/hls/ngx_rtmp_mpegts.h
@@ -3,10 +3,8 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_MPEGTS_H_INCLUDED_
 #define _NGX_RTMP_MPEGTS_H_INCLUDED_
-
 
 #include <ngx_config.h>
 #include <ngx_core.h>
@@ -14,35 +12,34 @@
 
 #include <ngx_rtmp_codec_module.h>
 
-
 typedef struct {
-    ngx_fd_t    fd;
-    ngx_log_t  *log;
-    unsigned    encrypt:1;
-    unsigned    size:4;
-    u_char      buf[16];
-    u_char      iv[16];
-    AES_KEY     key;
+    ngx_fd_t fd;
+    ngx_log_t *log;
+    unsigned encrypt : 1;
+    unsigned size : 4;
+    u_char buf[16];
+    u_char iv[16];
+    AES_KEY key;
 } ngx_rtmp_mpegts_file_t;
 
-
 typedef struct {
-    uint64_t    pts;
-    uint64_t    dts;
-    ngx_uint_t  pid;
-    ngx_uint_t  sid;
-    ngx_uint_t  cc;
-    unsigned    key:1;
+    uint64_t pts;
+    uint64_t dts;
+    ngx_uint_t pid;
+    ngx_uint_t sid;
+    ngx_uint_t cc;
+    unsigned key : 1;
 } ngx_rtmp_mpegts_frame_t;
 
-
 ngx_int_t ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
-    u_char *key, size_t key_len, uint64_t iv);
+                                          u_char *key, size_t key_len,
+                                          uint64_t iv);
 ngx_int_t ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
-    ngx_log_t *log, ngx_rtmp_codec_ctx_t *codec_ctx, ngx_uint_t mpegts_cc);
+                                    ngx_log_t *log,
+                                    ngx_rtmp_codec_ctx_t *codec_ctx,
+                                    ngx_uint_t mpegts_cc);
 ngx_int_t ngx_rtmp_mpegts_close_file(ngx_rtmp_mpegts_file_t *file);
 ngx_int_t ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
-    ngx_rtmp_mpegts_frame_t *f, ngx_buf_t *b);
-
+                                      ngx_rtmp_mpegts_frame_t *f, ngx_buf_t *b);
 
 #endif /* _NGX_RTMP_MPEGTS_H_INCLUDED_ */

--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -3,105 +3,87 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp.h"
+#include <nginx.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_event.h>
-#include <nginx.h>
-#include "ngx_rtmp.h"
-
 
 static char *ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static ngx_int_t ngx_rtmp_add_ports(ngx_conf_t *cf, ngx_array_t *ports,
-    ngx_rtmp_listen_t *listen);
+                                    ngx_rtmp_listen_t *listen);
 static char *ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports);
 static ngx_int_t ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
-    ngx_rtmp_conf_addr_t *addr);
+                                    ngx_rtmp_conf_addr_t *addr);
 #if (NGX_HAVE_INET6)
 static ngx_int_t ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
-    ngx_rtmp_conf_addr_t *addr);
+                                     ngx_rtmp_conf_addr_t *addr);
 #endif
 static ngx_int_t ngx_rtmp_cmp_conf_addrs(const void *one, const void *two);
 static ngx_int_t ngx_rtmp_init_events(ngx_conf_t *cf,
-        ngx_rtmp_core_main_conf_t *cmcf);
+                                      ngx_rtmp_core_main_conf_t *cmcf);
 static ngx_int_t ngx_rtmp_init_event_handlers(ngx_conf_t *cf,
-        ngx_rtmp_core_main_conf_t *cmcf);
-static char * ngx_rtmp_merge_applications(ngx_conf_t *cf,
-        ngx_array_t *applications, void **app_conf, ngx_rtmp_module_t *module,
-        ngx_uint_t ctx_index);
+                                              ngx_rtmp_core_main_conf_t *cmcf);
+static char *ngx_rtmp_merge_applications(ngx_conf_t *cf,
+                                         ngx_array_t *applications,
+                                         void **app_conf,
+                                         ngx_rtmp_module_t *module,
+                                         ngx_uint_t ctx_index);
 static ngx_int_t ngx_rtmp_init_process(ngx_cycle_t *cycle);
 
-
 #if (nginx_version >= 1007011)
-ngx_queue_t                         ngx_rtmp_init_queue;
+ngx_queue_t ngx_rtmp_init_queue;
 #elif (nginx_version >= 1007005)
-ngx_thread_volatile ngx_queue_t     ngx_rtmp_init_queue;
+ngx_thread_volatile ngx_queue_t ngx_rtmp_init_queue;
 #else
-ngx_thread_volatile ngx_event_t    *ngx_rtmp_init_queue;
+ngx_thread_volatile ngx_event_t *ngx_rtmp_init_queue;
 #endif
 
+ngx_uint_t ngx_rtmp_max_module;
 
-ngx_uint_t  ngx_rtmp_max_module;
+static ngx_command_t ngx_rtmp_commands[] = {
 
+    {ngx_string("rtmp"), NGX_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS,
+     ngx_rtmp_block, 0, 0, NULL},
 
-static ngx_command_t  ngx_rtmp_commands[] = {
+    ngx_null_command};
 
-    { ngx_string("rtmp"),
-      NGX_MAIN_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
-      ngx_rtmp_block,
-      0,
-      0,
-      NULL },
+static ngx_core_module_t ngx_rtmp_module_ctx = {ngx_string("rtmp"), NULL, NULL};
 
-      ngx_null_command
-};
+ngx_module_t ngx_rtmp_module = {NGX_MODULE_V1,
+                                &ngx_rtmp_module_ctx,  /* module context */
+                                ngx_rtmp_commands,     /* module directives */
+                                NGX_CORE_MODULE,       /* module type */
+                                NULL,                  /* init master */
+                                NULL,                  /* init module */
+                                ngx_rtmp_init_process, /* init process */
+                                NULL,                  /* init thread */
+                                NULL,                  /* exit thread */
+                                NULL,                  /* exit process */
+                                NULL,                  /* exit master */
+                                NGX_MODULE_V1_PADDING};
 
-
-static ngx_core_module_t  ngx_rtmp_module_ctx = {
-    ngx_string("rtmp"),
-    NULL,
-    NULL
-};
-
-
-ngx_module_t  ngx_rtmp_module = {
-    NGX_MODULE_V1,
-    &ngx_rtmp_module_ctx,                  /* module context */
-    ngx_rtmp_commands,                     /* module directives */
-    NGX_CORE_MODULE,                       /* module type */
-    NULL,                                  /* init master */
-    NULL,                                  /* init module */
-    ngx_rtmp_init_process,                 /* init process */
-    NULL,                                  /* init thread */
-    NULL,                                  /* exit thread */
-    NULL,                                  /* exit process */
-    NULL,                                  /* exit master */
-    NGX_MODULE_V1_PADDING
-};
-
-
-static char *
-ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    char                        *rv;
-    ngx_uint_t                   i, m, mi, s;
-    ngx_conf_t                   pcf;
-    ngx_array_t                  ports;
-    ngx_module_t               **modules;
-    ngx_rtmp_listen_t           *listen;
-    ngx_rtmp_module_t           *module;
-    ngx_rtmp_conf_ctx_t         *ctx;
-    ngx_rtmp_core_srv_conf_t    *cscf, **cscfp;
-    ngx_rtmp_core_main_conf_t   *cmcf;
+    char *rv;
+    ngx_uint_t i, m, mi, s;
+    ngx_conf_t pcf;
+    ngx_array_t ports;
+    ngx_module_t **modules;
+    ngx_rtmp_listen_t *listen;
+    ngx_rtmp_module_t *module;
+    ngx_rtmp_conf_ctx_t *ctx;
+    ngx_rtmp_core_srv_conf_t *cscf, **cscfp;
+    ngx_rtmp_core_main_conf_t *cmcf;
 
     ctx = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_conf_ctx_t));
     if (ctx == NULL) {
         return NGX_CONF_ERROR;
     }
 
-    *(ngx_rtmp_conf_ctx_t **) conf = ctx;
+    *(ngx_rtmp_conf_ctx_t **)conf = ctx;
 
-    /* count the number of the rtmp modules and set up their indices */
+/* count the number of the rtmp modules and set up their indices */
 #if defined(nginx_version) && nginx_version >= 1009011
     modules = cf->cycle->modules;
 #else
@@ -116,15 +98,13 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         modules[m]->ctx_index = ngx_rtmp_max_module++;
     }
 
-
     /* the rtmp main_conf context, it is the same in the all rtmp contexts */
 
-    ctx->main_conf = ngx_pcalloc(cf->pool,
-                                 sizeof(void *) * ngx_rtmp_max_module);
+    ctx->main_conf =
+        ngx_pcalloc(cf->pool, sizeof(void *) * ngx_rtmp_max_module);
     if (ctx->main_conf == NULL) {
         return NGX_CONF_ERROR;
     }
-
 
     /*
      * the rtmp null srv_conf context, it is used to merge
@@ -136,7 +116,6 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
-
     /*
      * the rtmp null app_conf context, it is used to merge
      * the server{}s' app_conf's
@@ -146,7 +125,6 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (ctx->app_conf == NULL) {
         return NGX_CONF_ERROR;
     }
-
 
     /*
      * create the main_conf's, the null srv_conf's, and the null app_conf's
@@ -159,7 +137,7 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
         module = modules[m]->ctx;
-        mi = modules[m]->ctx_index;
+        mi     = modules[m]->ctx_index;
 
         if (module->create_main_conf) {
             ctx->main_conf[mi] = module->create_main_conf(cf);
@@ -183,7 +161,7 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
     }
 
-    pcf = *cf;
+    pcf     = *cf;
     cf->ctx = ctx;
 
     for (m = 0; modules[m]; m++) {
@@ -203,18 +181,17 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     /* parse inside the rtmp{} block */
 
     cf->module_type = NGX_RTMP_MODULE;
-    cf->cmd_type = NGX_RTMP_MAIN_CONF;
-    rv = ngx_conf_parse(cf, NULL);
+    cf->cmd_type    = NGX_RTMP_MAIN_CONF;
+    rv              = ngx_conf_parse(cf, NULL);
 
     if (rv != NGX_CONF_OK) {
         *cf = pcf;
         return rv;
     }
 
-
     /* init rtmp{} main_conf's, merge the server{}s' srv_conf's */
 
-    cmcf = ctx->main_conf[ngx_rtmp_core_module.ctx_index];
+    cmcf  = ctx->main_conf[ngx_rtmp_core_module.ctx_index];
     cscfp = cmcf->servers.elts;
 
     for (m = 0; modules[m]; m++) {
@@ -223,7 +200,7 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
         module = modules[m]->ctx;
-        mi = modules[m]->ctx_index;
+        mi     = modules[m]->ctx_index;
 
         /* init rtmp{} main_conf's */
 
@@ -238,14 +215,12 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
         for (s = 0; s < cmcf->servers.nelts; s++) {
-
             /* merge the server{}s' srv_conf's */
 
             cf->ctx = cscfp[s]->ctx;
 
             if (module->merge_srv_conf) {
-                rv = module->merge_srv_conf(cf,
-                                            ctx->srv_conf[mi],
+                rv = module->merge_srv_conf(cf, ctx->srv_conf[mi],
                                             cscfp[s]->ctx->srv_conf[mi]);
                 if (rv != NGX_CONF_OK) {
                     *cf = pcf;
@@ -254,13 +229,11 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             }
 
             if (module->merge_app_conf) {
-
                 /* merge the server{}'s app_conf */
 
                 /*ctx->app_conf = cscfp[s]->ctx->loc_conf;*/
 
-                rv = module->merge_app_conf(cf,
-                                            ctx->app_conf[mi],
+                rv = module->merge_app_conf(cf, ctx->app_conf[mi],
                                             cscfp[s]->ctx->app_conf[mi]);
                 if (rv != NGX_CONF_OK) {
                     *cf = pcf;
@@ -272,17 +245,15 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 cscf = cscfp[s]->ctx->srv_conf[ngx_rtmp_core_module.ctx_index];
 
                 rv = ngx_rtmp_merge_applications(cf, &cscf->applications,
-                                            cscfp[s]->ctx->app_conf,
-                                            module, mi);
+                                                 cscfp[s]->ctx->app_conf,
+                                                 module, mi);
                 if (rv != NGX_CONF_OK) {
                     *cf = pcf;
                     return rv;
                 }
             }
-
         }
     }
-
 
     if (ngx_rtmp_init_events(cf, cmcf) != NGX_OK) {
         return NGX_CONF_ERROR;
@@ -308,9 +279,8 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
-    if (ngx_array_init(&ports, cf->temp_pool, 4, sizeof(ngx_rtmp_conf_port_t))
-        != NGX_OK)
-    {
+    if (ngx_array_init(&ports, cf->temp_pool, 4,
+                       sizeof(ngx_rtmp_conf_port_t)) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 
@@ -325,39 +295,38 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return ngx_rtmp_optimize_servers(cf, &ports);
 }
 
-
-static char *
-ngx_rtmp_merge_applications(ngx_conf_t *cf, ngx_array_t *applications,
-            void **app_conf, ngx_rtmp_module_t *module, ngx_uint_t ctx_index)
+static char *ngx_rtmp_merge_applications(ngx_conf_t *cf,
+                                         ngx_array_t *applications,
+                                         void **app_conf,
+                                         ngx_rtmp_module_t *module,
+                                         ngx_uint_t ctx_index)
 {
-    char                           *rv;
-    ngx_rtmp_conf_ctx_t            *ctx, saved;
-    ngx_rtmp_core_app_conf_t      **cacfp;
-    ngx_uint_t                      n;
-    ngx_rtmp_core_app_conf_t       *cacf;
+    char *rv;
+    ngx_rtmp_conf_ctx_t *ctx, saved;
+    ngx_rtmp_core_app_conf_t **cacfp;
+    ngx_uint_t n;
+    ngx_rtmp_core_app_conf_t *cacf;
 
     if (applications == NULL) {
         return NGX_CONF_OK;
     }
 
-    ctx = (ngx_rtmp_conf_ctx_t *) cf->ctx;
+    ctx   = (ngx_rtmp_conf_ctx_t *)cf->ctx;
     saved = *ctx;
 
     cacfp = applications->elts;
     for (n = 0; n < applications->nelts; ++n, ++cacfp) {
-
         ctx->app_conf = (*cacfp)->app_conf;
 
         rv = module->merge_app_conf(cf, app_conf[ctx_index],
-                (*cacfp)->app_conf[ctx_index]);
+                                    (*cacfp)->app_conf[ctx_index]);
         if (rv != NGX_CONF_OK) {
             return rv;
         }
 
         cacf = (*cacfp)->app_conf[ngx_rtmp_core_module.ctx_index];
-        rv = ngx_rtmp_merge_applications(cf, &cacf->applications,
-                                         (*cacfp)->app_conf,
-                                         module, ctx_index);
+        rv   = ngx_rtmp_merge_applications(cf, &cacf->applications,
+                                         (*cacfp)->app_conf, module, ctx_index);
         if (rv != NGX_CONF_OK) {
             return rv;
         }
@@ -368,157 +337,139 @@ ngx_rtmp_merge_applications(ngx_conf_t *cf, ngx_array_t *applications,
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_init_events(ngx_conf_t *cf, ngx_rtmp_core_main_conf_t *cmcf)
+static ngx_int_t ngx_rtmp_init_events(ngx_conf_t *cf,
+                                      ngx_rtmp_core_main_conf_t *cmcf)
 {
-    size_t                      n;
+    size_t n;
 
-    for(n = 0; n < NGX_RTMP_MAX_EVENT; ++n) {
+    for (n = 0; n < NGX_RTMP_MAX_EVENT; ++n) {
         if (ngx_array_init(&cmcf->events[n], cf->pool, 1,
-                sizeof(ngx_rtmp_handler_pt)) != NGX_OK)
-        {
+                           sizeof(ngx_rtmp_handler_pt)) != NGX_OK) {
             return NGX_ERROR;
         }
     }
 
     if (ngx_array_init(&cmcf->amf, cf->pool, 1,
-                sizeof(ngx_rtmp_amf_handler_t)) != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_amf_handler_t)) != NGX_OK) {
         return NGX_ERROR;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_init_event_handlers(ngx_conf_t *cf, ngx_rtmp_core_main_conf_t *cmcf)
+static ngx_int_t ngx_rtmp_init_event_handlers(ngx_conf_t *cf,
+                                              ngx_rtmp_core_main_conf_t *cmcf)
 {
-    ngx_hash_init_t             calls_hash;
-    ngx_rtmp_handler_pt        *eh;
-    ngx_rtmp_amf_handler_t     *h;
-    ngx_hash_key_t             *ha;
-    size_t                      n, m;
+    ngx_hash_init_t calls_hash;
+    ngx_rtmp_handler_pt *eh;
+    ngx_rtmp_amf_handler_t *h;
+    ngx_hash_key_t *ha;
+    size_t n, m;
 
-    static size_t               pm_events[] = {
-        NGX_RTMP_MSG_CHUNK_SIZE,
-        NGX_RTMP_MSG_ABORT,
-        NGX_RTMP_MSG_ACK,
-        NGX_RTMP_MSG_ACK_SIZE,
-        NGX_RTMP_MSG_BANDWIDTH
-    };
+    static size_t pm_events[] = {NGX_RTMP_MSG_CHUNK_SIZE, NGX_RTMP_MSG_ABORT,
+                                 NGX_RTMP_MSG_ACK, NGX_RTMP_MSG_ACK_SIZE,
+                                 NGX_RTMP_MSG_BANDWIDTH};
 
-    static size_t               amf_events[] = {
-        NGX_RTMP_MSG_AMF_CMD,
-        NGX_RTMP_MSG_AMF_META,
-        NGX_RTMP_MSG_AMF_SHARED,
-        NGX_RTMP_MSG_AMF3_CMD,
-        NGX_RTMP_MSG_AMF3_META,
-        NGX_RTMP_MSG_AMF3_SHARED
-    };
+    static size_t amf_events[] = {
+        NGX_RTMP_MSG_AMF_CMD,    NGX_RTMP_MSG_AMF_META,
+        NGX_RTMP_MSG_AMF_SHARED, NGX_RTMP_MSG_AMF3_CMD,
+        NGX_RTMP_MSG_AMF3_META,  NGX_RTMP_MSG_AMF3_SHARED};
 
     /* init standard protocol events */
-    for(n = 0; n < sizeof(pm_events) / sizeof(pm_events[0]); ++n) {
-        eh = ngx_array_push(&cmcf->events[pm_events[n]]);
+    for (n = 0; n < sizeof(pm_events) / sizeof(pm_events[0]); ++n) {
+        eh  = ngx_array_push(&cmcf->events[pm_events[n]]);
         *eh = ngx_rtmp_protocol_message_handler;
     }
 
     /* init amf events */
-    for(n = 0; n < sizeof(amf_events) / sizeof(amf_events[0]); ++n) {
-        eh = ngx_array_push(&cmcf->events[amf_events[n]]);
+    for (n = 0; n < sizeof(amf_events) / sizeof(amf_events[0]); ++n) {
+        eh  = ngx_array_push(&cmcf->events[amf_events[n]]);
         *eh = ngx_rtmp_amf_message_handler;
     }
 
     /* init user protocol events */
-    eh = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_USER]);
+    eh  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_USER]);
     *eh = ngx_rtmp_user_message_handler;
 
     /* aggregate to audio/video map */
-    eh = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AGGREGATE]);
+    eh  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AGGREGATE]);
     *eh = ngx_rtmp_aggregate_message_handler;
 
     /* init amf callbacks */
     ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t));
 
     h = cmcf->amf.elts;
-    for(n = 0; n < cmcf->amf.nelts; ++n, ++h) {
+    for (n = 0; n < cmcf->amf.nelts; ++n, ++h) {
         ha = cmcf->amf_arrays.elts;
-        for(m = 0; m < cmcf->amf_arrays.nelts; ++m, ++ha) {
-            if (h->name.len == ha->key.len
-                    && !ngx_strncmp(h->name.data, ha->key.data, ha->key.len))
-            {
+        for (m = 0; m < cmcf->amf_arrays.nelts; ++m, ++ha) {
+            if (h->name.len == ha->key.len &&
+                !ngx_strncmp(h->name.data, ha->key.data, ha->key.len)) {
                 break;
             }
         }
         if (m == cmcf->amf_arrays.nelts) {
-            ha = ngx_array_push(&cmcf->amf_arrays);
-            ha->key = h->name;
+            ha           = ngx_array_push(&cmcf->amf_arrays);
+            ha->key      = h->name;
             ha->key_hash = ngx_hash_key_lc(ha->key.data, ha->key.len);
-            ha->value = ngx_array_create(cf->pool, 1,
-                    sizeof(ngx_rtmp_handler_pt));
+            ha->value =
+                ngx_array_create(cf->pool, 1, sizeof(ngx_rtmp_handler_pt));
             if (ha->value == NULL) {
                 return NGX_ERROR;
             }
         }
 
-        eh = ngx_array_push((ngx_array_t*)ha->value);
+        eh  = ngx_array_push((ngx_array_t *)ha->value);
         *eh = h->handler;
     }
 
-    calls_hash.hash = &cmcf->amf_hash;
-    calls_hash.key = ngx_hash_key_lc;
-    calls_hash.max_size = 512;
+    calls_hash.hash        = &cmcf->amf_hash;
+    calls_hash.key         = ngx_hash_key_lc;
+    calls_hash.max_size    = 512;
     calls_hash.bucket_size = ngx_cacheline_size;
-    calls_hash.name = "amf_hash";
-    calls_hash.pool = cf->pool;
-    calls_hash.temp_pool = NULL;
+    calls_hash.name        = "amf_hash";
+    calls_hash.pool        = cf->pool;
+    calls_hash.temp_pool   = NULL;
 
-    if (ngx_hash_init(&calls_hash, cmcf->amf_arrays.elts, cmcf->amf_arrays.nelts)
-            != NGX_OK)
-    {
+    if (ngx_hash_init(&calls_hash, cmcf->amf_arrays.elts,
+                      cmcf->amf_arrays.nelts) != NGX_OK) {
         return NGX_ERROR;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_add_ports(ngx_conf_t *cf, ngx_array_t *ports,
-    ngx_rtmp_listen_t *listen)
+static ngx_int_t ngx_rtmp_add_ports(ngx_conf_t *cf, ngx_array_t *ports,
+                                    ngx_rtmp_listen_t *listen)
 {
-    in_port_t              p;
-    ngx_uint_t             i;
-    struct sockaddr       *sa;
-    struct sockaddr_in    *sin;
-    ngx_rtmp_conf_port_t  *port;
-    ngx_rtmp_conf_addr_t  *addr;
+    in_port_t p;
+    ngx_uint_t i;
+    struct sockaddr *sa;
+    struct sockaddr_in *sin;
+    ngx_rtmp_conf_port_t *port;
+    ngx_rtmp_conf_addr_t *addr;
 #if (NGX_HAVE_INET6)
-    struct sockaddr_in6   *sin6;
+    struct sockaddr_in6 *sin6;
 #endif
 
-    sa = (struct sockaddr *) &listen->sockaddr;
+    sa = (struct sockaddr *)&listen->sockaddr;
 
     switch (sa->sa_family) {
-
 #if (NGX_HAVE_INET6)
     case AF_INET6:
-        sin6 = (struct sockaddr_in6 *) sa;
-        p = sin6->sin6_port;
+        sin6 = (struct sockaddr_in6 *)sa;
+        p    = sin6->sin6_port;
         break;
 #endif
 
     default: /* AF_INET */
-        sin = (struct sockaddr_in *) sa;
-        p = sin->sin_port;
+        sin = (struct sockaddr_in *)sa;
+        p   = sin->sin_port;
         break;
     }
 
     port = ports->elts;
     for (i = 0; i < ports->nelts; i++) {
         if (p == port[i].port && sa->sa_family == port[i].family) {
-
             /* a port is already in the port list */
 
             port = &port[i];
@@ -534,12 +485,10 @@ ngx_rtmp_add_ports(ngx_conf_t *cf, ngx_array_t *ports,
     }
 
     port->family = sa->sa_family;
-    port->port = p;
+    port->port   = p;
 
     if (ngx_array_init(&port->addrs, cf->temp_pool, 2,
-                       sizeof(ngx_rtmp_conf_addr_t))
-        != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_conf_addr_t)) != NGX_OK) {
         return NGX_ERROR;
     }
 
@@ -550,17 +499,17 @@ found:
         return NGX_ERROR;
     }
 
-    addr->sockaddr = (struct sockaddr *) &listen->sockaddr;
-    addr->socklen = listen->socklen;
-    addr->ctx = listen->ctx;
-    addr->bind = listen->bind;
-    addr->wildcard = listen->wildcard;
-    addr->so_keepalive = listen->so_keepalive;
+    addr->sockaddr       = (struct sockaddr *)&listen->sockaddr;
+    addr->socklen        = listen->socklen;
+    addr->ctx            = listen->ctx;
+    addr->bind           = listen->bind;
+    addr->wildcard       = listen->wildcard;
+    addr->so_keepalive   = listen->so_keepalive;
     addr->proxy_protocol = listen->proxy_protocol;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
-    addr->tcp_keepidle = listen->tcp_keepidle;
+    addr->tcp_keepidle  = listen->tcp_keepidle;
     addr->tcp_keepintvl = listen->tcp_keepintvl;
-    addr->tcp_keepcnt = listen->tcp_keepcnt;
+    addr->tcp_keepcnt   = listen->tcp_keepcnt;
 #endif
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
     addr->ipv6only = listen->ipv6only;
@@ -569,20 +518,17 @@ found:
     return NGX_OK;
 }
 
-
-static char *
-ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
+static char *ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
 {
-    ngx_uint_t             i, p, last, bind_wildcard;
-    ngx_listening_t       *ls;
-    ngx_rtmp_port_t       *mport;
-    ngx_rtmp_conf_port_t  *port;
-    ngx_rtmp_conf_addr_t  *addr;
+    ngx_uint_t i, p, last, bind_wildcard;
+    ngx_listening_t *ls;
+    ngx_rtmp_port_t *mport;
+    ngx_rtmp_conf_port_t *port;
+    ngx_rtmp_conf_addr_t *addr;
 
     port = ports->elts;
     for (p = 0; p < ports->nelts; p++) {
-
-        ngx_sort(port[p].addrs.elts, (size_t) port[p].addrs.nelts,
+        ngx_sort(port[p].addrs.elts, (size_t)port[p].addrs.nelts,
                  sizeof(ngx_rtmp_conf_addr_t), ngx_rtmp_cmp_conf_addrs);
 
         addr = port[p].addrs.elts;
@@ -595,7 +541,7 @@ ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
 
         if (addr[last - 1].wildcard) {
             addr[last - 1].bind = 1;
-            bind_wildcard = 1;
+            bind_wildcard       = 1;
 
         } else {
             bind_wildcard = 0;
@@ -604,7 +550,6 @@ ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
         i = 0;
 
         while (i < last) {
-
             if (bind_wildcard && !addr[i].bind) {
                 i++;
                 continue;
@@ -616,19 +561,19 @@ ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             }
 
             ls->addr_ntop = 1;
-            ls->handler = ngx_rtmp_init_connection;
+            ls->handler   = ngx_rtmp_init_connection;
             ls->pool_size = 4096;
 
             /* TODO: error_log directive */
-            ls->logp = &cf->cycle->new_log;
-            ls->log.data = &ls->addr_text;
+            ls->logp        = &cf->cycle->new_log;
+            ls->log.data    = &ls->addr_text;
             ls->log.handler = ngx_accept_log_error;
 
             ls->keepalive = addr[i].so_keepalive;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
-            ls->keepidle = addr[i].tcp_keepidle;
+            ls->keepidle  = addr[i].tcp_keepidle;
             ls->keepintvl = addr[i].tcp_keepintvl;
-            ls->keepcnt = addr[i].tcp_keepcnt;
+            ls->keepcnt   = addr[i].tcp_keepcnt;
 #endif
 
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
@@ -647,7 +592,7 @@ ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
 
             } else {
                 mport->naddrs = 1;
-                i = 0;
+                i             = 0;
             }
 
             switch (ls->sockaddr->sa_family) {
@@ -673,20 +618,18 @@ ngx_rtmp_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
-    ngx_rtmp_conf_addr_t *addr)
+static ngx_int_t ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
+                                    ngx_rtmp_conf_addr_t *addr)
 {
-    u_char              *p;
-    size_t               len;
-    ngx_uint_t           i;
-    ngx_rtmp_in_addr_t  *addrs;
-    struct sockaddr_in  *sin;
-    u_char               buf[NGX_SOCKADDR_STRLEN];
+    u_char *p;
+    size_t len;
+    ngx_uint_t i;
+    ngx_rtmp_in_addr_t *addrs;
+    struct sockaddr_in *sin;
+    u_char buf[NGX_SOCKADDR_STRLEN];
 
-    mport->addrs = ngx_pcalloc(cf->pool,
-                               mport->naddrs * sizeof(ngx_rtmp_in_addr_t));
+    mport->addrs =
+        ngx_pcalloc(cf->pool, mport->naddrs * sizeof(ngx_rtmp_in_addr_t));
     if (mport->addrs == NULL) {
         return NGX_ERROR;
     }
@@ -694,8 +637,7 @@ ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
     addrs = mport->addrs;
 
     for (i = 0; i < mport->naddrs; i++) {
-
-        sin = (struct sockaddr_in *) addr[i].sockaddr;
+        sin           = (struct sockaddr_in *)addr[i].sockaddr;
         addrs[i].addr = sin->sin_addr.s_addr;
 
         addrs[i].conf.ctx = addr[i].ctx;
@@ -713,7 +655,7 @@ ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
 
         ngx_memcpy(p, buf, len);
 
-        addrs[i].conf.addr_text.len = len;
+        addrs[i].conf.addr_text.len  = len;
         addrs[i].conf.addr_text.data = p;
         addrs[i].conf.proxy_protocol = addr->proxy_protocol;
     }
@@ -721,22 +663,20 @@ ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
     return NGX_OK;
 }
 
-
 #if (NGX_HAVE_INET6)
 
-static ngx_int_t
-ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
-    ngx_rtmp_conf_addr_t *addr)
+static ngx_int_t ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
+                                     ngx_rtmp_conf_addr_t *addr)
 {
-    u_char               *p;
-    size_t                len;
-    ngx_uint_t            i;
-    ngx_rtmp_in6_addr_t  *addrs6;
-    struct sockaddr_in6  *sin6;
-    u_char                buf[NGX_SOCKADDR_STRLEN];
+    u_char *p;
+    size_t len;
+    ngx_uint_t i;
+    ngx_rtmp_in6_addr_t *addrs6;
+    struct sockaddr_in6 *sin6;
+    u_char buf[NGX_SOCKADDR_STRLEN];
 
-    mport->addrs = ngx_pcalloc(cf->pool,
-                               mport->naddrs * sizeof(ngx_rtmp_in6_addr_t));
+    mport->addrs =
+        ngx_pcalloc(cf->pool, mport->naddrs * sizeof(ngx_rtmp_in6_addr_t));
     if (mport->addrs == NULL) {
         return NGX_ERROR;
     }
@@ -744,8 +684,7 @@ ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
     addrs6 = mport->addrs;
 
     for (i = 0; i < mport->naddrs; i++) {
-
-        sin6 = (struct sockaddr_in6 *) addr[i].sockaddr;
+        sin6            = (struct sockaddr_in6 *)addr[i].sockaddr;
         addrs6[i].addr6 = sin6->sin6_addr;
 
         addrs6[i].conf.ctx = addr[i].ctx;
@@ -763,7 +702,7 @@ ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
 
         ngx_memcpy(p, buf, len);
 
-        addrs6[i].conf.addr_text.len = len;
+        addrs6[i].conf.addr_text.len  = len;
         addrs6[i].conf.addr_text.data = p;
         addrs6[i].conf.proxy_protocol = addr->proxy_protocol;
     }
@@ -773,14 +712,12 @@ ngx_rtmp_add_addrs6(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
 
 #endif
 
-
-static ngx_int_t
-ngx_rtmp_cmp_conf_addrs(const void *one, const void *two)
+static ngx_int_t ngx_rtmp_cmp_conf_addrs(const void *one, const void *two)
 {
-    ngx_rtmp_conf_addr_t  *first, *second;
+    ngx_rtmp_conf_addr_t *first, *second;
 
-    first = (ngx_rtmp_conf_addr_t *) one;
-    second = (ngx_rtmp_conf_addr_t *) two;
+    first  = (ngx_rtmp_conf_addr_t *)one;
+    second = (ngx_rtmp_conf_addr_t *)two;
 
     if (first->wildcard) {
         /* a wildcard must be the last resort, shift it to the end */
@@ -802,21 +739,19 @@ ngx_rtmp_cmp_conf_addrs(const void *one, const void *two)
     return 0;
 }
 
-
-ngx_int_t
-ngx_rtmp_fire_event(ngx_rtmp_session_t *s, ngx_uint_t evt,
-        ngx_rtmp_header_t *h, ngx_chain_t *in)
+ngx_int_t ngx_rtmp_fire_event(ngx_rtmp_session_t *s, ngx_uint_t evt,
+                              ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_core_main_conf_t      *cmcf;
-    ngx_array_t                    *ch;
-    ngx_rtmp_handler_pt            *hh;
-    size_t                          n;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_array_t *ch;
+    ngx_rtmp_handler_pt *hh;
+    size_t n;
 
     cmcf = ngx_rtmp_get_module_main_conf(s, ngx_rtmp_core_module);
 
     ch = &cmcf->events[evt];
     hh = ch->elts;
-    for(n = 0; n < ch->nelts; ++n, ++hh) {
+    for (n = 0; n < ch->nelts; ++n, ++hh) {
         if (*hh && (*hh)(s, h, in) != NGX_OK) {
             return NGX_ERROR;
         }
@@ -824,28 +759,24 @@ ngx_rtmp_fire_event(ngx_rtmp_session_t *s, ngx_uint_t evt,
     return NGX_OK;
 }
 
-
-void *
-ngx_rtmp_rmemcpy(void *dst, const void* src, size_t n)
+void *ngx_rtmp_rmemcpy(void *dst, const void *src, size_t n)
 {
-    u_char     *d, *s;
+    u_char *d, *s;
 
     d = dst;
-    s = (u_char*)src + n - 1;
+    s = (u_char *)src + n - 1;
 
-    while(s >= (u_char*)src) {
+    while (s >= (u_char *)src) {
         *d++ = *s--;
     }
 
     return dst;
 }
 
-
-static ngx_int_t
-ngx_rtmp_init_process(ngx_cycle_t *cycle)
+static ngx_int_t ngx_rtmp_init_process(ngx_cycle_t *cycle)
 {
 #if (nginx_version >= 1007005)
-    ngx_queue_init((ngx_queue_t*) &ngx_rtmp_init_queue);
+    ngx_queue_init((ngx_queue_t *)&ngx_rtmp_init_queue);
 #endif
     return NGX_OK;
 }

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -3,279 +3,259 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_H_INCLUDED_
 #define _NGX_RTMP_H_INCLUDED_
 
-
+#include <nginx.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_event.h>
 #include <ngx_event_connect.h>
-#include <nginx.h>
 
 #include "ngx_rtmp_amf.h"
 #include "ngx_rtmp_bandwidth.h"
 
-
 #if (NGX_WIN32)
-typedef __int8              int8_t;
-typedef unsigned __int8     uint8_t;
+typedef __int8 int8_t;
+typedef unsigned __int8 uint8_t;
 #endif
 
-
 typedef struct {
-    void                  **main_conf;
-    void                  **srv_conf;
-    void                  **app_conf;
+    void **main_conf;
+    void **srv_conf;
+    void **app_conf;
 } ngx_rtmp_conf_ctx_t;
 
-
 typedef struct {
-    u_char                  sockaddr[NGX_SOCKADDRLEN];
-    socklen_t               socklen;
+    u_char sockaddr[NGX_SOCKADDRLEN];
+    socklen_t socklen;
 
     /* server ctx */
-    ngx_rtmp_conf_ctx_t    *ctx;
+    ngx_rtmp_conf_ctx_t *ctx;
 
-    unsigned                bind:1;
-    unsigned                wildcard:1;
+    unsigned bind : 1;
+    unsigned wildcard : 1;
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
-    unsigned                ipv6only:2;
+    unsigned ipv6only : 2;
 #endif
-    unsigned                so_keepalive:2;
-    unsigned                proxy_protocol:1;
+    unsigned so_keepalive : 2;
+    unsigned proxy_protocol : 1;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
-    int                     tcp_keepidle;
-    int                     tcp_keepintvl;
-    int                     tcp_keepcnt;
+    int tcp_keepidle;
+    int tcp_keepintvl;
+    int tcp_keepcnt;
 #endif
 } ngx_rtmp_listen_t;
 
-
 typedef struct {
-    ngx_rtmp_conf_ctx_t    *ctx;
-    ngx_str_t               addr_text;
-    unsigned                proxy_protocol:1;
+    ngx_rtmp_conf_ctx_t *ctx;
+    ngx_str_t addr_text;
+    unsigned proxy_protocol : 1;
 } ngx_rtmp_addr_conf_t;
 
 typedef struct {
-    ngx_rtmp_addr_conf_t    conf;
-    in_addr_t               addr;
+    ngx_rtmp_addr_conf_t conf;
+    in_addr_t addr;
 } ngx_rtmp_in_addr_t;
-
 
 #if (NGX_HAVE_INET6)
 
 typedef struct {
-    ngx_rtmp_addr_conf_t    conf;
-    struct in6_addr         addr6;
+    ngx_rtmp_addr_conf_t conf;
+    struct in6_addr addr6;
 } ngx_rtmp_in6_addr_t;
 
 #endif
 
-
 typedef struct {
-    void                   *addrs;
-    ngx_uint_t              naddrs;
+    void *addrs;
+    ngx_uint_t naddrs;
 } ngx_rtmp_port_t;
 
-
 typedef struct {
-    int                     family;
-    in_port_t               port;
-    ngx_array_t             addrs;       /* array of ngx_rtmp_conf_addr_t */
+    int family;
+    in_port_t port;
+    ngx_array_t addrs; /* array of ngx_rtmp_conf_addr_t */
 } ngx_rtmp_conf_port_t;
 
-
 typedef struct {
-    struct sockaddr        *sockaddr;
-    socklen_t               socklen;
+    struct sockaddr *sockaddr;
+    socklen_t socklen;
 
-    ngx_rtmp_conf_ctx_t    *ctx;
+    ngx_rtmp_conf_ctx_t *ctx;
 
-    unsigned                bind:1;
-    unsigned                wildcard:1;
+    unsigned bind : 1;
+    unsigned wildcard : 1;
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
-    unsigned                ipv6only:2;
+    unsigned ipv6only : 2;
 #endif
-    unsigned                so_keepalive:2;
-    unsigned                proxy_protocol:1;
+    unsigned so_keepalive : 2;
+    unsigned proxy_protocol : 1;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
-    int                     tcp_keepidle;
-    int                     tcp_keepintvl;
-    int                     tcp_keepcnt;
+    int tcp_keepidle;
+    int tcp_keepintvl;
+    int tcp_keepcnt;
 #endif
 } ngx_rtmp_conf_addr_t;
 
+#define NGX_RTMP_VERSION 3
 
-#define NGX_RTMP_VERSION                3
+#define NGX_LOG_DEBUG_RTMP NGX_LOG_DEBUG_CORE
 
-#define NGX_LOG_DEBUG_RTMP              NGX_LOG_DEBUG_CORE
-
-#define NGX_RTMP_DEFAULT_CHUNK_SIZE     128
-
+#define NGX_RTMP_DEFAULT_CHUNK_SIZE 128
 
 /* RTMP message types */
-#define NGX_RTMP_MSG_CHUNK_SIZE         1
-#define NGX_RTMP_MSG_ABORT              2
-#define NGX_RTMP_MSG_ACK                3
-#define NGX_RTMP_MSG_USER               4
-#define NGX_RTMP_MSG_ACK_SIZE           5
-#define NGX_RTMP_MSG_BANDWIDTH          6
-#define NGX_RTMP_MSG_EDGE               7
-#define NGX_RTMP_MSG_AUDIO              8
-#define NGX_RTMP_MSG_VIDEO              9
-#define NGX_RTMP_MSG_AMF3_META          15
-#define NGX_RTMP_MSG_AMF3_SHARED        16
-#define NGX_RTMP_MSG_AMF3_CMD           17
-#define NGX_RTMP_MSG_AMF_META           18
-#define NGX_RTMP_MSG_AMF_SHARED         19
-#define NGX_RTMP_MSG_AMF_CMD            20
-#define NGX_RTMP_MSG_AGGREGATE          22
-#define NGX_RTMP_MSG_MAX                22
+#define NGX_RTMP_MSG_CHUNK_SIZE 1
+#define NGX_RTMP_MSG_ABORT 2
+#define NGX_RTMP_MSG_ACK 3
+#define NGX_RTMP_MSG_USER 4
+#define NGX_RTMP_MSG_ACK_SIZE 5
+#define NGX_RTMP_MSG_BANDWIDTH 6
+#define NGX_RTMP_MSG_EDGE 7
+#define NGX_RTMP_MSG_AUDIO 8
+#define NGX_RTMP_MSG_VIDEO 9
+#define NGX_RTMP_MSG_AMF3_META 15
+#define NGX_RTMP_MSG_AMF3_SHARED 16
+#define NGX_RTMP_MSG_AMF3_CMD 17
+#define NGX_RTMP_MSG_AMF_META 18
+#define NGX_RTMP_MSG_AMF_SHARED 19
+#define NGX_RTMP_MSG_AMF_CMD 20
+#define NGX_RTMP_MSG_AGGREGATE 22
+#define NGX_RTMP_MSG_MAX 22
 
-#define NGX_RTMP_CONNECT                NGX_RTMP_MSG_MAX + 1
-#define NGX_RTMP_DISCONNECT             NGX_RTMP_MSG_MAX + 2
-#define NGX_RTMP_HANDSHAKE_DONE         NGX_RTMP_MSG_MAX + 3
-#define NGX_RTMP_MAX_EVENT              NGX_RTMP_MSG_MAX + 4
-
+#define NGX_RTMP_CONNECT NGX_RTMP_MSG_MAX + 1
+#define NGX_RTMP_DISCONNECT NGX_RTMP_MSG_MAX + 2
+#define NGX_RTMP_HANDSHAKE_DONE NGX_RTMP_MSG_MAX + 3
+#define NGX_RTMP_MAX_EVENT NGX_RTMP_MSG_MAX + 4
 
 /* RMTP control message types */
-#define NGX_RTMP_USER_STREAM_BEGIN      0
-#define NGX_RTMP_USER_STREAM_EOF        1
-#define NGX_RTMP_USER_STREAM_DRY        2
-#define NGX_RTMP_USER_SET_BUFLEN        3
-#define NGX_RTMP_USER_RECORDED          4
-#define NGX_RTMP_USER_PING_REQUEST      6
-#define NGX_RTMP_USER_PING_RESPONSE     7
-#define NGX_RTMP_USER_UNKNOWN           8
-#define NGX_RTMP_USER_BUFFER_END        31
-
+#define NGX_RTMP_USER_STREAM_BEGIN 0
+#define NGX_RTMP_USER_STREAM_EOF 1
+#define NGX_RTMP_USER_STREAM_DRY 2
+#define NGX_RTMP_USER_SET_BUFLEN 3
+#define NGX_RTMP_USER_RECORDED 4
+#define NGX_RTMP_USER_PING_REQUEST 6
+#define NGX_RTMP_USER_PING_RESPONSE 7
+#define NGX_RTMP_USER_UNKNOWN 8
+#define NGX_RTMP_USER_BUFFER_END 31
 
 /* Chunk header:
  *   max 3  basic header
  * + max 11 message header
  * + max 4  extended header (timestamp) */
-#define NGX_RTMP_MAX_CHUNK_HEADER       18
-
+#define NGX_RTMP_MAX_CHUNK_HEADER 18
 
 typedef struct {
-    uint32_t                csid;       /* chunk stream id */
-    uint32_t                timestamp;  /* timestamp (delta) */
-    uint32_t                mlen;       /* message length */
-    uint8_t                 type;       /* message type id */
-    uint32_t                msid;       /* message stream id */
+    uint32_t csid;      /* chunk stream id */
+    uint32_t timestamp; /* timestamp (delta) */
+    uint32_t mlen;      /* message length */
+    uint8_t type;       /* message type id */
+    uint32_t msid;      /* message stream id */
 } ngx_rtmp_header_t;
 
-
 typedef struct {
-    ngx_rtmp_header_t       hdr;
-    uint32_t                dtime;
-    uint32_t                len;        /* current fragment length */
-    uint8_t                 ext;
-    ngx_chain_t            *in;
+    ngx_rtmp_header_t hdr;
+    uint32_t dtime;
+    uint32_t len; /* current fragment length */
+    uint8_t ext;
+    ngx_chain_t *in;
 } ngx_rtmp_stream_t;
-
 
 /* disable zero-sized array warning by msvc */
 
 #if (NGX_WIN32)
 #pragma warning(push)
-#pragma warning(disable:4200)
+#pragma warning(disable : 4200)
 #endif
 
-
 typedef struct {
-    uint32_t                signature;  /* "RTMP" */ /* <-- FIXME wtf */
+    uint32_t signature; /* "RTMP" */ /* <-- FIXME wtf */
 
-    ngx_event_t             close;
+    ngx_event_t close;
 
-    void                  **ctx;
-    void                  **main_conf;
-    void                  **srv_conf;
-    void                  **app_conf;
+    void **ctx;
+    void **main_conf;
+    void **srv_conf;
+    void **app_conf;
 
-    ngx_str_t              *addr_text;
-    int                     connected;
+    ngx_str_t *addr_text;
+    int connected;
 
 #if (nginx_version >= 1007005)
-    ngx_queue_t             posted_dry_events;
+    ngx_queue_t posted_dry_events;
 #else
-    ngx_event_t            *posted_dry_events;
+    ngx_event_t *posted_dry_events;
 #endif
 
     /* client buffer time in msec */
-    uint32_t                buflen;
-    uint32_t                ack_size;
+    uint32_t buflen;
+    uint32_t ack_size;
 
     /* connection parameters */
-    ngx_str_t               app;
-    ngx_str_t               args;
-    ngx_str_t               flashver;
-    ngx_str_t               swf_url;
-    ngx_str_t               tc_url;
-    uint32_t                acodecs;
-    uint32_t                vcodecs;
-    ngx_str_t               page_url;
+    ngx_str_t app;
+    ngx_str_t args;
+    ngx_str_t flashver;
+    ngx_str_t swf_url;
+    ngx_str_t tc_url;
+    uint32_t acodecs;
+    uint32_t vcodecs;
+    ngx_str_t page_url;
 
     /* handshake data */
-    ngx_buf_t              *hs_buf;
-    u_char                 *hs_digest;
-    unsigned                hs_old:1;
-    ngx_uint_t              hs_stage;
+    ngx_buf_t *hs_buf;
+    u_char *hs_digest;
+    unsigned hs_old : 1;
+    ngx_uint_t hs_stage;
 
     /* connection timestamps */
-    ngx_msec_t              epoch;
-    ngx_msec_t              peer_epoch;
-    ngx_msec_t              base_time;
-    uint32_t                current_time;
+    ngx_msec_t epoch;
+    ngx_msec_t peer_epoch;
+    ngx_msec_t base_time;
+    uint32_t current_time;
 
     /* ready for publishing? */
-    unsigned                ready_for_publish:1;
+    unsigned ready_for_publish : 1;
 
     /* ping */
-    ngx_event_t             ping_evt;
-    unsigned                ping_active:1;
-    unsigned                ping_reset:1;
+    ngx_event_t ping_evt;
+    unsigned ping_active : 1;
+    unsigned ping_reset : 1;
 
     /* auto-pushed? */
-    unsigned                auto_pushed:1;
-    unsigned                relay:1;
-    unsigned                static_relay:1;
+    unsigned auto_pushed : 1;
+    unsigned relay : 1;
+    unsigned static_relay : 1;
 
     /* input stream 0 (reserved by RTMP spec)
      * is used as free chain link */
 
-    ngx_rtmp_stream_t      *in_streams;
-    uint32_t                in_csid;
-    ngx_uint_t              in_chunk_size;
-    ngx_pool_t             *in_pool;
-    uint32_t                in_bytes;
-    uint32_t                in_last_ack;
+    ngx_rtmp_stream_t *in_streams;
+    uint32_t in_csid;
+    ngx_uint_t in_chunk_size;
+    ngx_pool_t *in_pool;
+    uint32_t in_bytes;
+    uint32_t in_last_ack;
 
-    ngx_pool_t             *in_old_pool;
-    ngx_int_t               in_chunk_size_changing;
+    ngx_pool_t *in_old_pool;
+    ngx_int_t in_chunk_size_changing;
 
-    ngx_connection_t       *connection;
+    ngx_connection_t *connection;
 
     /* circular buffer of RTMP message pointers */
-    ngx_msec_t              timeout;
-    uint32_t                out_bytes;
-    size_t                  out_pos, out_last;
-    ngx_chain_t            *out_chain;
-    u_char                 *out_bpos;
-    unsigned                out_buffer:1;
-    size_t                  out_queue;
-    size_t                  out_cork;
-    ngx_chain_t            *out[0];
+    ngx_msec_t timeout;
+    uint32_t out_bytes;
+    size_t out_pos, out_last;
+    ngx_chain_t *out_chain;
+    u_char *out_bpos;
+    unsigned out_buffer : 1;
+    size_t out_queue;
+    size_t out_cork;
+    ngx_chain_t *out[0];
 } ngx_rtmp_session_t;
-
 
 #if (NGX_WIN32)
 #pragma warning(pop)
 #endif
-
 
 /* handler result code:
  *  NGX_ERROR - error
@@ -283,127 +263,114 @@ typedef struct {
  *  NGX_DONE  - success, input parsed, reply sent; need no
  *      more calls on this event */
 typedef ngx_int_t (*ngx_rtmp_handler_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
-
+                                         ngx_rtmp_header_t *h, ngx_chain_t *in);
 
 typedef struct {
-    ngx_str_t               name;
-    ngx_rtmp_handler_pt     handler;
+    ngx_str_t name;
+    ngx_rtmp_handler_pt handler;
 } ngx_rtmp_amf_handler_t;
 
-
 typedef struct {
-    ngx_array_t             servers;    /* ngx_rtmp_core_srv_conf_t */
-    ngx_array_t             listen;     /* ngx_rtmp_listen_t */
+    ngx_array_t servers; /* ngx_rtmp_core_srv_conf_t */
+    ngx_array_t listen;  /* ngx_rtmp_listen_t */
 
-    ngx_array_t             events[NGX_RTMP_MAX_EVENT];
+    ngx_array_t events[NGX_RTMP_MAX_EVENT];
 
-    ngx_hash_t              amf_hash;
-    ngx_array_t             amf_arrays;
-    ngx_array_t             amf;
+    ngx_hash_t amf_hash;
+    ngx_array_t amf_arrays;
+    ngx_array_t amf;
 } ngx_rtmp_core_main_conf_t;
 
-
 /* global main conf for stats */
-extern ngx_rtmp_core_main_conf_t   *ngx_rtmp_core_main_conf;
-
+extern ngx_rtmp_core_main_conf_t *ngx_rtmp_core_main_conf;
 
 typedef struct ngx_rtmp_core_srv_conf_s {
-    ngx_array_t             applications; /* ngx_rtmp_core_app_conf_t */
+    ngx_array_t applications; /* ngx_rtmp_core_app_conf_t */
 
-    ngx_msec_t              timeout;
-    ngx_msec_t              ping;
-    ngx_msec_t              ping_timeout;
-    ngx_flag_t              so_keepalive;
-    ngx_int_t               max_streams;
+    ngx_msec_t timeout;
+    ngx_msec_t ping;
+    ngx_msec_t ping_timeout;
+    ngx_flag_t so_keepalive;
+    ngx_int_t max_streams;
 
-    ngx_uint_t              ack_window;
+    ngx_uint_t ack_window;
 
-    ngx_int_t               chunk_size;
-    ngx_pool_t             *pool;
-    ngx_chain_t            *free;
-    ngx_chain_t            *free_hs;
-    size_t                  max_message;
-    ngx_flag_t              play_time_fix;
-    ngx_flag_t              publish_time_fix;
-    ngx_flag_t              busy;
-    size_t                  out_queue;
-    size_t                  out_cork;
-    ngx_msec_t              buflen;
+    ngx_int_t chunk_size;
+    ngx_pool_t *pool;
+    ngx_chain_t *free;
+    ngx_chain_t *free_hs;
+    size_t max_message;
+    ngx_flag_t play_time_fix;
+    ngx_flag_t publish_time_fix;
+    ngx_flag_t busy;
+    size_t out_queue;
+    size_t out_cork;
+    ngx_msec_t buflen;
 
-    ngx_rtmp_conf_ctx_t    *ctx;
+    ngx_rtmp_conf_ctx_t *ctx;
 } ngx_rtmp_core_srv_conf_t;
 
-
 typedef struct {
-    ngx_array_t             applications; /* ngx_rtmp_core_app_conf_t */
-    ngx_str_t               name;
-    void                  **app_conf;
+    ngx_array_t applications; /* ngx_rtmp_core_app_conf_t */
+    ngx_str_t name;
+    void **app_conf;
 } ngx_rtmp_core_app_conf_t;
 
-
 typedef struct {
-    ngx_str_t              *client;
-    ngx_rtmp_session_t     *session;
+    ngx_str_t *client;
+    ngx_rtmp_session_t *session;
 } ngx_rtmp_error_log_ctx_t;
 
-
 typedef struct {
-    ngx_int_t             (*preconfiguration)(ngx_conf_t *cf);
-    ngx_int_t             (*postconfiguration)(ngx_conf_t *cf);
+    ngx_int_t (*preconfiguration)(ngx_conf_t *cf);
+    ngx_int_t (*postconfiguration)(ngx_conf_t *cf);
 
-    void                 *(*create_main_conf)(ngx_conf_t *cf);
-    char                 *(*init_main_conf)(ngx_conf_t *cf, void *conf);
+    void *(*create_main_conf)(ngx_conf_t *cf);
+    char *(*init_main_conf)(ngx_conf_t *cf, void *conf);
 
-    void                 *(*create_srv_conf)(ngx_conf_t *cf);
-    char                 *(*merge_srv_conf)(ngx_conf_t *cf, void *prev,
-                                    void *conf);
+    void *(*create_srv_conf)(ngx_conf_t *cf);
+    char *(*merge_srv_conf)(ngx_conf_t *cf, void *prev, void *conf);
 
-    void                 *(*create_app_conf)(ngx_conf_t *cf);
-    char                 *(*merge_app_conf)(ngx_conf_t *cf, void *prev,
-                                    void *conf);
+    void *(*create_app_conf)(ngx_conf_t *cf);
+    char *(*merge_app_conf)(ngx_conf_t *cf, void *prev, void *conf);
 } ngx_rtmp_module_t;
 
-#define NGX_RTMP_MODULE                 0x504D5452     /* "RTMP" */
+#define NGX_RTMP_MODULE 0x504D5452 /* "RTMP" */
 
-#define NGX_RTMP_MAIN_CONF              0x02000000
-#define NGX_RTMP_SRV_CONF               0x04000000
-#define NGX_RTMP_APP_CONF               0x08000000
-#define NGX_RTMP_REC_CONF               0x10000000
+#define NGX_RTMP_MAIN_CONF 0x02000000
+#define NGX_RTMP_SRV_CONF 0x04000000
+#define NGX_RTMP_APP_CONF 0x08000000
+#define NGX_RTMP_REC_CONF 0x10000000
 
+#define NGX_RTMP_MAIN_CONF_OFFSET offsetof(ngx_rtmp_conf_ctx_t, main_conf)
+#define NGX_RTMP_SRV_CONF_OFFSET offsetof(ngx_rtmp_conf_ctx_t, srv_conf)
+#define NGX_RTMP_APP_CONF_OFFSET offsetof(ngx_rtmp_conf_ctx_t, app_conf)
 
-#define NGX_RTMP_MAIN_CONF_OFFSET  offsetof(ngx_rtmp_conf_ctx_t, main_conf)
-#define NGX_RTMP_SRV_CONF_OFFSET   offsetof(ngx_rtmp_conf_ctx_t, srv_conf)
-#define NGX_RTMP_APP_CONF_OFFSET   offsetof(ngx_rtmp_conf_ctx_t, app_conf)
+#define ngx_rtmp_get_module_ctx(s, module) (s)->ctx[module.ctx_index]
+#define ngx_rtmp_set_ctx(s, c, module) s->ctx[module.ctx_index] = c;
+#define ngx_rtmp_delete_ctx(s, module) s->ctx[module.ctx_index] = NULL;
 
-
-#define ngx_rtmp_get_module_ctx(s, module)     (s)->ctx[module.ctx_index]
-#define ngx_rtmp_set_ctx(s, c, module)         s->ctx[module.ctx_index] = c;
-#define ngx_rtmp_delete_ctx(s, module)         s->ctx[module.ctx_index] = NULL;
-
-
-#define ngx_rtmp_get_module_main_conf(s, module)                             \
+#define ngx_rtmp_get_module_main_conf(s, module)                               \
     (s)->main_conf[module.ctx_index]
-#define ngx_rtmp_get_module_srv_conf(s, module)  (s)->srv_conf[module.ctx_index]
-#define ngx_rtmp_get_module_app_conf(s, module)  ((s)->app_conf ? \
-    (s)->app_conf[module.ctx_index] : NULL)
+#define ngx_rtmp_get_module_srv_conf(s, module) (s)->srv_conf[module.ctx_index]
+#define ngx_rtmp_get_module_app_conf(s, module)                                \
+    ((s)->app_conf ? (s)->app_conf[module.ctx_index] : NULL)
 
-#define ngx_rtmp_conf_get_module_main_conf(cf, module)                       \
-    ((ngx_rtmp_conf_ctx_t *) cf->ctx)->main_conf[module.ctx_index]
-#define ngx_rtmp_conf_get_module_srv_conf(cf, module)                        \
-    ((ngx_rtmp_conf_ctx_t *) cf->ctx)->srv_conf[module.ctx_index]
-#define ngx_rtmp_conf_get_module_app_conf(cf, module)                        \
-    ((ngx_rtmp_conf_ctx_t *) cf->ctx)->app_conf[module.ctx_index]
-
+#define ngx_rtmp_conf_get_module_main_conf(cf, module)                         \
+    ((ngx_rtmp_conf_ctx_t *)cf->ctx)->main_conf[module.ctx_index]
+#define ngx_rtmp_conf_get_module_srv_conf(cf, module)                          \
+    ((ngx_rtmp_conf_ctx_t *)cf->ctx)->srv_conf[module.ctx_index]
+#define ngx_rtmp_conf_get_module_app_conf(cf, module)                          \
+    ((ngx_rtmp_conf_ctx_t *)cf->ctx)->app_conf[module.ctx_index]
 
 #ifdef NGX_DEBUG
-char* ngx_rtmp_message_type(uint8_t type);
-char* ngx_rtmp_user_message_type(uint16_t evt);
+char *ngx_rtmp_message_type(uint8_t type);
+char *ngx_rtmp_user_message_type(uint16_t evt);
 #endif
 
 void ngx_rtmp_init_connection(ngx_connection_t *c);
-ngx_rtmp_session_t * ngx_rtmp_init_session(ngx_connection_t *c,
-     ngx_rtmp_addr_conf_t *addr_conf);
+ngx_rtmp_session_t *ngx_rtmp_init_session(ngx_connection_t *c,
+                                          ngx_rtmp_addr_conf_t *addr_conf);
 void ngx_rtmp_finalize_session(ngx_rtmp_session_t *s);
 void ngx_rtmp_handshake(ngx_rtmp_session_t *s);
 void ngx_rtmp_client_handshake(ngx_rtmp_session_t *s, unsigned async);
@@ -411,221 +378,185 @@ void ngx_rtmp_free_handshake_buffers(ngx_rtmp_session_t *s);
 void ngx_rtmp_cycle(ngx_rtmp_session_t *s);
 void ngx_rtmp_reset_ping(ngx_rtmp_session_t *s);
 ngx_int_t ngx_rtmp_fire_event(ngx_rtmp_session_t *s, ngx_uint_t evt,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
-
+                              ngx_rtmp_header_t *h, ngx_chain_t *in);
 
 ngx_int_t ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size);
 
-
 /* Bit reverse: we need big-endians in many places  */
-void * ngx_rtmp_rmemcpy(void *dst, const void* src, size_t n);
+void *ngx_rtmp_rmemcpy(void *dst, const void *src, size_t n);
 
-#define ngx_rtmp_rcpymem(dst, src, n) \
-    (((u_char*)ngx_rtmp_rmemcpy(dst, src, n)) + (n))
+#define ngx_rtmp_rcpymem(dst, src, n)                                          \
+    (((u_char *)ngx_rtmp_rmemcpy(dst, src, n)) + (n))
 
-
-static ngx_inline uint16_t
-ngx_rtmp_r16(uint16_t n)
+static ngx_inline uint16_t ngx_rtmp_r16(uint16_t n)
 {
     return (n << 8) | (n >> 8);
 }
 
-
-static ngx_inline uint32_t
-ngx_rtmp_r32(uint32_t n)
+static ngx_inline uint32_t ngx_rtmp_r32(uint32_t n)
 {
     return (n << 24) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | (n >> 24);
 }
 
-
-static ngx_inline uint64_t
-ngx_rtmp_r64(uint64_t n)
+static ngx_inline uint64_t ngx_rtmp_r64(uint64_t n)
 {
-    return (uint64_t) ngx_rtmp_r32((uint32_t) n) << 32 |
-                      ngx_rtmp_r32((uint32_t) (n >> 32));
+    return (uint64_t)ngx_rtmp_r32((uint32_t)n) << 32 |
+           ngx_rtmp_r32((uint32_t)(n >> 32));
 }
 
-
 /* Receiving messages */
-ngx_int_t ngx_rtmp_receive_message(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
+ngx_int_t ngx_rtmp_receive_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                                   ngx_chain_t *in);
 ngx_int_t ngx_rtmp_protocol_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
+                                            ngx_rtmp_header_t *h,
+                                            ngx_chain_t *in);
 ngx_int_t ngx_rtmp_user_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
+                                        ngx_rtmp_header_t *h, ngx_chain_t *in);
 ngx_int_t ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
+                                             ngx_rtmp_header_t *h,
+                                             ngx_chain_t *in);
 ngx_int_t ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
+                                       ngx_rtmp_header_t *h, ngx_chain_t *in);
 ngx_int_t ngx_rtmp_amf_shared_object_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in);
-
+                                             ngx_rtmp_header_t *h,
+                                             ngx_chain_t *in);
 
 /* Shared output buffers */
 
 /* Store refcount in negative bytes of shared buffer */
 
-#define NGX_RTMP_REFCOUNT_TYPE              uint32_t
-#define NGX_RTMP_REFCOUNT_BYTES             sizeof(NGX_RTMP_REFCOUNT_TYPE)
+#define NGX_RTMP_REFCOUNT_TYPE uint32_t
+#define NGX_RTMP_REFCOUNT_BYTES sizeof(NGX_RTMP_REFCOUNT_TYPE)
 
-#define ngx_rtmp_ref(b)                     \
-    *((NGX_RTMP_REFCOUNT_TYPE*)(b) - 1)
+#define ngx_rtmp_ref(b) *((NGX_RTMP_REFCOUNT_TYPE *)(b)-1)
 
-#define ngx_rtmp_ref_set(b, v)              \
-    ngx_rtmp_ref(b) = v
+#define ngx_rtmp_ref_set(b, v) ngx_rtmp_ref(b) = v
 
-#define ngx_rtmp_ref_get(b)                 \
-    ++ngx_rtmp_ref(b)
+#define ngx_rtmp_ref_get(b) ++ngx_rtmp_ref(b)
 
-#define ngx_rtmp_ref_put(b)                 \
-    --ngx_rtmp_ref(b)
+#define ngx_rtmp_ref_put(b) --ngx_rtmp_ref(b)
 
-ngx_chain_t * ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf);
+ngx_chain_t *ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf);
 void ngx_rtmp_free_shared_chain(ngx_rtmp_core_srv_conf_t *cscf,
-        ngx_chain_t *in);
-ngx_chain_t * ngx_rtmp_append_shared_bufs(ngx_rtmp_core_srv_conf_t *cscf,
-        ngx_chain_t *head, ngx_chain_t *in);
+                                ngx_chain_t *in);
+ngx_chain_t *ngx_rtmp_append_shared_bufs(ngx_rtmp_core_srv_conf_t *cscf,
+                                         ngx_chain_t *head, ngx_chain_t *in);
 
-#define ngx_rtmp_acquire_shared_chain(in)   \
-    ngx_rtmp_ref_get(in);                   \
-
+#define ngx_rtmp_acquire_shared_chain(in) ngx_rtmp_ref_get(in);
 
 /* Sending messages */
 void ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_rtmp_header_t *lh, ngx_chain_t *out);
+                              ngx_rtmp_header_t *lh, ngx_chain_t *out);
 ngx_int_t ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
-        ngx_uint_t priority);
+                                ngx_uint_t priority);
 
 /* Note on priorities:
  * the bigger value the lower the priority.
  * priority=0 is the highest */
 
-
-#define NGX_RTMP_LIMIT_SOFT         0
-#define NGX_RTMP_LIMIT_HARD         1
-#define NGX_RTMP_LIMIT_DYNAMIC      2
+#define NGX_RTMP_LIMIT_SOFT 0
+#define NGX_RTMP_LIMIT_HARD 1
+#define NGX_RTMP_LIMIT_DYNAMIC 2
 
 /* Protocol control messages */
-ngx_chain_t * ngx_rtmp_create_chunk_size(ngx_rtmp_session_t *s,
-        uint32_t chunk_size);
-ngx_chain_t * ngx_rtmp_create_abort(ngx_rtmp_session_t *s,
-        uint32_t csid);
-ngx_chain_t * ngx_rtmp_create_ack(ngx_rtmp_session_t *s,
-        uint32_t seq);
-ngx_chain_t * ngx_rtmp_create_ack_size(ngx_rtmp_session_t *s,
-        uint32_t ack_size);
-ngx_chain_t * ngx_rtmp_create_bandwidth(ngx_rtmp_session_t *s,
-        uint32_t ack_size, uint8_t limit_type);
+ngx_chain_t *ngx_rtmp_create_chunk_size(ngx_rtmp_session_t *s,
+                                        uint32_t chunk_size);
+ngx_chain_t *ngx_rtmp_create_abort(ngx_rtmp_session_t *s, uint32_t csid);
+ngx_chain_t *ngx_rtmp_create_ack(ngx_rtmp_session_t *s, uint32_t seq);
+ngx_chain_t *ngx_rtmp_create_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size);
+ngx_chain_t *ngx_rtmp_create_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
+                                       uint8_t limit_type);
 
-ngx_int_t ngx_rtmp_send_chunk_size(ngx_rtmp_session_t *s,
-        uint32_t chunk_size);
-ngx_int_t ngx_rtmp_send_abort(ngx_rtmp_session_t *s,
-        uint32_t csid);
-ngx_int_t ngx_rtmp_send_ack(ngx_rtmp_session_t *s,
-        uint32_t seq);
-ngx_int_t ngx_rtmp_send_ack_size(ngx_rtmp_session_t *s,
-        uint32_t ack_size);
-ngx_int_t ngx_rtmp_send_bandwidth(ngx_rtmp_session_t *s,
-        uint32_t ack_size, uint8_t limit_type);
+ngx_int_t ngx_rtmp_send_chunk_size(ngx_rtmp_session_t *s, uint32_t chunk_size);
+ngx_int_t ngx_rtmp_send_abort(ngx_rtmp_session_t *s, uint32_t csid);
+ngx_int_t ngx_rtmp_send_ack(ngx_rtmp_session_t *s, uint32_t seq);
+ngx_int_t ngx_rtmp_send_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size);
+ngx_int_t ngx_rtmp_send_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
+                                  uint8_t limit_type);
 
 /* User control messages */
-ngx_chain_t * ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_chain_t * ngx_rtmp_create_stream_eof(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_chain_t * ngx_rtmp_create_stream_dry(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_chain_t * ngx_rtmp_create_set_buflen(ngx_rtmp_session_t *s,
-        uint32_t msid, uint32_t buflen_msec);
-ngx_chain_t * ngx_rtmp_create_recorded(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_chain_t * ngx_rtmp_create_ping_request(ngx_rtmp_session_t *s,
-        uint32_t timestamp);
-ngx_chain_t * ngx_rtmp_create_ping_response(ngx_rtmp_session_t *s,
-        uint32_t timestamp);
+ngx_chain_t *ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_chain_t *ngx_rtmp_create_stream_eof(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_chain_t *ngx_rtmp_create_stream_dry(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_chain_t *ngx_rtmp_create_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
+                                        uint32_t buflen_msec);
+ngx_chain_t *ngx_rtmp_create_recorded(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_chain_t *ngx_rtmp_create_ping_request(ngx_rtmp_session_t *s,
+                                          uint32_t timestamp);
+ngx_chain_t *ngx_rtmp_create_ping_response(ngx_rtmp_session_t *s,
+                                           uint32_t timestamp);
 
-ngx_int_t ngx_rtmp_send_stream_begin(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_int_t ngx_rtmp_send_stream_eof(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_int_t ngx_rtmp_send_stream_dry(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_int_t ngx_rtmp_send_set_buflen(ngx_rtmp_session_t *s,
-        uint32_t msid, uint32_t buflen_msec);
-ngx_int_t ngx_rtmp_send_recorded(ngx_rtmp_session_t *s,
-        uint32_t msid);
-ngx_int_t ngx_rtmp_send_ping_request(ngx_rtmp_session_t *s,
-        uint32_t timestamp);
+ngx_int_t ngx_rtmp_send_stream_begin(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_int_t ngx_rtmp_send_stream_eof(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_int_t ngx_rtmp_send_stream_dry(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_int_t ngx_rtmp_send_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
+                                   uint32_t buflen_msec);
+ngx_int_t ngx_rtmp_send_recorded(ngx_rtmp_session_t *s, uint32_t msid);
+ngx_int_t ngx_rtmp_send_ping_request(ngx_rtmp_session_t *s, uint32_t timestamp);
 ngx_int_t ngx_rtmp_send_ping_response(ngx_rtmp_session_t *s,
-        uint32_t timestamp);
+                                      uint32_t timestamp);
 
 /* AMF sender/receiver */
-ngx_int_t ngx_rtmp_append_amf(ngx_rtmp_session_t *s,
-        ngx_chain_t **first, ngx_chain_t **last,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
+ngx_int_t ngx_rtmp_append_amf(ngx_rtmp_session_t *s, ngx_chain_t **first,
+                              ngx_chain_t **last, ngx_rtmp_amf_elt_t *elts,
+                              size_t nelts);
 ngx_int_t ngx_rtmp_receive_amf(ngx_rtmp_session_t *s, ngx_chain_t *in,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
+                               ngx_rtmp_amf_elt_t *elts, size_t nelts);
 
-ngx_chain_t * ngx_rtmp_create_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
+ngx_chain_t *ngx_rtmp_create_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                                 ngx_rtmp_amf_elt_t *elts, size_t nelts);
 ngx_int_t ngx_rtmp_send_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
+                            ngx_rtmp_amf_elt_t *elts, size_t nelts);
 
 /* AMF status sender */
-ngx_chain_t * ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code,
-        char* level, char *desc);
-ngx_chain_t * ngx_rtmp_create_play_status(ngx_rtmp_session_t *s, char *code,
-        char* level, ngx_uint_t duration, ngx_uint_t bytes);
-ngx_chain_t * ngx_rtmp_create_sample_access(ngx_rtmp_session_t *s);
+ngx_chain_t *ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code,
+                                    char *level, char *desc);
+ngx_chain_t *ngx_rtmp_create_play_status(ngx_rtmp_session_t *s, char *code,
+                                         char *level, ngx_uint_t duration,
+                                         ngx_uint_t bytes);
+ngx_chain_t *ngx_rtmp_create_sample_access(ngx_rtmp_session_t *s);
 
-ngx_int_t ngx_rtmp_send_status(ngx_rtmp_session_t *s, char *code,
-        char* level, char *desc);
+ngx_int_t ngx_rtmp_send_status(ngx_rtmp_session_t *s, char *code, char *level,
+                               char *desc);
 ngx_int_t ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code,
-        char* level, ngx_uint_t duration, ngx_uint_t bytes);
+                                    char *level, ngx_uint_t duration,
+                                    ngx_uint_t bytes);
 ngx_int_t ngx_rtmp_send_sample_access(ngx_rtmp_session_t *s);
-ngx_int_t ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s,
-        char *callMethod, char *desc, ngx_str_t to_url);
+ngx_int_t ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s, char *callMethod,
+                                        char *desc, ngx_str_t to_url);
 ngx_int_t ngx_rtmp_send_close_method(ngx_rtmp_session_t *s, char *methodName);
 ngx_int_t ngx_rtmp_send_fcpublish(ngx_rtmp_session_t *s, u_char *desc);
 ngx_int_t ngx_rtmp_send_fcunpublish(ngx_rtmp_session_t *s, u_char *desc);
 ngx_int_t ngx_rtmp_send_fi(ngx_rtmp_session_t *s);
 
-
 /* Frame types */
-#define NGX_RTMP_VIDEO_KEY_FRAME            1
-#define NGX_RTMP_VIDEO_INTER_FRAME          2
-#define NGX_RTMP_VIDEO_DISPOSABLE_FRAME     3
+#define NGX_RTMP_VIDEO_KEY_FRAME 1
+#define NGX_RTMP_VIDEO_INTER_FRAME 2
+#define NGX_RTMP_VIDEO_DISPOSABLE_FRAME 3
 
-
-static ngx_inline ngx_int_t
-ngx_rtmp_get_video_frame_type(ngx_chain_t *in)
+static ngx_inline ngx_int_t ngx_rtmp_get_video_frame_type(ngx_chain_t *in)
 {
     return (in->buf->pos[0] & 0xf0) >> 4;
 }
 
-
-static ngx_inline ngx_int_t
-ngx_rtmp_is_codec_header(ngx_chain_t *in)
+static ngx_inline ngx_int_t ngx_rtmp_is_codec_header(ngx_chain_t *in)
 {
     return in->buf->pos + 1 < in->buf->last && in->buf->pos[1] == 0;
 }
 
+extern ngx_rtmp_bandwidth_t ngx_rtmp_bw_out;
+extern ngx_rtmp_bandwidth_t ngx_rtmp_bw_in;
 
-extern ngx_rtmp_bandwidth_t                 ngx_rtmp_bw_out;
-extern ngx_rtmp_bandwidth_t                 ngx_rtmp_bw_in;
-
-
-extern ngx_uint_t                           ngx_rtmp_naccepted;
+extern ngx_uint_t ngx_rtmp_naccepted;
 #if (nginx_version >= 1007011)
-extern ngx_queue_t                          ngx_rtmp_init_queue;
+extern ngx_queue_t ngx_rtmp_init_queue;
 #elif (nginx_version >= 1007005)
-extern ngx_thread_volatile ngx_queue_t      ngx_rtmp_init_queue;
+extern ngx_thread_volatile ngx_queue_t ngx_rtmp_init_queue;
 #else
-extern ngx_thread_volatile ngx_event_t     *ngx_rtmp_init_queue;
+extern ngx_thread_volatile ngx_event_t *ngx_rtmp_init_queue;
 #endif
 
-extern ngx_uint_t                           ngx_rtmp_max_module;
-extern ngx_module_t                         ngx_rtmp_core_module;
-
+extern ngx_uint_t ngx_rtmp_max_module;
+extern ngx_module_t ngx_rtmp_core_module;
 
 #endif /* _NGX_RTMP_H_INCLUDED_ */

--- a/ngx_rtmp_access_module.c
+++ b/ngx_rtmp_access_module.c
@@ -3,109 +3,89 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_cmd_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_play_pt next_play;
 
-static ngx_rtmp_publish_pt          next_publish;
-static ngx_rtmp_play_pt             next_play;
+#define NGX_RTMP_ACCESS_PUBLISH 0x01
+#define NGX_RTMP_ACCESS_PLAY 0x02
 
-
-#define NGX_RTMP_ACCESS_PUBLISH     0x01
-#define NGX_RTMP_ACCESS_PLAY        0x02
-
-
-static char * ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+static char *ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd,
+                                  void *conf);
 static ngx_int_t ngx_rtmp_access_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_access_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_access_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
-
+static void *ngx_rtmp_access_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_access_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                            void *child);
 
 typedef struct {
-    in_addr_t               mask;
-    in_addr_t               addr;
-    ngx_uint_t              deny;
-    ngx_uint_t              flags;
+    in_addr_t mask;
+    in_addr_t addr;
+    ngx_uint_t deny;
+    ngx_uint_t flags;
 } ngx_rtmp_access_rule_t;
-
 
 #if (NGX_HAVE_INET6)
 
 typedef struct {
-    struct in6_addr         addr;
-    struct in6_addr         mask;
-    ngx_uint_t              deny;
-    ngx_uint_t              flags;
+    struct in6_addr addr;
+    struct in6_addr mask;
+    ngx_uint_t deny;
+    ngx_uint_t flags;
 } ngx_rtmp_access_rule6_t;
 
 #endif
 
-
 typedef struct {
-    ngx_array_t             rules;     /* array of ngx_rtmp_access_rule_t */
+    ngx_array_t rules; /* array of ngx_rtmp_access_rule_t */
 #if (NGX_HAVE_INET6)
-    ngx_array_t             rules6;    /* array of ngx_rtmp_access_rule6_t */
+    ngx_array_t rules6; /* array of ngx_rtmp_access_rule6_t */
 #endif
 } ngx_rtmp_access_app_conf_t;
 
+static ngx_command_t ngx_rtmp_access_commands[] = {
 
-static ngx_command_t  ngx_rtmp_access_commands[] = {
+    {ngx_string("allow"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                              NGX_RTMP_APP_CONF | NGX_CONF_TAKE12,
+     ngx_rtmp_access_rule, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("allow"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE12,
-      ngx_rtmp_access_rule,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("deny"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                             NGX_RTMP_APP_CONF | NGX_CONF_TAKE12,
+     ngx_rtmp_access_rule, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("deny"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE12,
-      ngx_rtmp_access_rule,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_access_module_ctx = {
+    NULL,                              /* preconfiguration */
+    ngx_rtmp_access_postconfiguration, /* postconfiguration */
+    NULL,                              /* create main configuration */
+    NULL,                              /* init main configuration */
+    NULL,                              /* create server configuration */
+    NULL,                              /* merge server configuration */
+    ngx_rtmp_access_create_app_conf,   /* create app configuration */
+    ngx_rtmp_access_merge_app_conf,    /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_access_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_access_postconfiguration,      /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    ngx_rtmp_access_create_app_conf,        /* create app configuration */
-    ngx_rtmp_access_merge_app_conf,         /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_access_module = {
+ngx_module_t ngx_rtmp_access_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_access_module_ctx,            /* module context */
-    ngx_rtmp_access_commands,               /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_access_module_ctx, /* module context */
+    ngx_rtmp_access_commands,    /* module directives */
+    NGX_RTMP_MODULE,             /* module type */
+    NULL,                        /* init master */
+    NULL,                        /* init module */
+    NULL,                        /* init process */
+    NULL,                        /* init thread */
+    NULL,                        /* exit thread */
+    NULL,                        /* exit process */
+    NULL,                        /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void *
-ngx_rtmp_access_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_access_create_app_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_access_app_conf_t      *aacf;
+    ngx_rtmp_access_app_conf_t *aacf;
 
     aacf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_access_app_conf_t));
     if (aacf == NULL) {
@@ -113,17 +93,13 @@ ngx_rtmp_access_create_app_conf(ngx_conf_t *cf)
     }
 
     if (ngx_array_init(&aacf->rules, cf->pool, 1,
-                       sizeof(ngx_rtmp_access_rule_t))
-        != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_access_rule_t)) != NGX_OK) {
         return NULL;
     }
 
 #if (NGX_HAVE_INET6)
     if (ngx_array_init(&aacf->rules6, cf->pool, 1,
-                       sizeof(ngx_rtmp_access_rule6_t))
-        != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_access_rule6_t)) != NGX_OK) {
         return NULL;
     }
 #endif
@@ -131,11 +107,10 @@ ngx_rtmp_access_create_app_conf(ngx_conf_t *cf)
     return aacf;
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_merge_rules(ngx_array_t *prev, ngx_array_t *rules)
+static ngx_int_t ngx_rtmp_access_merge_rules(ngx_array_t *prev,
+                                             ngx_array_t *rules)
 {
-    void   *p;
+    void *p;
 
     if (prev->nelts == 0) {
         return NGX_OK;
@@ -156,9 +131,8 @@ ngx_rtmp_access_merge_rules(ngx_array_t *prev, ngx_array_t *rules)
     return NGX_OK;
 }
 
-
-static char *
-ngx_rtmp_access_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_access_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                            void *child)
 {
     ngx_rtmp_access_app_conf_t *prev = parent;
     ngx_rtmp_access_app_conf_t *conf = child;
@@ -176,9 +150,7 @@ ngx_rtmp_access_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_found(ngx_rtmp_session_t *s, ngx_uint_t deny)
+static ngx_int_t ngx_rtmp_access_found(ngx_rtmp_session_t *s, ngx_uint_t deny)
 {
     if (deny) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
@@ -189,22 +161,20 @@ ngx_rtmp_access_found(ngx_rtmp_session_t *s, ngx_uint_t deny)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_inet(ngx_rtmp_session_t *s, in_addr_t addr, ngx_uint_t flag)
+static ngx_int_t ngx_rtmp_access_inet(ngx_rtmp_session_t *s, in_addr_t addr,
+                                      ngx_uint_t flag)
 {
-    ngx_uint_t                  i;
-    ngx_rtmp_access_rule_t     *rule;
+    ngx_uint_t i;
+    ngx_rtmp_access_rule_t *rule;
     ngx_rtmp_access_app_conf_t *ascf;
 
     ascf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_access_module);
 
     rule = ascf->rules.elts;
     for (i = 0; i < ascf->rules.nelts; i++) {
-
         ngx_log_debug3(NGX_LOG_DEBUG_HTTP, s->connection->log, 0,
-                       "access: %08XD %08XD %08XD",
-                       addr, rule[i].mask, rule[i].addr);
+                       "access: %08XD %08XD %08XD", addr, rule[i].mask,
+                       rule[i].addr);
 
         if ((addr & rule[i].mask) == rule[i].addr && (flag & rule[i].flags)) {
             return ngx_rtmp_access_found(s, rule[i].deny);
@@ -214,35 +184,35 @@ ngx_rtmp_access_inet(ngx_rtmp_session_t *s, in_addr_t addr, ngx_uint_t flag)
     return NGX_OK;
 }
 
-
 #if (NGX_HAVE_INET6)
 
-static ngx_int_t
-ngx_rtmp_access_inet6(ngx_rtmp_session_t *s, u_char *p, ngx_uint_t flag)
+static ngx_int_t ngx_rtmp_access_inet6(ngx_rtmp_session_t *s, u_char *p,
+                                       ngx_uint_t flag)
 {
-    ngx_uint_t                  n;
-    ngx_uint_t                  i;
-    ngx_rtmp_access_rule6_t    *rule6;
+    ngx_uint_t n;
+    ngx_uint_t i;
+    ngx_rtmp_access_rule6_t *rule6;
     ngx_rtmp_access_app_conf_t *ascf;
 
     ascf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_access_module);
 
     rule6 = ascf->rules6.elts;
     for (i = 0; i < ascf->rules6.nelts; i++) {
-
 #if (NGX_DEBUG)
         {
-        size_t  cl, ml, al;
-        u_char  ct[NGX_INET6_ADDRSTRLEN];
-        u_char  mt[NGX_INET6_ADDRSTRLEN];
-        u_char  at[NGX_INET6_ADDRSTRLEN];
+            size_t cl, ml, al;
+            u_char ct[NGX_INET6_ADDRSTRLEN];
+            u_char mt[NGX_INET6_ADDRSTRLEN];
+            u_char at[NGX_INET6_ADDRSTRLEN];
 
-        cl = ngx_inet6_ntop(p, ct, NGX_INET6_ADDRSTRLEN);
-        ml = ngx_inet6_ntop(rule6[i].mask.s6_addr, mt, NGX_INET6_ADDRSTRLEN);
-        al = ngx_inet6_ntop(rule6[i].addr.s6_addr, at, NGX_INET6_ADDRSTRLEN);
+            cl = ngx_inet6_ntop(p, ct, NGX_INET6_ADDRSTRLEN);
+            ml =
+                ngx_inet6_ntop(rule6[i].mask.s6_addr, mt, NGX_INET6_ADDRSTRLEN);
+            al =
+                ngx_inet6_ntop(rule6[i].addr.s6_addr, at, NGX_INET6_ADDRSTRLEN);
 
-        ngx_log_debug6(NGX_LOG_DEBUG_HTTP, s->connection->log, 0,
-                       "access: %*s %*s %*s", cl, ct, ml, mt, al, at);
+            ngx_log_debug6(NGX_LOG_DEBUG_HTTP, s->connection->log, 0,
+                           "access: %*s %*s %*s", cl, ct, ml, mt, al, at);
         }
 #endif
 
@@ -265,16 +235,14 @@ ngx_rtmp_access_inet6(ngx_rtmp_session_t *s, u_char *p, ngx_uint_t flag)
 
 #endif
 
-
-static ngx_int_t
-ngx_rtmp_access(ngx_rtmp_session_t *s, ngx_uint_t flag)
+static ngx_int_t ngx_rtmp_access(ngx_rtmp_session_t *s, ngx_uint_t flag)
 {
-    struct sockaddr_in             *sin;
-    ngx_rtmp_access_app_conf_t     *ascf;
+    struct sockaddr_in *sin;
+    ngx_rtmp_access_app_conf_t *ascf;
 #if (NGX_HAVE_INET6)
-    u_char                         *p;
-    in_addr_t                       addr;
-    struct sockaddr_in6            *sin6;
+    u_char *p;
+    in_addr_t addr;
+    struct sockaddr_in6 *sin6;
 #endif
 
     ascf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_access_module);
@@ -290,19 +258,18 @@ ngx_rtmp_access(ngx_rtmp_session_t *s, ngx_uint_t flag)
     }
 
     switch (s->connection->sockaddr->sa_family) {
-
     case AF_INET:
-        sin = (struct sockaddr_in *) s->connection->sockaddr;
+        sin = (struct sockaddr_in *)s->connection->sockaddr;
         return ngx_rtmp_access_inet(s, sin->sin_addr.s_addr, flag);
 
 #if (NGX_HAVE_INET6)
 
     case AF_INET6:
-        sin6 = (struct sockaddr_in6 *) s->connection->sockaddr;
-        p = sin6->sin6_addr.s6_addr;
+        sin6 = (struct sockaddr_in6 *)s->connection->sockaddr;
+        p    = sin6->sin6_addr.s6_addr;
 
         if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
-            addr  = p[12] << 24;
+            addr = p[12] << 24;
             addr += p[13] << 16;
             addr += p[14] << 8;
             addr += p[15];
@@ -317,52 +284,44 @@ ngx_rtmp_access(ngx_rtmp_session_t *s, ngx_uint_t flag)
     return NGX_OK;
 }
 
-
-static char *
-ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd,
+                                  void *conf)
 {
-    ngx_rtmp_access_app_conf_t         *ascf = conf;
+    ngx_rtmp_access_app_conf_t *ascf = conf;
 
-    ngx_int_t                           rc;
-    ngx_uint_t                          all;
-    ngx_str_t                          *value;
-    ngx_cidr_t                          cidr;
-    ngx_rtmp_access_rule_t             *rule;
+    ngx_int_t rc;
+    ngx_uint_t all;
+    ngx_str_t *value;
+    ngx_cidr_t cidr;
+    ngx_rtmp_access_rule_t *rule;
 #if (NGX_HAVE_INET6)
-    ngx_rtmp_access_rule6_t            *rule6;
+    ngx_rtmp_access_rule6_t *rule6;
 #endif
-    size_t                              n;
-    ngx_uint_t                          flags;
+    size_t n;
+    ngx_uint_t flags;
 
     ngx_memzero(&cidr, sizeof(ngx_cidr_t));
 
     value = cf->args->elts;
 
-    n = 1;
+    n     = 1;
     flags = 0;
 
     if (cf->args->nelts == 2) {
-
         flags = NGX_RTMP_ACCESS_PUBLISH | NGX_RTMP_ACCESS_PLAY;
 
     } else {
-
-        for(; n < cf->args->nelts - 1; ++n) {
-
+        for (; n < cf->args->nelts - 1; ++n) {
             if (value[n].len == sizeof("publish") - 1 &&
-                ngx_strcmp(value[1].data, "publish") == 0)
-            {
+                ngx_strcmp(value[1].data, "publish") == 0) {
                 flags |= NGX_RTMP_ACCESS_PUBLISH;
                 continue;
-
             }
 
             if (value[n].len == sizeof("play") - 1 &&
-                ngx_strcmp(value[1].data, "play") == 0)
-            {
+                ngx_strcmp(value[1].data, "play") == 0) {
                 flags |= NGX_RTMP_ACCESS_PLAY;
                 continue;
-
             }
 
             ngx_log_error(NGX_LOG_ERR, cf->log, 0,
@@ -374,12 +333,11 @@ ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     all = (value[n].len == 3 && ngx_strcmp(value[n].data, "all") == 0);
 
     if (!all) {
-
         rc = ngx_ptocidr(&value[n], &cidr);
 
         if (rc == NGX_ERROR) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                               "invalid parameter \"%V\"", &value[1]);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "invalid parameter \"%V\"",
+                               &value[1]);
             return NGX_CONF_ERROR;
         }
 
@@ -391,7 +349,6 @@ ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     switch (cidr.family) {
-
 #if (NGX_HAVE_INET6)
     case AF_INET6:
     case 0: /* all */
@@ -401,16 +358,16 @@ ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return NGX_CONF_ERROR;
         }
 
-        rule6->mask = cidr.u.in6.mask;
-        rule6->addr = cidr.u.in6.addr;
-        rule6->deny = (value[0].data[0] == 'd') ? 1 : 0;
+        rule6->mask  = cidr.u.in6.mask;
+        rule6->addr  = cidr.u.in6.addr;
+        rule6->deny  = (value[0].data[0] == 'd') ? 1 : 0;
         rule6->flags = flags;
 
         if (!all) {
             break;
         }
 
-        /* "all" passes through */
+/* "all" passes through */
 #endif
 
     default: /* AF_INET */
@@ -420,18 +377,17 @@ ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return NGX_CONF_ERROR;
         }
 
-        rule->mask = cidr.u.in.mask;
-        rule->addr = cidr.u.in.addr;
-        rule->deny = (value[0].data[0] == 'd') ? 1 : 0;
+        rule->mask  = cidr.u.in.mask;
+        rule->addr  = cidr.u.in.addr;
+        rule->deny  = (value[0].data[0] == 'd') ? 1 : 0;
         rule->flags = flags;
     }
 
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_access_publish(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_publish_t *v)
 {
     if (s->auto_pushed) {
         goto next;
@@ -445,9 +401,7 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
+static ngx_int_t ngx_rtmp_access_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
                   "access: ngx_rtmp_access_play");
@@ -463,15 +417,13 @@ ngx_rtmp_access_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
     return next_play(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_access_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_access_postconfiguration(ngx_conf_t *cf)
 {
     /* chain handlers */
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_access_publish;
 
-    next_play = ngx_rtmp_play;
+    next_play     = ngx_rtmp_play;
     ngx_rtmp_play = ngx_rtmp_access_play;
 
     return NGX_OK;

--- a/ngx_rtmp_amf.c
+++ b/ngx_rtmp_amf.c
@@ -3,25 +3,23 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp_amf.h"
 #include "ngx_rtmp.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <string.h>
 
-
-static ngx_inline void*
-ngx_rtmp_amf_reverse_copy(void *dst, void* src, size_t len)
+static ngx_inline void *ngx_rtmp_amf_reverse_copy(void *dst, void *src,
+                                                  size_t len)
 {
-    size_t  k;
+    size_t k;
 
     if (dst == NULL || src == NULL) {
         return NULL;
     }
 
-    for(k = 0; k < len; ++k) {
-        ((u_char*)dst)[k] = ((u_char*)src)[len - 1 - k];
+    for (k = 0; k < len; ++k) {
+        ((u_char *)dst)[k] = ((u_char *)src)[len - 1 - k];
     }
 
     return dst;
@@ -30,25 +28,24 @@ ngx_rtmp_amf_reverse_copy(void *dst, void* src, size_t len)
 #define NGX_RTMP_AMF_DEBUG_SIZE 72
 
 #ifdef NGX_DEBUG
-static void
-ngx_rtmp_amf_debug(const char* op, ngx_log_t *log, u_char *p, size_t n)
+static void ngx_rtmp_amf_debug(const char *op, ngx_log_t *log, u_char *p,
+                               size_t n)
 {
-    u_char          hstr[3 * NGX_RTMP_AMF_DEBUG_SIZE + 1];
-    u_char          str[NGX_RTMP_AMF_DEBUG_SIZE + 1];
-    u_char         *hp, *sp;
-    static u_char   hex[] = "0123456789ABCDEF";
-    size_t          i;
+    u_char hstr[3 * NGX_RTMP_AMF_DEBUG_SIZE + 1];
+    u_char str[NGX_RTMP_AMF_DEBUG_SIZE + 1];
+    u_char *hp, *sp;
+    static u_char hex[] = "0123456789ABCDEF";
+    size_t i;
 
     hp = hstr;
     sp = str;
 
-    for(i = 0; i < n && i < NGX_RTMP_AMF_DEBUG_SIZE; ++i) {
+    for (i = 0; i < n && i < NGX_RTMP_AMF_DEBUG_SIZE; ++i) {
         *hp++ = ' ';
         if (p) {
             *hp++ = hex[(*p & 0xf0) >> 4];
             *hp++ = hex[*p & 0x0f];
-            *sp++ = (*p >= 0x20 && *p <= 0x7e) ?
-                *p : (u_char)'?';
+            *sp++ = (*p >= 0x20 && *p <= 0x7e) ? *p : (u_char)'?';
             ++p;
         } else {
             *hp++ = 'X';
@@ -58,28 +55,26 @@ ngx_rtmp_amf_debug(const char* op, ngx_log_t *log, u_char *p, size_t n)
     }
     *hp = *sp = '\0';
 
-    ngx_log_debug4(NGX_LOG_DEBUG_RTMP, log, 0,
-            "AMF %s (%d)%s '%s'", op, n, hstr, str);
+    ngx_log_debug4(NGX_LOG_DEBUG_RTMP, log, 0, "AMF %s (%d)%s '%s'", op, n,
+                   hstr, str);
 }
 #endif
 
-static ngx_int_t
-ngx_rtmp_amf_get(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
+static ngx_int_t ngx_rtmp_amf_get(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
 {
-    size_t          size;
-    ngx_chain_t    *l;
-    size_t          offset;
-    u_char         *pos, *last;
+    size_t size;
+    ngx_chain_t *l;
+    size_t offset;
+    u_char *pos, *last;
 #ifdef NGX_DEBUG
-    void           *op = p;
-    size_t          on = n;
+    void *op  = p;
+    size_t on = n;
 #endif
 
     if (!n)
         return NGX_OK;
 
-    for(l = ctx->link, offset = ctx->offset; l; l = l->next, offset = 0) {
-
+    for (l = ctx->link, offset = ctx->offset; l; l = l->next, offset = 0) {
         pos  = l->buf->pos + offset;
         last = l->buf->last;
 
@@ -88,10 +83,10 @@ ngx_rtmp_amf_get(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
                 p = ngx_cpymem(p, pos, n);
             }
             ctx->offset = offset + n;
-            ctx->link = l;
+            ctx->link   = l;
 
 #ifdef NGX_DEBUG
-            ngx_rtmp_amf_debug("read", ctx->log, (u_char*)op, on);
+            ngx_rtmp_amf_debug("read", ctx->log, (u_char *)op, on);
 #endif
 
             return NGX_OK;
@@ -106,22 +101,19 @@ ngx_rtmp_amf_get(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
         n -= size;
     }
 
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, ctx->log, 0,
-            "AMF read eof (%d)", n);
+    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, ctx->log, 0, "AMF read eof (%d)", n);
 
     return NGX_DONE;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_put(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
+static ngx_int_t ngx_rtmp_amf_put(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
 {
-    ngx_buf_t       *b;
-    size_t          size;
-    ngx_chain_t    *l, *ln;
+    ngx_buf_t *b;
+    size_t size;
+    ngx_chain_t *l, *ln;
 
 #ifdef NGX_DEBUG
-    ngx_rtmp_amf_debug("write", ctx->log, (u_char*)p, n);
+    ngx_rtmp_amf_debug("write", ctx->log, (u_char *)p, n);
 #endif
 
     l = ctx->link;
@@ -130,11 +122,10 @@ ngx_rtmp_amf_put(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
         ctx->first = ctx->link;
     }
 
-    while(n) {
+    while (n) {
         b = l ? l->buf : NULL;
 
         if (b == NULL || b->last == b->end) {
-
             ln = ctx->alloc(ctx->arg);
             if (ln == NULL) {
                 return NGX_ERROR;
@@ -148,9 +139,9 @@ ngx_rtmp_amf_put(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
                 l->next = ln;
             }
 
-            l = ln;
+            l         = ln;
             ctx->link = l;
-            b = l->buf;
+            b         = l->buf;
         }
 
         size = b->end - b->last;
@@ -161,37 +152,35 @@ ngx_rtmp_amf_put(ngx_rtmp_amf_ctx_t *ctx, void *p, size_t n)
         }
 
         b->last = ngx_cpymem(b->last, p, size);
-        p = (u_char*)p + size;
+        p       = (u_char *)p + size;
         n -= size;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_read_object(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
-        size_t nelts)
+static ngx_int_t ngx_rtmp_amf_read_object(ngx_rtmp_amf_ctx_t *ctx,
+                                          ngx_rtmp_amf_elt_t *elts,
+                                          size_t nelts)
 {
-    uint8_t                 type;
-    uint16_t                len;
-    size_t                  n, namelen, maxlen;
-    ngx_int_t               rc;
-    u_char                  buf[2];
+    uint8_t type;
+    uint16_t len;
+    size_t n, namelen, maxlen;
+    ngx_int_t rc;
+    u_char buf[2];
 
     maxlen = 0;
-    for(n = 0; n < nelts; ++n) {
+    for (n = 0; n < nelts; ++n) {
         namelen = elts[n].name.len;
         if (namelen > maxlen)
             maxlen = namelen;
     }
 
-    for( ;; ) {
-
+    for (;;) {
 #if !(NGX_WIN32)
-        char    name[maxlen];
+        char name[maxlen];
 #else
-        char    name[1024];
+        char name[1024];
         if (maxlen > sizeof(name)) {
             return NGX_ERROR;
         }
@@ -227,32 +216,28 @@ ngx_rtmp_amf_read_object(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
 
         /* TODO: if we require array to be sorted on name
          * then we could be able to use binary search */
-        for(n = 0; n < nelts
-                && (len != elts[n].name.len
-                    || ngx_strncmp(name, elts[n].name.data, len));
-                ++n);
+        for (n = 0; n < nelts && (len != elts[n].name.len ||
+                                  ngx_strncmp(name, elts[n].name.data, len));
+             ++n)
+            ;
 
         if (ngx_rtmp_amf_read(ctx, n < nelts ? &elts[n] : NULL, 1) != NGX_OK)
             return NGX_ERROR;
     }
 
-    if (ngx_rtmp_amf_get(ctx, &type, 1) != NGX_OK
-        || type != NGX_RTMP_AMF_END)
-    {
+    if (ngx_rtmp_amf_get(ctx, &type, 1) != NGX_OK || type != NGX_RTMP_AMF_END) {
         return NGX_ERROR;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_read_array(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
-        size_t nelts)
+static ngx_int_t ngx_rtmp_amf_read_array(ngx_rtmp_amf_ctx_t *ctx,
+                                         ngx_rtmp_amf_elt_t *elts, size_t nelts)
 {
-    uint32_t                len;
-    size_t                  n;
-    u_char                  buf[4];
+    uint32_t len;
+    size_t n;
+    u_char buf[4];
 
     /* read length */
     if (ngx_rtmp_amf_get(ctx, buf, 4) != NGX_OK)
@@ -268,15 +253,14 @@ ngx_rtmp_amf_read_array(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_read_variant(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
-        size_t nelts)
+static ngx_int_t ngx_rtmp_amf_read_variant(ngx_rtmp_amf_ctx_t *ctx,
+                                           ngx_rtmp_amf_elt_t *elts,
+                                           size_t nelts)
 {
-    uint8_t                 type;
-    ngx_int_t               rc;
-    size_t                  n;
-    ngx_rtmp_amf_elt_t      elt;
+    uint8_t type;
+    ngx_int_t rc;
+    size_t n;
+    ngx_rtmp_amf_elt_t elt;
 
     rc = ngx_rtmp_amf_get(ctx, &type, 1);
     if (rc != NGX_OK) {
@@ -296,161 +280,155 @@ ngx_rtmp_amf_read_variant(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
     return ngx_rtmp_amf_read(ctx, &elt, 1);
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_is_compatible_type(uint8_t t1, uint8_t t2)
+static ngx_int_t ngx_rtmp_amf_is_compatible_type(uint8_t t1, uint8_t t2)
 {
-    return t1 == t2
-        || (t1 == NGX_RTMP_AMF_OBJECT && t2 == NGX_RTMP_AMF_MIXED_ARRAY)
-        || (t2 == NGX_RTMP_AMF_OBJECT && t1 == NGX_RTMP_AMF_MIXED_ARRAY);
+    return t1 == t2 ||
+           (t1 == NGX_RTMP_AMF_OBJECT && t2 == NGX_RTMP_AMF_MIXED_ARRAY) ||
+           (t2 == NGX_RTMP_AMF_OBJECT && t1 == NGX_RTMP_AMF_MIXED_ARRAY);
 }
 
-
-ngx_int_t
-ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
-        size_t nelts)
+ngx_int_t ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
+                            size_t nelts)
 {
-    void                       *data;
-    ngx_int_t                   type;
-    uint8_t                     type8;
-    size_t                      n;
-    uint16_t                    len;
-    ngx_int_t                   rc;
-    u_char                      buf[8];
-    uint32_t                    max_index;
+    void *data;
+    ngx_int_t type;
+    uint8_t type8;
+    size_t n;
+    uint16_t len;
+    ngx_int_t rc;
+    u_char buf[8];
+    uint32_t max_index;
 
-    for(n = 0; n < nelts; ++n) {
-
+    for (n = 0; n < nelts; ++n) {
         if (elts && elts->type & NGX_RTMP_AMF_TYPELESS) {
             type = elts->type & ~NGX_RTMP_AMF_TYPELESS;
             data = elts->data;
 
         } else {
             switch (ngx_rtmp_amf_get(ctx, &type8, 1)) {
-                case NGX_DONE:
-                    if (elts->type & NGX_RTMP_AMF_OPTIONAL) {
-                        return NGX_OK;
-                    }
-                case NGX_ERROR:
-                    return NGX_ERROR;
+            case NGX_DONE:
+                if (elts->type & NGX_RTMP_AMF_OPTIONAL) {
+                    return NGX_OK;
+                }
+            case NGX_ERROR:
+                return NGX_ERROR;
             }
             type = type8;
-            data = (elts &&
-                    ngx_rtmp_amf_is_compatible_type(
-                                 (uint8_t) (elts->type & 0xff), (uint8_t) type))
-                ? elts->data
-                : NULL;
+            data = (elts && ngx_rtmp_amf_is_compatible_type(
+                                (uint8_t)(elts->type & 0xff), (uint8_t)type))
+                       ? elts->data
+                       : NULL;
 
             if (elts && (elts->type & NGX_RTMP_AMF_CONTEXT)) {
                 if (data) {
-                    *(ngx_rtmp_amf_ctx_t *) data = *ctx;
+                    *(ngx_rtmp_amf_ctx_t *)data = *ctx;
                 }
                 data = NULL;
             }
         }
 
         switch (type) {
-            case NGX_RTMP_AMF_NUMBER:
-                if (ngx_rtmp_amf_get(ctx, buf, 8) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                ngx_rtmp_amf_reverse_copy(data, buf, 8);
-                break;
-
-            case NGX_RTMP_AMF_BOOLEAN:
-                if (ngx_rtmp_amf_get(ctx, data, 1) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_STRING:
-                if (ngx_rtmp_amf_get(ctx, buf, 2) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                ngx_rtmp_amf_reverse_copy(&len, buf, 2);
-
-                if (data == NULL) {
-                    rc = ngx_rtmp_amf_get(ctx, data, len);
-
-                } else if (elts->len <= len) {
-                    rc = ngx_rtmp_amf_get(ctx, data, elts->len - 1);
-                    if (rc != NGX_OK)
-                        return NGX_ERROR;
-                    ((char*)data)[elts->len - 1] = 0;
-                    rc = ngx_rtmp_amf_get(ctx, NULL, len - elts->len + 1);
-
-                } else {
-                    rc = ngx_rtmp_amf_get(ctx, data, len);
-                    ((char*)data)[len] = 0;
-                }
-
-                if (rc != NGX_OK) {
-                    return NGX_ERROR;
-                }
-
-                break;
-
-            case NGX_RTMP_AMF_NULL:
-            case NGX_RTMP_AMF_ARRAY_NULL:
-                break;
-
-            case NGX_RTMP_AMF_MIXED_ARRAY:
-                if (ngx_rtmp_amf_get(ctx, &max_index, 4) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-
-            case NGX_RTMP_AMF_OBJECT:
-                if (ngx_rtmp_amf_read_object(ctx, data,
-                    data && elts ? elts->len / sizeof(ngx_rtmp_amf_elt_t) : 0
-                    ) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_ARRAY:
-                if (ngx_rtmp_amf_read_array(ctx, data,
-                    data && elts ? elts->len / sizeof(ngx_rtmp_amf_elt_t) : 0
-                    ) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_VARIANT_:
-                if (ngx_rtmp_amf_read_variant(ctx, data,
-                    data && elts ? elts->len / sizeof(ngx_rtmp_amf_elt_t) : 0
-                    ) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_INT8:
-                if (ngx_rtmp_amf_get(ctx, data, 1) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_INT16:
-                if (ngx_rtmp_amf_get(ctx, buf, 2) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                ngx_rtmp_amf_reverse_copy(data, buf, 2);
-                break;
-
-            case NGX_RTMP_AMF_INT32:
-                if (ngx_rtmp_amf_get(ctx, buf, 4) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                ngx_rtmp_amf_reverse_copy(data, buf, 4);
-                break;
-
-            case NGX_RTMP_AMF_END:
-                return NGX_OK;
-
-            default:
+        case NGX_RTMP_AMF_NUMBER:
+            if (ngx_rtmp_amf_get(ctx, buf, 8) != NGX_OK) {
                 return NGX_ERROR;
+            }
+            ngx_rtmp_amf_reverse_copy(data, buf, 8);
+            break;
+
+        case NGX_RTMP_AMF_BOOLEAN:
+            if (ngx_rtmp_amf_get(ctx, data, 1) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_STRING:
+            if (ngx_rtmp_amf_get(ctx, buf, 2) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            ngx_rtmp_amf_reverse_copy(&len, buf, 2);
+
+            if (data == NULL) {
+                rc = ngx_rtmp_amf_get(ctx, data, len);
+
+            } else if (elts->len <= len) {
+                rc = ngx_rtmp_amf_get(ctx, data, elts->len - 1);
+                if (rc != NGX_OK)
+                    return NGX_ERROR;
+                ((char *)data)[elts->len - 1] = 0;
+                rc = ngx_rtmp_amf_get(ctx, NULL, len - elts->len + 1);
+
+            } else {
+                rc                  = ngx_rtmp_amf_get(ctx, data, len);
+                ((char *)data)[len] = 0;
+            }
+
+            if (rc != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+            break;
+
+        case NGX_RTMP_AMF_NULL:
+        case NGX_RTMP_AMF_ARRAY_NULL:
+            break;
+
+        case NGX_RTMP_AMF_MIXED_ARRAY:
+            if (ngx_rtmp_amf_get(ctx, &max_index, 4) != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+        case NGX_RTMP_AMF_OBJECT:
+            if (ngx_rtmp_amf_read_object(
+                    ctx, data, data && elts
+                                   ? elts->len / sizeof(ngx_rtmp_amf_elt_t)
+                                   : 0) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_ARRAY:
+            if (ngx_rtmp_amf_read_array(
+                    ctx, data, data && elts
+                                   ? elts->len / sizeof(ngx_rtmp_amf_elt_t)
+                                   : 0) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_VARIANT_:
+            if (ngx_rtmp_amf_read_variant(
+                    ctx, data, data && elts
+                                   ? elts->len / sizeof(ngx_rtmp_amf_elt_t)
+                                   : 0) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_INT8:
+            if (ngx_rtmp_amf_get(ctx, data, 1) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_INT16:
+            if (ngx_rtmp_amf_get(ctx, buf, 2) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            ngx_rtmp_amf_reverse_copy(data, buf, 2);
+            break;
+
+        case NGX_RTMP_AMF_INT32:
+            if (ngx_rtmp_amf_get(ctx, buf, 4) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            ngx_rtmp_amf_reverse_copy(data, buf, 4);
+            break;
+
+        case NGX_RTMP_AMF_END:
+            return NGX_OK;
+
+        default:
+            return NGX_ERROR;
         }
 
         if (elts) {
@@ -461,23 +439,19 @@ ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_write_object(ngx_rtmp_amf_ctx_t *ctx,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts)
+static ngx_int_t ngx_rtmp_amf_write_object(ngx_rtmp_amf_ctx_t *ctx,
+                                           ngx_rtmp_amf_elt_t *elts,
+                                           size_t nelts)
 {
-    uint16_t                len;
-    size_t                  n;
-    u_char                  buf[2];
+    uint16_t len;
+    size_t n;
+    u_char buf[2];
 
-    for(n = 0; n < nelts; ++n) {
+    for (n = 0; n < nelts; ++n) {
+        len = (uint16_t)elts[n].name.len;
 
-        len = (uint16_t) elts[n].name.len;
-
-        if (ngx_rtmp_amf_put(ctx,
-                    ngx_rtmp_amf_reverse_copy(buf,
-                        &len, 2), 2) != NGX_OK)
-        {
+        if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, &len, 2), 2) !=
+            NGX_OK) {
             return NGX_ERROR;
         }
 
@@ -497,24 +471,21 @@ ngx_rtmp_amf_write_object(ngx_rtmp_amf_ctx_t *ctx,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_amf_write_array(ngx_rtmp_amf_ctx_t *ctx,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts)
+static ngx_int_t ngx_rtmp_amf_write_array(ngx_rtmp_amf_ctx_t *ctx,
+                                          ngx_rtmp_amf_elt_t *elts,
+                                          size_t nelts)
 {
-    uint32_t                len;
-    size_t                  n;
-    u_char                  buf[4];
+    uint32_t len;
+    size_t n;
+    u_char buf[4];
 
     len = nelts;
-    if (ngx_rtmp_amf_put(ctx,
-                ngx_rtmp_amf_reverse_copy(buf,
-                    &len, 4), 4) != NGX_OK)
-    {
+    if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, &len, 4), 4) !=
+        NGX_OK) {
         return NGX_ERROR;
     }
 
-    for(n = 0; n < nelts; ++n) {
+    for (n = 0; n < nelts; ++n) {
         if (ngx_rtmp_amf_write(ctx, &elts[n], 1) != NGX_OK) {
             return NGX_ERROR;
         }
@@ -523,24 +494,21 @@ ngx_rtmp_amf_write_array(ngx_rtmp_amf_ctx_t *ctx,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts)
+ngx_int_t ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
+                             size_t nelts)
 {
-    size_t                  n;
-    ngx_int_t               type;
-    uint8_t                 type8;
-    void                   *data;
-    uint16_t                len;
-    uint32_t                max_index;
-    u_char                  buf[8];
+    size_t n;
+    ngx_int_t type;
+    uint8_t type8;
+    void *data;
+    uint16_t len;
+    uint32_t max_index;
+    u_char buf[8];
 
-    for(n = 0; n < nelts; ++n) {
-
+    for (n = 0; n < nelts; ++n) {
         type = elts[n].type;
         data = elts[n].data;
-        len  = (uint16_t) elts[n].len;
+        len  = (uint16_t)elts[n].len;
 
         if (type & NGX_RTMP_AMF_TYPELESS) {
             type &= ~NGX_RTMP_AMF_TYPELESS;
@@ -550,96 +518,87 @@ ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx,
                 return NGX_ERROR;
         }
 
-        switch(type) {
-            case NGX_RTMP_AMF_NUMBER:
-                if (ngx_rtmp_amf_put(ctx,
-                            ngx_rtmp_amf_reverse_copy(buf,
-                                data, 8), 8) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_BOOLEAN:
-                if (ngx_rtmp_amf_put(ctx, data, 1) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_STRING:
-                if (len == 0 && data) {
-                    len = (uint16_t) ngx_strlen((u_char*) data);
-                }
-
-                if (ngx_rtmp_amf_put(ctx,
-                            ngx_rtmp_amf_reverse_copy(buf,
-                                &len, 2), 2) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-
-                if (ngx_rtmp_amf_put(ctx, data, len) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_NULL:
-            case NGX_RTMP_AMF_ARRAY_NULL:
-                break;
-
-            case NGX_RTMP_AMF_MIXED_ARRAY:
-                max_index = 0;
-                if (ngx_rtmp_amf_put(ctx, &max_index, 4) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-
-            case NGX_RTMP_AMF_OBJECT:
-                type8 = NGX_RTMP_AMF_END;
-                if (ngx_rtmp_amf_write_object(ctx, data,
-                        elts[n].len / sizeof(ngx_rtmp_amf_elt_t)) != NGX_OK
-                    || ngx_rtmp_amf_put(ctx, &type8, 1) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_ARRAY:
-                if (ngx_rtmp_amf_write_array(ctx, data,
-                        elts[n].len / sizeof(ngx_rtmp_amf_elt_t)) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_INT8:
-                if (ngx_rtmp_amf_put(ctx, data, 1) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_INT16:
-                if (ngx_rtmp_amf_put(ctx,
-                            ngx_rtmp_amf_reverse_copy(buf,
-                                data, 2), 2) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            case NGX_RTMP_AMF_INT32:
-                if (ngx_rtmp_amf_put(ctx,
-                            ngx_rtmp_amf_reverse_copy(buf,
-                                data, 4), 4) != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-                break;
-
-            default:
+        switch (type) {
+        case NGX_RTMP_AMF_NUMBER:
+            if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, data, 8),
+                                 8) != NGX_OK) {
                 return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_BOOLEAN:
+            if (ngx_rtmp_amf_put(ctx, data, 1) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_STRING:
+            if (len == 0 && data) {
+                len = (uint16_t)ngx_strlen((u_char *)data);
+            }
+
+            if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, &len, 2),
+                                 2) != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+            if (ngx_rtmp_amf_put(ctx, data, len) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_NULL:
+        case NGX_RTMP_AMF_ARRAY_NULL:
+            break;
+
+        case NGX_RTMP_AMF_MIXED_ARRAY:
+            max_index = 0;
+            if (ngx_rtmp_amf_put(ctx, &max_index, 4) != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+        case NGX_RTMP_AMF_OBJECT:
+            type8 = NGX_RTMP_AMF_END;
+            if (ngx_rtmp_amf_write_object(
+                    ctx, data, elts[n].len / sizeof(ngx_rtmp_amf_elt_t)) !=
+                    NGX_OK ||
+                ngx_rtmp_amf_put(ctx, &type8, 1) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_ARRAY:
+            if (ngx_rtmp_amf_write_array(
+                    ctx, data, elts[n].len / sizeof(ngx_rtmp_amf_elt_t)) !=
+                NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_INT8:
+            if (ngx_rtmp_amf_put(ctx, data, 1) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_INT16:
+            if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, data, 2),
+                                 2) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        case NGX_RTMP_AMF_INT32:
+            if (ngx_rtmp_amf_put(ctx, ngx_rtmp_amf_reverse_copy(buf, data, 4),
+                                 4) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            break;
+
+        default:
+            return NGX_ERROR;
         }
     }
 
     return NGX_OK;
 }
-

--- a/ngx_rtmp_amf.h
+++ b/ngx_rtmp_amf.h
@@ -3,69 +3,59 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_AMF_H_INCLUDED_
 #define _NGX_RTMP_AMF_H_INCLUDED_
-
 
 #include <ngx_config.h>
 #include <ngx_core.h>
 
-
 /* basic types */
-#define NGX_RTMP_AMF_NUMBER             0x00
-#define NGX_RTMP_AMF_BOOLEAN            0x01
-#define NGX_RTMP_AMF_STRING             0x02
-#define NGX_RTMP_AMF_OBJECT             0x03
-#define NGX_RTMP_AMF_NULL               0x05
-#define NGX_RTMP_AMF_ARRAY_NULL         0x06
-#define NGX_RTMP_AMF_MIXED_ARRAY        0x08
-#define NGX_RTMP_AMF_END                0x09
-#define NGX_RTMP_AMF_ARRAY              0x0a
+#define NGX_RTMP_AMF_NUMBER 0x00
+#define NGX_RTMP_AMF_BOOLEAN 0x01
+#define NGX_RTMP_AMF_STRING 0x02
+#define NGX_RTMP_AMF_OBJECT 0x03
+#define NGX_RTMP_AMF_NULL 0x05
+#define NGX_RTMP_AMF_ARRAY_NULL 0x06
+#define NGX_RTMP_AMF_MIXED_ARRAY 0x08
+#define NGX_RTMP_AMF_END 0x09
+#define NGX_RTMP_AMF_ARRAY 0x0a
 
 /* extended types */
-#define NGX_RTMP_AMF_INT8               0x0100
-#define NGX_RTMP_AMF_INT16              0x0101
-#define NGX_RTMP_AMF_INT32              0x0102
-#define NGX_RTMP_AMF_VARIANT_           0x0103
+#define NGX_RTMP_AMF_INT8 0x0100
+#define NGX_RTMP_AMF_INT16 0x0101
+#define NGX_RTMP_AMF_INT32 0x0102
+#define NGX_RTMP_AMF_VARIANT_ 0x0103
 
 /* r/w flags */
-#define NGX_RTMP_AMF_OPTIONAL           0x1000
-#define NGX_RTMP_AMF_TYPELESS           0x2000
-#define NGX_RTMP_AMF_CONTEXT            0x4000
+#define NGX_RTMP_AMF_OPTIONAL 0x1000
+#define NGX_RTMP_AMF_TYPELESS 0x2000
+#define NGX_RTMP_AMF_CONTEXT 0x4000
 
-#define NGX_RTMP_AMF_VARIANT            (NGX_RTMP_AMF_VARIANT_\
-                                        |NGX_RTMP_AMF_TYPELESS)
-
+#define NGX_RTMP_AMF_VARIANT (NGX_RTMP_AMF_VARIANT_ | NGX_RTMP_AMF_TYPELESS)
 
 typedef struct {
-    ngx_int_t                           type;
-    ngx_str_t                           name;
-    void                               *data;
-    size_t                              len;
+    ngx_int_t type;
+    ngx_str_t name;
+    void *data;
+    size_t len;
 } ngx_rtmp_amf_elt_t;
 
-
-typedef ngx_chain_t * (*ngx_rtmp_amf_alloc_pt)(void *arg);
-
+typedef ngx_chain_t *(*ngx_rtmp_amf_alloc_pt)(void *arg);
 
 typedef struct {
-    ngx_chain_t                        *link, *first;
-    size_t                              offset;
-    ngx_rtmp_amf_alloc_pt               alloc;
-    void                               *arg;
-    ngx_log_t                          *log;
+    ngx_chain_t *link, *first;
+    size_t offset;
+    ngx_rtmp_amf_alloc_pt alloc;
+    void *arg;
+    ngx_log_t *log;
 } ngx_rtmp_amf_ctx_t;
 
-
 /* reading AMF */
-ngx_int_t ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
+ngx_int_t ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
+                            size_t nelts);
 
 /* writing AMF */
-ngx_int_t ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts);
-
+ngx_int_t ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
+                             size_t nelts);
 
 #endif /* _NGX_RTMP_AMF_H_INCLUDED_ */
-

--- a/ngx_rtmp_auto_push_module.c
+++ b/ngx_rtmp_auto_push_module.c
@@ -3,135 +3,113 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp_cmd_module.h"
 #include "ngx_rtmp_relay_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
-
-static ngx_rtmp_publish_pt          next_publish;
-static ngx_rtmp_delete_stream_pt    next_delete_stream;
-
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_delete_stream_pt next_delete_stream;
 
 static ngx_int_t ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle);
 static void ngx_rtmp_auto_push_exit_process(ngx_cycle_t *cycle);
-static void * ngx_rtmp_auto_push_create_conf(ngx_cycle_t *cf);
-static char * ngx_rtmp_auto_push_init_conf(ngx_cycle_t *cycle, void *conf);
+static void *ngx_rtmp_auto_push_create_conf(ngx_cycle_t *cf);
+static char *ngx_rtmp_auto_push_init_conf(ngx_cycle_t *cycle, void *conf);
 #if (NGX_HAVE_UNIX_DOMAIN)
 static ngx_int_t ngx_rtmp_auto_push_publish(ngx_rtmp_session_t *s,
-       ngx_rtmp_publish_t *v);
+                                            ngx_rtmp_publish_t *v);
 static ngx_int_t ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
-       ngx_rtmp_delete_stream_t *v);
+                                                  ngx_rtmp_delete_stream_t *v);
 #endif
-
 
 typedef struct ngx_rtmp_auto_push_ctx_s ngx_rtmp_auto_push_ctx_t;
 
 struct ngx_rtmp_auto_push_ctx_s {
-    ngx_int_t                      *slots; /* NGX_MAX_PROCESSES */
-    u_char                          name[NGX_RTMP_MAX_NAME];
-    u_char                          args[NGX_RTMP_MAX_ARGS];
-    ngx_event_t                     push_evt;
+    ngx_int_t *slots; /* NGX_MAX_PROCESSES */
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    ngx_event_t push_evt;
 };
-
 
 typedef struct {
-    ngx_flag_t                      auto_push;
-    ngx_str_t                       socket_dir;
-    ngx_msec_t                      push_reconnect;
+    ngx_flag_t auto_push;
+    ngx_str_t socket_dir;
+    ngx_msec_t push_reconnect;
 } ngx_rtmp_auto_push_conf_t;
 
+static ngx_command_t ngx_rtmp_auto_push_commands[] = {
 
-static ngx_command_t  ngx_rtmp_auto_push_commands[] = {
+    {ngx_string("rtmp_auto_push"),
+     NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1, ngx_conf_set_flag_slot,
+     0, offsetof(ngx_rtmp_auto_push_conf_t, auto_push), NULL},
 
-    { ngx_string("rtmp_auto_push"),
-      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      0,
-      offsetof(ngx_rtmp_auto_push_conf_t, auto_push),
-      NULL },
+    {ngx_string("rtmp_auto_push_reconnect"),
+     NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1, ngx_conf_set_msec_slot,
+     0, offsetof(ngx_rtmp_auto_push_conf_t, push_reconnect), NULL},
 
-    { ngx_string("rtmp_auto_push_reconnect"),
-      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      0,
-      offsetof(ngx_rtmp_auto_push_conf_t, push_reconnect),
-      NULL },
+    {ngx_string("rtmp_socket_dir"),
+     NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1, ngx_conf_set_str_slot, 0,
+     offsetof(ngx_rtmp_auto_push_conf_t, socket_dir), NULL},
 
-    { ngx_string("rtmp_socket_dir"),
-      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_str_slot,
-      0,
-      offsetof(ngx_rtmp_auto_push_conf_t, socket_dir),
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
-};
-
-
-static ngx_core_module_t  ngx_rtmp_auto_push_module_ctx = {
+static ngx_core_module_t ngx_rtmp_auto_push_module_ctx = {
     ngx_string("rtmp_auto_push"),
-    ngx_rtmp_auto_push_create_conf,         /* create conf */
-    ngx_rtmp_auto_push_init_conf            /* init conf */
+    ngx_rtmp_auto_push_create_conf, /* create conf */
+    ngx_rtmp_auto_push_init_conf    /* init conf */
 };
 
-
-ngx_module_t  ngx_rtmp_auto_push_module = {
+ngx_module_t ngx_rtmp_auto_push_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_auto_push_module_ctx,         /* module context */
-    ngx_rtmp_auto_push_commands,            /* module directives */
-    NGX_CORE_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    ngx_rtmp_auto_push_init_process,        /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    ngx_rtmp_auto_push_exit_process,        /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_auto_push_module_ctx,  /* module context */
+    ngx_rtmp_auto_push_commands,     /* module directives */
+    NGX_CORE_MODULE,                 /* module type */
+    NULL,                            /* init master */
+    NULL,                            /* init module */
+    ngx_rtmp_auto_push_init_process, /* init process */
+    NULL,                            /* init thread */
+    NULL,                            /* exit thread */
+    ngx_rtmp_auto_push_exit_process, /* exit process */
+    NULL,                            /* exit master */
+    NGX_MODULE_V1_PADDING};
 
+#define NGX_RTMP_AUTO_PUSH_SOCKNAME "nginx-rtmp"
 
-#define NGX_RTMP_AUTO_PUSH_SOCKNAME         "nginx-rtmp"
-
-
-static ngx_int_t
-ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
+static ngx_int_t ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
 {
 #if (NGX_HAVE_UNIX_DOMAIN)
-    ngx_rtmp_auto_push_conf_t  *apcf;
-    ngx_listening_t            *ls, *lss;
-    struct sockaddr_un         *saun;
-    int                         reuseaddr;
-    ngx_socket_t                s;
-    size_t                      n;
-    ngx_file_info_t             fi;
+    ngx_rtmp_auto_push_conf_t *apcf;
+    ngx_listening_t *ls, *lss;
+    struct sockaddr_un *saun;
+    int reuseaddr;
+    ngx_socket_t s;
+    size_t n;
+    ngx_file_info_t fi;
 
     if (ngx_process != NGX_PROCESS_WORKER) {
         return NGX_OK;
     }
 
-    apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(cycle->conf_ctx,
-                                                    ngx_rtmp_auto_push_module);
+    apcf = (ngx_rtmp_auto_push_conf_t *)ngx_get_conf(cycle->conf_ctx,
+                                                     ngx_rtmp_auto_push_module);
     if (apcf->auto_push == 0) {
         return NGX_OK;
     }
 
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_auto_push_publish;
 
-    next_delete_stream = ngx_rtmp_delete_stream;
+    next_delete_stream     = ngx_rtmp_delete_stream;
     ngx_rtmp_delete_stream = ngx_rtmp_auto_push_delete_stream;
 
     reuseaddr = 1;
-    s = (ngx_socket_t) -1;
+    s         = (ngx_socket_t)-1;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, cycle->log, 0,
-            "auto_push: creating sockets");
+                   "auto_push: creating sockets");
 
     /*TODO: clone all RTMP listenings? */
-    ls = cycle->listening.elts;
+    ls  = cycle->listening.elts;
     lss = NULL;
     for (n = 0; n < cycle->listening.nelts; ++n, ++ls) {
         if (ls->handler == ngx_rtmp_init_connection) {
@@ -156,21 +134,19 @@ ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
      * Nginx generates bad addr_text with this enabled */
     ls->addr_ntop = 0;
 
-    ls->socklen = sizeof(struct sockaddr_un);
-    saun = ngx_pcalloc(cycle->pool, ls->socklen);
-    ls->sockaddr = (struct sockaddr *) saun;
+    ls->socklen  = sizeof(struct sockaddr_un);
+    saun         = ngx_pcalloc(cycle->pool, ls->socklen);
+    ls->sockaddr = (struct sockaddr *)saun;
     if (ls->sockaddr == NULL) {
         return NGX_ERROR;
     }
     saun->sun_family = AF_UNIX;
-    *ngx_snprintf((u_char *) saun->sun_path, sizeof(saun->sun_path),
-                  "%V/" NGX_RTMP_AUTO_PUSH_SOCKNAME ".%i",
-                  &apcf->socket_dir, ngx_process_slot)
-        = 0;
+    *ngx_snprintf((u_char *)saun->sun_path, sizeof(saun->sun_path),
+                  "%V/" NGX_RTMP_AUTO_PUSH_SOCKNAME ".%i", &apcf->socket_dir,
+                  ngx_process_slot) = 0;
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, cycle->log, 0,
-                   "auto_push: create socket '%s'",
-                   saun->sun_path);
+                   "auto_push: create socket '%s'", saun->sun_path);
 
     if (ngx_file_info(saun->sun_path, &fi) != ENOENT) {
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, cycle->log, 0,
@@ -188,12 +164,10 @@ ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
         return NGX_ERROR;
     }
 
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR,
-                   (const void *) &reuseaddr, sizeof(int))
-        == -1)
-    {
+    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (const void *)&reuseaddr,
+                   sizeof(int)) == -1) {
         ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
-                "setsockopt(SO_REUSEADDR) worker_socket failed");
+                      "setsockopt(SO_REUSEADDR) worker_socket failed");
         goto sock_error;
     }
 
@@ -205,7 +179,7 @@ ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
         }
     }
 
-    if (bind(s, (struct sockaddr *) saun, sizeof(*saun)) == -1) {
+    if (bind(s, (struct sockaddr *)saun, sizeof(*saun)) == -1) {
         ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
                       ngx_nonblocking_n " worker_socket bind failed");
         goto sock_error;
@@ -218,72 +192,64 @@ ngx_rtmp_auto_push_init_process(ngx_cycle_t *cycle)
         goto sock_error;
     }
 
-    ls->fd = s;
+    ls->fd     = s;
     ls->listen = 1;
 
     return NGX_OK;
 
 sock_error:
-    if (s != (ngx_socket_t) -1 && ngx_close_socket(s) == -1) {
+    if (s != (ngx_socket_t)-1 && ngx_close_socket(s) == -1) {
         ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
-                ngx_close_socket_n " worker_socket failed");
+                      ngx_close_socket_n " worker_socket failed");
     }
     ngx_delete_file(saun->sun_path);
 
     return NGX_ERROR;
 
-#else  /* NGX_HAVE_UNIX_DOMAIN */
+#else /* NGX_HAVE_UNIX_DOMAIN */
 
     return NGX_OK;
 
 #endif /* NGX_HAVE_UNIX_DOMAIN */
 }
 
-
-static void
-ngx_rtmp_auto_push_exit_process(ngx_cycle_t *cycle)
+static void ngx_rtmp_auto_push_exit_process(ngx_cycle_t *cycle)
 {
 #if (NGX_HAVE_UNIX_DOMAIN)
-    ngx_rtmp_auto_push_conf_t  *apcf;
-    u_char                      path[NGX_MAX_PATH];
+    ngx_rtmp_auto_push_conf_t *apcf;
+    u_char path[NGX_MAX_PATH];
 
-    apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(cycle->conf_ctx,
-                                                    ngx_rtmp_auto_push_module);
+    apcf = (ngx_rtmp_auto_push_conf_t *)ngx_get_conf(cycle->conf_ctx,
+                                                     ngx_rtmp_auto_push_module);
     if (apcf->auto_push == 0) {
         return;
     }
-    *ngx_snprintf(path, sizeof(path),
-                  "%V/" NGX_RTMP_AUTO_PUSH_SOCKNAME ".%i",
-                  &apcf->socket_dir, ngx_process_slot)
-         = 0;
+    *ngx_snprintf(path, sizeof(path), "%V/" NGX_RTMP_AUTO_PUSH_SOCKNAME ".%i",
+                  &apcf->socket_dir, ngx_process_slot) = 0;
 
     ngx_delete_file(path);
 
 #endif
 }
 
-
-static void *
-ngx_rtmp_auto_push_create_conf(ngx_cycle_t *cycle)
+static void *ngx_rtmp_auto_push_create_conf(ngx_cycle_t *cycle)
 {
-    ngx_rtmp_auto_push_conf_t       *apcf;
+    ngx_rtmp_auto_push_conf_t *apcf;
 
     apcf = ngx_pcalloc(cycle->pool, sizeof(ngx_rtmp_auto_push_conf_t));
     if (apcf == NULL) {
         return NULL;
     }
 
-    apcf->auto_push = NGX_CONF_UNSET;
+    apcf->auto_push      = NGX_CONF_UNSET;
     apcf->push_reconnect = NGX_CONF_UNSET_MSEC;
 
     return apcf;
 }
 
-
-static char *
-ngx_rtmp_auto_push_init_conf(ngx_cycle_t *cycle, void *conf)
+static char *ngx_rtmp_auto_push_init_conf(ngx_cycle_t *cycle, void *conf)
 {
-    ngx_rtmp_auto_push_conf_t      *apcf = conf;
+    ngx_rtmp_auto_push_conf_t *apcf = conf;
 
     ngx_conf_init_value(apcf->auto_push, 0);
     ngx_conf_init_msec_value(apcf->push_reconnect, 100);
@@ -295,42 +261,39 @@ ngx_rtmp_auto_push_init_conf(ngx_cycle_t *cycle, void *conf)
     return NGX_CONF_OK;
 }
 
-
 #if (NGX_HAVE_UNIX_DOMAIN)
-static void
-ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
+static void ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
 {
-    ngx_rtmp_session_t             *s = ev->data;
+    ngx_rtmp_session_t *s = ev->data;
 
-    ngx_rtmp_auto_push_conf_t      *apcf;
-    ngx_rtmp_auto_push_ctx_t       *ctx;
-    ngx_int_t                      *slot;
-    ngx_int_t                       n;
-    ngx_rtmp_relay_target_t         at;
-    u_char                          path[sizeof("unix:") + NGX_MAX_PATH];
-    u_char                          flash_ver[sizeof("APSH ,") +
-                                              NGX_INT_T_LEN * 2];
-    u_char                          play_path[NGX_RTMP_MAX_NAME];
-    ngx_str_t                       name;
-    u_char                         *p;
-    ngx_str_t                      *u;
-    ngx_pid_t                       pid;
-    ngx_int_t                       npushed;
-    ngx_core_conf_t                *ccf;
-    ngx_file_info_t                 fi;
+    ngx_rtmp_auto_push_conf_t *apcf;
+    ngx_rtmp_auto_push_ctx_t *ctx;
+    ngx_int_t *slot;
+    ngx_int_t n;
+    ngx_rtmp_relay_target_t at;
+    u_char path[sizeof("unix:") + NGX_MAX_PATH];
+    u_char flash_ver[sizeof("APSH ,") + NGX_INT_T_LEN * 2];
+    u_char play_path[NGX_RTMP_MAX_NAME];
+    ngx_str_t name;
+    u_char *p;
+    ngx_str_t *u;
+    ngx_pid_t pid;
+    ngx_int_t npushed;
+    ngx_core_conf_t *ccf;
+    ngx_file_info_t fi;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "auto_push: reconnect");
 
-    apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
-                                                    ngx_rtmp_auto_push_module);
+    apcf = (ngx_rtmp_auto_push_conf_t *)ngx_get_conf(ngx_cycle->conf_ctx,
+                                                     ngx_rtmp_auto_push_module);
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_module);
     if (ctx == NULL) {
         return;
     }
 
     name.data = ctx->name;
-    name.len = ngx_strlen(name.data);
+    name.len  = ngx_strlen(name.data);
 
     ngx_memzero(&at, sizeof(at));
     ngx_str_set(&at.page_url, "nginx-auto-push");
@@ -338,12 +301,12 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
 
     if (ctx->args[0]) {
         at.play_path.data = play_path;
-        at.play_path.len = ngx_snprintf(play_path, sizeof(play_path),
-                                        "%s?%s", ctx->name, ctx->args) -
+        at.play_path.len  = ngx_snprintf(play_path, sizeof(play_path), "%s?%s",
+                                        ctx->name, ctx->args) -
                            play_path;
     }
 
-    slot = ctx->slots;
+    slot    = ctx->slots;
     npushed = 0;
 
     for (n = 0; n < NGX_MAX_PROCESSES; ++n, ++slot) {
@@ -373,13 +336,14 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
         if (ngx_file_info(path + sizeof("unix:") - 1, &fi) != NGX_OK) {
             ngx_log_debug5(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                            "auto_push: " ngx_file_info_n " failed: "
-                           "slot=%i pid=%P socket='%s'" "url='%V' name='%s'",
+                           "slot=%i pid=%P socket='%s'"
+                           "url='%V' name='%s'",
                            n, pid, path, u, ctx->name);
             continue;
         }
 
         u->data = path;
-        u->len = p - path;
+        u->len  = p - path;
         if (ngx_parse_url(s->connection->pool, &at.url) != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                           "auto_push: auto-push parse_url failed "
@@ -389,13 +353,14 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
         }
 
         p = ngx_snprintf(flash_ver, sizeof(flash_ver) - 1, "APSH %i,%i",
-                         (ngx_int_t) ngx_process_slot, (ngx_int_t) ngx_pid);
+                         (ngx_int_t)ngx_process_slot, (ngx_int_t)ngx_pid);
         at.flash_ver.data = flash_ver;
-        at.flash_ver.len = p - flash_ver;
+        at.flash_ver.len  = p - flash_ver;
 
-        ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                       "auto_push: connect slot=%i pid=%P socket='%s' name='%s'",
-                       n, pid, path, ctx->name);
+        ngx_log_debug4(
+            NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+            "auto_push: connect slot=%i pid=%P socket='%s' name='%s'", n, pid,
+            path, ctx->name);
 
         if (ngx_rtmp_relay_push(s, &name, &at) == NGX_OK) {
             *slot = 1;
@@ -404,18 +369,16 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
         }
 
         ngx_log_debug5(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                      "auto_push: connect failed: slot=%i pid=%P socket='%s'"
-                      "url='%V' name='%s'",
-                      n, pid, path, u, ctx->name);
+                       "auto_push: connect failed: slot=%i pid=%P socket='%s'"
+                       "url='%V' name='%s'",
+                       n, pid, path, u, ctx->name);
     }
 
-    ccf = (ngx_core_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
-                                           ngx_core_module);
+    ccf = (ngx_core_conf_t *)ngx_get_conf(ngx_cycle->conf_ctx, ngx_core_module);
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "auto_push: pushed=%i total=%i failed=%i",
-                   npushed, ccf->worker_processes,
-                   ccf->worker_processes - 1 - npushed);
+                   "auto_push: pushed=%i total=%i failed=%i", npushed,
+                   ccf->worker_processes, ccf->worker_processes - 1 - npushed);
 
     if (ccf->worker_processes == npushed + 1) {
         return;
@@ -428,15 +391,14 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
     for (n = 0; n < NGX_MAX_PROCESSES; ++n, ++slot) {
         pid = ngx_processes[n].pid;
 
-        if (n == ngx_process_slot || *slot == 1 ||
-            pid == 0 || pid == NGX_INVALID_PID)
-        {
+        if (n == ngx_process_slot || *slot == 1 || pid == 0 ||
+            pid == NGX_INVALID_PID) {
             continue;
         }
 
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                      "auto_push: connect failed: slot=%i pid=%P name='%s'",
-                      n, pid, ctx->name);
+                      "auto_push: connect failed: slot=%i pid=%P name='%s'", n,
+                      pid, ctx->name);
     }
 
     if (!ctx->push_evt.timer_set) {
@@ -444,41 +406,38 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_auto_push_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_auto_push_publish(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_publish_t *v)
 {
-    ngx_rtmp_auto_push_conf_t      *apcf;
-    ngx_rtmp_auto_push_ctx_t       *ctx;
+    ngx_rtmp_auto_push_conf_t *apcf;
+    ngx_rtmp_auto_push_ctx_t *ctx;
 
     if (s->auto_pushed || (s->relay && !s->static_relay)) {
         goto next;
     }
 
-    apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
-                                                    ngx_rtmp_auto_push_module);
+    apcf = (ngx_rtmp_auto_push_conf_t *)ngx_get_conf(ngx_cycle->conf_ctx,
+                                                     ngx_rtmp_auto_push_module);
     if (apcf->auto_push == 0) {
         goto next;
     }
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_module);
     if (ctx == NULL) {
-        ctx = ngx_palloc(s->connection->pool,
-                         sizeof(ngx_rtmp_auto_push_ctx_t));
+        ctx = ngx_palloc(s->connection->pool, sizeof(ngx_rtmp_auto_push_ctx_t));
         if (ctx == NULL) {
             goto next;
         }
         ngx_rtmp_set_ctx(s, ctx, ngx_rtmp_auto_push_module);
-
     }
     ngx_memzero(ctx, sizeof(*ctx));
 
-    ctx->push_evt.data = s;
-    ctx->push_evt.log = s->connection->log;
+    ctx->push_evt.data    = s;
+    ctx->push_evt.log     = s->connection->log;
     ctx->push_evt.handler = ngx_rtmp_auto_push_reconnect;
 
-    ctx->slots = ngx_pcalloc(s->connection->pool,
-                             sizeof(ngx_int_t) * NGX_MAX_PROCESSES);
+    ctx->slots =
+        ngx_pcalloc(s->connection->pool, sizeof(ngx_int_t) * NGX_MAX_PROCESSES);
     if (ctx->slots == NULL) {
         goto next;
     }
@@ -492,18 +451,16 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
-    ngx_rtmp_delete_stream_t *v)
+static ngx_int_t ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
+                                                  ngx_rtmp_delete_stream_t *v)
 {
-    ngx_rtmp_auto_push_conf_t      *apcf;
-    ngx_rtmp_auto_push_ctx_t       *ctx, *pctx;
-    ngx_rtmp_relay_ctx_t           *rctx;
-    ngx_int_t                       slot;
+    ngx_rtmp_auto_push_conf_t *apcf;
+    ngx_rtmp_auto_push_ctx_t *ctx, *pctx;
+    ngx_rtmp_relay_ctx_t *rctx;
+    ngx_int_t slot;
 
-    apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
-                                                    ngx_rtmp_auto_push_module);
+    apcf = (ngx_rtmp_auto_push_conf_t *)ngx_get_conf(ngx_cycle->conf_ctx,
+                                                     ngx_rtmp_auto_push_module);
     if (apcf->auto_push == 0) {
         goto next;
     }
@@ -518,18 +475,16 @@ ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
 
     /* skip non-relays & publishers */
     rctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
-    if (rctx == NULL ||
-        rctx->tag != &ngx_rtmp_auto_push_module ||
-        rctx->publish == NULL)
-    {
+    if (rctx == NULL || rctx->tag != &ngx_rtmp_auto_push_module ||
+        rctx->publish == NULL) {
         goto next;
     }
 
-    slot = (ngx_process_t *) rctx->data - &ngx_processes[0];
+    slot = (ngx_process_t *)rctx->data - &ngx_processes[0];
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "auto_push: disconnect slot=%i app='%V' name='%V'",
-                   slot, &rctx->app, &rctx->name);
+                   "auto_push: disconnect slot=%i app='%V' name='%V'", slot,
+                   &rctx->app, &rctx->name);
 
     pctx = ngx_rtmp_get_module_ctx(rctx->publish->session,
                                    ngx_rtmp_auto_push_module);

--- a/ngx_rtmp_bandwidth.c
+++ b/ngx_rtmp_bandwidth.c
@@ -3,22 +3,19 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_bandwidth.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_bandwidth.h"
 
-
-void
-ngx_rtmp_update_bandwidth(ngx_rtmp_bandwidth_t *bw, uint32_t bytes)
+void ngx_rtmp_update_bandwidth(ngx_rtmp_bandwidth_t *bw, uint32_t bytes)
 {
     if (ngx_cached_time->sec > bw->intl_end) {
-        bw->bandwidth = ngx_cached_time->sec >
-            bw->intl_end + NGX_RTMP_BANDWIDTH_INTERVAL
-            ? 0
-            : bw->intl_bytes / NGX_RTMP_BANDWIDTH_INTERVAL;
+        bw->bandwidth =
+            ngx_cached_time->sec > bw->intl_end + NGX_RTMP_BANDWIDTH_INTERVAL
+                ? 0
+                : bw->intl_bytes / NGX_RTMP_BANDWIDTH_INTERVAL;
         bw->intl_bytes = 0;
-        bw->intl_end = ngx_cached_time->sec + NGX_RTMP_BANDWIDTH_INTERVAL;
+        bw->intl_end   = ngx_cached_time->sec + NGX_RTMP_BANDWIDTH_INTERVAL;
     }
 
     bw->bytes += bytes;

--- a/ngx_rtmp_bandwidth.h
+++ b/ngx_rtmp_bandwidth.h
@@ -3,29 +3,23 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_BANDWIDTH_H_INCLUDED_
 #define _NGX_RTMP_BANDWIDTH_H_INCLUDED_
-
 
 #include <ngx_config.h>
 #include <ngx_core.h>
 
-
 /* Bandwidth update interval in seconds */
-#define NGX_RTMP_BANDWIDTH_INTERVAL     10
-
+#define NGX_RTMP_BANDWIDTH_INTERVAL 10
 
 typedef struct {
-    uint64_t            bytes;
-    uint64_t            bandwidth;      /* bytes/sec */
+    uint64_t bytes;
+    uint64_t bandwidth; /* bytes/sec */
 
-    time_t              intl_end;
-    uint64_t            intl_bytes;
+    time_t intl_end;
+    uint64_t intl_bytes;
 } ngx_rtmp_bandwidth_t;
 
-
 void ngx_rtmp_update_bandwidth(ngx_rtmp_bandwidth_t *bw, uint32_t bytes);
-
 
 #endif /* _NGX_RTMP_BANDWIDTH_H_INCLUDED_ */

--- a/ngx_rtmp_bitop.c
+++ b/ngx_rtmp_bitop.c
@@ -3,41 +3,36 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_bitop.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_bitop.h"
 
-
-void
-ngx_rtmp_bit_init_reader(ngx_rtmp_bit_reader_t *br, u_char *pos, u_char *last)
+void ngx_rtmp_bit_init_reader(ngx_rtmp_bit_reader_t *br, u_char *pos,
+                              u_char *last)
 {
     ngx_memzero(br, sizeof(ngx_rtmp_bit_reader_t));
 
-    br->pos = pos;
+    br->pos  = pos;
     br->last = last;
 }
 
-
-uint64_t
-ngx_rtmp_bit_read(ngx_rtmp_bit_reader_t *br, ngx_uint_t n)
+uint64_t ngx_rtmp_bit_read(ngx_rtmp_bit_reader_t *br, ngx_uint_t n)
 {
-    uint64_t    v;
-    ngx_uint_t  d;
+    uint64_t v;
+    ngx_uint_t d;
 
     v = 0;
 
     while (n) {
-
         if (br->pos >= br->last) {
             br->err = 1;
             return 0;
         }
 
-        d = (br->offs + n > 8 ? (ngx_uint_t) (8 - br->offs) : n);
+        d = (br->offs + n > 8 ? (ngx_uint_t)(8 - br->offs) : n);
 
         v <<= d;
-        v += (*br->pos >> (8 - br->offs - d)) & ((u_char) 0xff >> (8 - d));
+        v += (*br->pos >> (8 - br->offs - d)) & ((u_char)0xff >> (8 - d));
 
         br->offs += d;
         n -= d;
@@ -51,13 +46,12 @@ ngx_rtmp_bit_read(ngx_rtmp_bit_reader_t *br, ngx_uint_t n)
     return v;
 }
 
-
-uint64_t
-ngx_rtmp_bit_read_golomb(ngx_rtmp_bit_reader_t *br)
+uint64_t ngx_rtmp_bit_read_golomb(ngx_rtmp_bit_reader_t *br)
 {
-    ngx_uint_t  n;
+    ngx_uint_t n;
 
-    for (n = 0; ngx_rtmp_bit_read(br, 1) == 0 && !br->err; n++);
+    for (n = 0; ngx_rtmp_bit_read(br, 1) == 0 && !br->err; n++)
+        ;
 
-    return ((uint64_t) 1 << n) + ngx_rtmp_bit_read(br, n) - 1;
+    return ((uint64_t)1 << n) + ngx_rtmp_bit_read(br, n) - 1;
 }

--- a/ngx_rtmp_bitop.h
+++ b/ngx_rtmp_bitop.h
@@ -3,44 +3,34 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_BITOP_H_INCLUDED_
 #define _NGX_RTMP_BITOP_H_INCLUDED_
-
 
 #include <ngx_config.h>
 #include <ngx_core.h>
 
-
 typedef struct {
-    u_char      *pos;
-    u_char      *last;
-    ngx_uint_t   offs;
-    ngx_uint_t   err;
+    u_char *pos;
+    u_char *last;
+    ngx_uint_t offs;
+    ngx_uint_t err;
 } ngx_rtmp_bit_reader_t;
 
-
 void ngx_rtmp_bit_init_reader(ngx_rtmp_bit_reader_t *br, u_char *pos,
-    u_char *last);
+                              u_char *last);
 uint64_t ngx_rtmp_bit_read(ngx_rtmp_bit_reader_t *br, ngx_uint_t n);
 uint64_t ngx_rtmp_bit_read_golomb(ngx_rtmp_bit_reader_t *br);
-
 
 #define ngx_rtmp_bit_read_err(br) ((br)->err)
 
 #define ngx_rtmp_bit_read_eof(br) ((br)->pos == (br)->last)
 
-#define ngx_rtmp_bit_read_8(br)                                               \
-    ((uint8_t) ngx_rtmp_bit_read(br, 8))
+#define ngx_rtmp_bit_read_8(br) ((uint8_t)ngx_rtmp_bit_read(br, 8))
 
-#define ngx_rtmp_bit_read_16(br)                                              \
-    ((uint16_t) ngx_rtmp_bit_read(br, 16))
+#define ngx_rtmp_bit_read_16(br) ((uint16_t)ngx_rtmp_bit_read(br, 16))
 
-#define ngx_rtmp_bit_read_32(br)                                              \
-    ((uint32_t) ngx_rtmp_bit_read(br, 32))
+#define ngx_rtmp_bit_read_32(br) ((uint32_t)ngx_rtmp_bit_read(br, 32))
 
-#define ngx_rtmp_bit_read_64(br)                                              \
-    ((uint64_t) ngx_rtmp_read(br, 64))
-
+#define ngx_rtmp_bit_read_64(br) ((uint64_t)ngx_rtmp_read(br, 64))
 
 #endif /* _NGX_RTMP_BITOP_H_INCLUDED_ */

--- a/ngx_rtmp_cmd_module.c
+++ b/ngx_rtmp_cmd_module.c
@@ -3,104 +3,92 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp_cmd_module.h"
 #include "ngx_rtmp_streams.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
-
-#define NGX_RTMP_FMS_VERSION        "FMS/3,0,1,123"
-#define NGX_RTMP_CAPABILITIES       31
-
+#define NGX_RTMP_FMS_VERSION "FMS/3,0,1,123"
+#define NGX_RTMP_CAPABILITIES 31
 
 static ngx_int_t ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s,
-       ngx_rtmp_connect_t *v);
+                                      ngx_rtmp_connect_t *v);
 static ngx_int_t ngx_rtmp_cmd_disconnect(ngx_rtmp_session_t *s);
 static ngx_int_t ngx_rtmp_cmd_create_stream(ngx_rtmp_session_t *s,
-       ngx_rtmp_create_stream_t *v);
+                                            ngx_rtmp_create_stream_t *v);
 static ngx_int_t ngx_rtmp_cmd_close_stream(ngx_rtmp_session_t *s,
-       ngx_rtmp_close_stream_t *v);
+                                           ngx_rtmp_close_stream_t *v);
 static ngx_int_t ngx_rtmp_cmd_delete_stream(ngx_rtmp_session_t *s,
-       ngx_rtmp_delete_stream_t *v);
+                                            ngx_rtmp_delete_stream_t *v);
 static ngx_int_t ngx_rtmp_cmd_publish(ngx_rtmp_session_t *s,
-       ngx_rtmp_publish_t *v);
-static ngx_int_t ngx_rtmp_cmd_play(ngx_rtmp_session_t *s,
-       ngx_rtmp_play_t *v);
-static ngx_int_t ngx_rtmp_cmd_seek(ngx_rtmp_session_t *s,
-       ngx_rtmp_seek_t *v);
-static ngx_int_t ngx_rtmp_cmd_pause(ngx_rtmp_session_t *s,
-       ngx_rtmp_pause_t *v);
-
+                                      ngx_rtmp_publish_t *v);
+static ngx_int_t ngx_rtmp_cmd_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v);
+static ngx_int_t ngx_rtmp_cmd_seek(ngx_rtmp_session_t *s, ngx_rtmp_seek_t *v);
+static ngx_int_t ngx_rtmp_cmd_pause(ngx_rtmp_session_t *s, ngx_rtmp_pause_t *v);
 
 static ngx_int_t ngx_rtmp_cmd_stream_begin(ngx_rtmp_session_t *s,
-       ngx_rtmp_stream_begin_t *v);
+                                           ngx_rtmp_stream_begin_t *v);
 static ngx_int_t ngx_rtmp_cmd_stream_eof(ngx_rtmp_session_t *s,
-       ngx_rtmp_stream_eof_t *v);
+                                         ngx_rtmp_stream_eof_t *v);
 static ngx_int_t ngx_rtmp_cmd_stream_dry(ngx_rtmp_session_t *s,
-       ngx_rtmp_stream_dry_t *v);
+                                         ngx_rtmp_stream_dry_t *v);
 static ngx_int_t ngx_rtmp_cmd_recorded(ngx_rtmp_session_t *s,
-       ngx_rtmp_recorded_t *v);
+                                       ngx_rtmp_recorded_t *v);
 static ngx_int_t ngx_rtmp_cmd_set_buflen(ngx_rtmp_session_t *s,
-       ngx_rtmp_set_buflen_t *v);
+                                         ngx_rtmp_set_buflen_t *v);
 
-static ngx_int_t ngx_rtmp_cmd_playlist(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v);
+static ngx_int_t ngx_rtmp_cmd_playlist(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_playlist_t *v);
 
-ngx_rtmp_connect_pt         ngx_rtmp_connect;
-ngx_rtmp_disconnect_pt      ngx_rtmp_disconnect;
-ngx_rtmp_create_stream_pt   ngx_rtmp_create_stream;
-ngx_rtmp_close_stream_pt    ngx_rtmp_close_stream;
-ngx_rtmp_delete_stream_pt   ngx_rtmp_delete_stream;
-ngx_rtmp_publish_pt         ngx_rtmp_publish;
-ngx_rtmp_play_pt            ngx_rtmp_play;
-ngx_rtmp_seek_pt            ngx_rtmp_seek;
-ngx_rtmp_pause_pt           ngx_rtmp_pause;
+ngx_rtmp_connect_pt ngx_rtmp_connect;
+ngx_rtmp_disconnect_pt ngx_rtmp_disconnect;
+ngx_rtmp_create_stream_pt ngx_rtmp_create_stream;
+ngx_rtmp_close_stream_pt ngx_rtmp_close_stream;
+ngx_rtmp_delete_stream_pt ngx_rtmp_delete_stream;
+ngx_rtmp_publish_pt ngx_rtmp_publish;
+ngx_rtmp_play_pt ngx_rtmp_play;
+ngx_rtmp_seek_pt ngx_rtmp_seek;
+ngx_rtmp_pause_pt ngx_rtmp_pause;
 
+ngx_rtmp_stream_begin_pt ngx_rtmp_stream_begin;
+ngx_rtmp_stream_eof_pt ngx_rtmp_stream_eof;
+ngx_rtmp_stream_dry_pt ngx_rtmp_stream_dry;
+ngx_rtmp_recorded_pt ngx_rtmp_recorded;
+ngx_rtmp_set_buflen_pt ngx_rtmp_set_buflen;
 
-ngx_rtmp_stream_begin_pt    ngx_rtmp_stream_begin;
-ngx_rtmp_stream_eof_pt      ngx_rtmp_stream_eof;
-ngx_rtmp_stream_dry_pt      ngx_rtmp_stream_dry;
-ngx_rtmp_recorded_pt        ngx_rtmp_recorded;
-ngx_rtmp_set_buflen_pt      ngx_rtmp_set_buflen;
-
-ngx_rtmp_playlist_pt        ngx_rtmp_playlist;
+ngx_rtmp_playlist_pt ngx_rtmp_playlist;
 
 static ngx_int_t ngx_rtmp_cmd_postconfiguration(ngx_conf_t *cf);
 
-
-static ngx_rtmp_module_t  ngx_rtmp_cmd_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_cmd_postconfiguration,         /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    NULL,                                   /* create app configuration */
-    NULL                                    /* merge app configuration */
+static ngx_rtmp_module_t ngx_rtmp_cmd_module_ctx = {
+    NULL,                           /* preconfiguration */
+    ngx_rtmp_cmd_postconfiguration, /* postconfiguration */
+    NULL,                           /* create main configuration */
+    NULL,                           /* init main configuration */
+    NULL,                           /* create server configuration */
+    NULL,                           /* merge server configuration */
+    NULL,                           /* create app configuration */
+    NULL                            /* merge app configuration */
 };
 
-
-ngx_module_t  ngx_rtmp_cmd_module = {
+ngx_module_t ngx_rtmp_cmd_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_cmd_module_ctx,               /* module context */
-    NULL,                                   /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_cmd_module_ctx, /* module context */
+    NULL,                     /* module directives */
+    NGX_RTMP_MODULE,          /* module type */
+    NULL,                     /* init master */
+    NULL,                     /* init module */
+    NULL,                     /* init process */
+    NULL,                     /* init thread */
+    NULL,                     /* exit thread */
+    NULL,                     /* exit process */
+    NULL,                     /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-void
-ngx_rtmp_cmd_fill_args(u_char name[NGX_RTMP_MAX_NAME],
-        u_char args[NGX_RTMP_MAX_ARGS])
+void ngx_rtmp_cmd_fill_args(u_char name[NGX_RTMP_MAX_NAME],
+                            u_char args[NGX_RTMP_MAX_ARGS])
 {
-    u_char      *p;
+    u_char *p;
 
     p = (u_char *)ngx_strchr(name, '?');
     if (p == NULL) {
@@ -111,65 +99,49 @@ ngx_rtmp_cmd_fill_args(u_char name[NGX_RTMP_MAX_NAME],
     ngx_cpystrn(args, p, NGX_RTMP_MAX_ARGS);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_connect_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_connect_init(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_header_t *h,
+                                           ngx_chain_t *in)
 {
-    size_t                      len;
+    size_t len;
 
-    static ngx_rtmp_connect_t   v;
+    static ngx_rtmp_connect_t v;
 
-    static ngx_rtmp_amf_elt_t  in_cmd[] = {
+    static ngx_rtmp_amf_elt_t in_cmd[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("app"),
-          v.app, sizeof(v.app) },
+        {NGX_RTMP_AMF_STRING, ngx_string("app"), v.app, sizeof(v.app)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("flashVer"),
-          v.flashver, sizeof(v.flashver) },
+        {NGX_RTMP_AMF_STRING, ngx_string("flashVer"), v.flashver,
+         sizeof(v.flashver)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("swfUrl"),
-          v.swf_url, sizeof(v.swf_url) },
+        {NGX_RTMP_AMF_STRING, ngx_string("swfUrl"), v.swf_url,
+         sizeof(v.swf_url)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("tcUrl"),
-          v.tc_url, sizeof(v.tc_url) },
+        {NGX_RTMP_AMF_STRING, ngx_string("tcUrl"), v.tc_url, sizeof(v.tc_url)},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audioCodecs"),
-          &v.acodecs, sizeof(v.acodecs) },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audioCodecs"), &v.acodecs,
+         sizeof(v.acodecs)},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videoCodecs"),
-          &v.vcodecs, sizeof(v.vcodecs) },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videoCodecs"), &v.vcodecs,
+         sizeof(v.vcodecs)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("pageUrl"),
-          v.page_url, sizeof(v.page_url) },
+        {NGX_RTMP_AMF_STRING, ngx_string("pageUrl"), v.page_url,
+         sizeof(v.page_url)},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("objectEncoding"),
-          &v.object_encoding, 0},
+        {NGX_RTMP_AMF_NUMBER, ngx_string("objectEncoding"), &v.object_encoding,
+         0},
     };
 
-    static ngx_rtmp_amf_elt_t  in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.trans, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_cmd, sizeof(in_cmd) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_cmd, sizeof(in_cmd)},
     };
 
     ngx_memzero(&v, sizeof(v));
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
@@ -183,82 +155,63 @@ ngx_rtmp_cmd_connect_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ngx_rtmp_cmd_fill_args(v.app, v.args);
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "connect: app='%s' args='%s' flashver='%s' swf_url='%s' "
-            "tc_url='%s' page_url='%s' acodecs=%uD vcodecs=%uD "
-            "object_encoding=%ui",
-            v.app, v.args, v.flashver, v.swf_url, v.tc_url, v.page_url,
-            (uint32_t)v.acodecs, (uint32_t)v.vcodecs,
-            (ngx_int_t)v.object_encoding);
+                  "connect: app='%s' args='%s' flashver='%s' swf_url='%s' "
+                  "tc_url='%s' page_url='%s' acodecs=%uD vcodecs=%uD "
+                  "object_encoding=%ui",
+                  v.app, v.args, v.flashver, v.swf_url, v.tc_url, v.page_url,
+                  (uint32_t)v.acodecs, (uint32_t)v.vcodecs,
+                  (ngx_int_t)v.object_encoding);
 
     return ngx_rtmp_connect(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
+static ngx_int_t ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s,
+                                      ngx_rtmp_connect_t *v)
 {
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_rtmp_core_app_conf_t  **cacfp;
-    ngx_uint_t                  n;
-    ngx_rtmp_header_t           h;
-    u_char                     *p;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_rtmp_core_app_conf_t **cacfp;
+    ngx_uint_t n;
+    ngx_rtmp_header_t h;
+    u_char *p;
 
-    static double               trans;
-    static double               capabilities = NGX_RTMP_CAPABILITIES;
-    static double               object_encoding = 0;
+    static double trans;
+    static double capabilities    = NGX_RTMP_CAPABILITIES;
+    static double object_encoding = 0;
 
-    static ngx_rtmp_amf_elt_t  out_obj[] = {
+    static ngx_rtmp_amf_elt_t out_obj[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("fmsVer"),
-          NGX_RTMP_FMS_VERSION, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("fmsVer"), NGX_RTMP_FMS_VERSION, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("capabilities"),
-          &capabilities, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("capabilities"), &capabilities, 0},
     };
 
-    static ngx_rtmp_amf_elt_t  out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          "status", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), "status", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          "NetConnection.Connect.Success", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"),
+         "NetConnection.Connect.Success", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          "Connection succeeded.", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"),
+         "Connection succeeded.", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("objectEncoding"),
-          &object_encoding, 0 }
-    };
+        {NGX_RTMP_AMF_NUMBER, ngx_string("objectEncoding"), &object_encoding,
+         0}};
 
-    static ngx_rtmp_amf_elt_t  out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "_result", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "_result", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_obj, sizeof(out_obj) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_obj, sizeof(out_obj)},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf, sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     if (s->connected) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "connect: duplicate connection");
+                      "connect: duplicate connection");
         return NGX_ERROR;
     }
 
@@ -273,10 +226,9 @@ ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
     h.csid = NGX_RTMP_CSID_AMF_INI;
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
-
-#define NGX_RTMP_SET_STRPAR(name)                                             \
-    s->name.len = ngx_strlen(v->name);                                        \
-    s->name.data = ngx_palloc(s->connection->pool, s->name.len);              \
+#define NGX_RTMP_SET_STRPAR(name)                                              \
+    s->name.len  = ngx_strlen(v->name);                                        \
+    s->name.data = ngx_palloc(s->connection->pool, s->name.len);               \
     ngx_memcpy(s->name.data, v->name, s->name.len)
 
     NGX_RTMP_SET_STRPAR(app);
@@ -293,15 +245,14 @@ ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
         s->app.len = (p - s->app.data);
     }
 
-    s->acodecs = (uint32_t) v->acodecs;
-    s->vcodecs = (uint32_t) v->vcodecs;
+    s->acodecs = (uint32_t)v->acodecs;
+    s->vcodecs = (uint32_t)v->vcodecs;
 
     /* find application & set app_conf */
     cacfp = cscf->applications.elts;
-    for(n = 0; n < cscf->applications.nelts; ++n, ++cacfp) {
+    for (n = 0; n < cscf->applications.nelts; ++n, ++cacfp) {
         if ((*cacfp)->name.len == s->app.len &&
-            ngx_strncmp((*cacfp)->name.data, s->app.data, s->app.len) == 0)
-        {
+            ngx_strncmp((*cacfp)->name.data, s->app.data, s->app.len) == 0) {
             /* found app! */
             s->app_conf = (*cacfp)->app_conf;
             break;
@@ -317,31 +268,29 @@ ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
     object_encoding = v->object_encoding;
 
     return ngx_rtmp_send_ack_size(s, cscf->ack_window) != NGX_OK ||
-           ngx_rtmp_send_bandwidth(s, cscf->ack_window,
-                                   NGX_RTMP_LIMIT_DYNAMIC) != NGX_OK ||
-           ngx_rtmp_send_chunk_size(s, cscf->chunk_size) != NGX_OK ||
-           ngx_rtmp_send_amf(s, &h, out_elts,
-                             sizeof(out_elts) / sizeof(out_elts[0]))
-           != NGX_OK ? NGX_ERROR : NGX_OK;
+                   ngx_rtmp_send_bandwidth(s, cscf->ack_window,
+                                           NGX_RTMP_LIMIT_DYNAMIC) != NGX_OK ||
+                   ngx_rtmp_send_chunk_size(s, cscf->chunk_size) != NGX_OK ||
+                   ngx_rtmp_send_amf(s, &h, out_elts,
+                                     sizeof(out_elts) / sizeof(out_elts[0])) !=
+                       NGX_OK
+               ? NGX_ERROR
+               : NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_create_stream_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                                ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_create_stream_init(ngx_rtmp_session_t *s,
+                                                 ngx_rtmp_header_t *h,
+                                                 ngx_chain_t *in)
 {
-    static ngx_rtmp_create_stream_t     v;
+    static ngx_rtmp_create_stream_t v;
 
-    static ngx_rtmp_amf_elt_t  in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.trans, sizeof(v.trans) },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.trans, sizeof(v.trans)},
     };
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
@@ -350,35 +299,26 @@ ngx_rtmp_cmd_create_stream_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_create_stream(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_create_stream(ngx_rtmp_session_t *s, ngx_rtmp_create_stream_t *v)
+static ngx_int_t ngx_rtmp_cmd_create_stream(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_create_stream_t *v)
 {
     /* support one message stream per connection */
-    static double               stream;
-    static double               trans;
-    ngx_rtmp_header_t           h;
+    static double stream;
+    static double trans;
+    ngx_rtmp_header_t h;
 
-    static ngx_rtmp_amf_elt_t  out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "_result", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "_result", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &stream, sizeof(stream) },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &stream, sizeof(stream)},
     };
 
-    trans = v->trans;
+    trans  = v->trans;
     stream = NGX_RTMP_MSID;
 
     ngx_memzero(&h, sizeof(h));
@@ -387,27 +327,24 @@ ngx_rtmp_cmd_create_stream(ngx_rtmp_session_t *s, ngx_rtmp_create_stream_t *v)
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
     return ngx_rtmp_send_amf(s, &h, out_elts,
-                             sizeof(out_elts) / sizeof(out_elts[0])) == NGX_OK ?
-           NGX_DONE : NGX_ERROR;
+                             sizeof(out_elts) / sizeof(out_elts[0])) == NGX_OK
+               ? NGX_DONE
+               : NGX_ERROR;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_close_stream_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                               ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_close_stream_init(ngx_rtmp_session_t *s,
+                                                ngx_rtmp_header_t *h,
+                                                ngx_chain_t *in)
 {
-    static ngx_rtmp_close_stream_t     v;
+    static ngx_rtmp_close_stream_t v;
 
-    static ngx_rtmp_amf_elt_t  in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.stream, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.stream, 0},
     };
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
@@ -416,49 +353,39 @@ ngx_rtmp_cmd_close_stream_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_close_stream(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_close_stream(ngx_rtmp_session_t *s, ngx_rtmp_close_stream_t *v)
+static ngx_int_t ngx_rtmp_cmd_close_stream(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_close_stream_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_delete_stream_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                                ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_delete_stream_init(ngx_rtmp_session_t *s,
+                                                 ngx_rtmp_header_t *h,
+                                                 ngx_chain_t *in)
 {
-    static ngx_rtmp_delete_stream_t     v;
+    static ngx_rtmp_delete_stream_t v;
 
-    static ngx_rtmp_amf_elt_t  in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.stream, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.stream, 0},
     };
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     return ngx_rtmp_delete_stream(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_delete_stream(ngx_rtmp_session_t *s, ngx_rtmp_delete_stream_t *v)
+static ngx_int_t ngx_rtmp_cmd_delete_stream(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_delete_stream_t *v)
 {
-    ngx_rtmp_close_stream_t         cv;
+    ngx_rtmp_close_stream_t cv;
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "deleteStream");
 
@@ -467,96 +394,74 @@ ngx_rtmp_cmd_delete_stream(ngx_rtmp_session_t *s, ngx_rtmp_delete_stream_t *v)
     return ngx_rtmp_close_stream(s, &cv);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_publish_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_publish_init(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_header_t *h,
+                                           ngx_chain_t *in)
 {
-    static ngx_rtmp_publish_t       v;
+    static ngx_rtmp_publish_t v;
 
-    static ngx_rtmp_amf_elt_t      in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
         /* transaction is always 0 */
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          &v.name, sizeof(v.name) },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, &v.name, sizeof(v.name)},
 
-        { NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          &v.type, sizeof(v.type) },
+        {NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_STRING, ngx_null_string, &v.type,
+         sizeof(v.type)},
     };
 
     ngx_memzero(&v, sizeof(v));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     ngx_rtmp_cmd_fill_args(v.name, v.args);
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "publish: name='%s' args='%s' type=%s silent=%d",
-                  v.name, v.args, v.type, v.silent);
+                  "publish: name='%s' args='%s' type=%s silent=%d", v.name,
+                  v.args, v.type, v.silent);
 
     return ngx_rtmp_publish(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_cmd_publish(ngx_rtmp_session_t *s,
+                                      ngx_rtmp_publish_t *v)
 {
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_cmd_play_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_play_init(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    static ngx_rtmp_play_t          v;
+    static ngx_rtmp_play_t v;
 
-    static ngx_rtmp_amf_elt_t       in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
         /* transaction is always 0 */
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          &v.name, sizeof(v.name) },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, &v.name, sizeof(v.name)},
 
-        { NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.start, 0 },
+        {NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.start,
+         0},
 
-        { NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.duration, 0 },
+        {NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_NUMBER, ngx_null_string,
+         &v.duration, 0},
 
-        { NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_BOOLEAN,
-          ngx_null_string,
-          &v.reset, 0 }
-    };
+        {NGX_RTMP_AMF_OPTIONAL | NGX_RTMP_AMF_BOOLEAN, ngx_null_string,
+         &v.reset, 0}};
 
     ngx_memzero(&v, sizeof(v));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
@@ -565,70 +470,54 @@ ngx_rtmp_cmd_play_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                   "play: name='%s' args='%s' start=%i duration=%i "
                   "reset=%i silent=%i",
-                  v.name, v.args, (ngx_int_t) v.start,
-                  (ngx_int_t) v.duration, (ngx_int_t) v.reset,
-                  (ngx_int_t) v.silent);
+                  v.name, v.args, (ngx_int_t)v.start, (ngx_int_t)v.duration,
+                  (ngx_int_t)v.reset, (ngx_int_t)v.silent);
 
     return ngx_rtmp_play(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
+static ngx_int_t ngx_rtmp_cmd_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
                   "cmd: ngx_rtmp_cmd_play");
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_play2_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_play2_init(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    static ngx_rtmp_play_t          v;
-    static ngx_rtmp_close_stream_t  vc;
+    static ngx_rtmp_play_t v;
+    static ngx_rtmp_close_stream_t vc;
 
-    static ngx_rtmp_amf_elt_t       in_obj[] = {
+    static ngx_rtmp_amf_elt_t in_obj[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("start"),
-          &v.start, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("start"), &v.start, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("streamName"),
-          &v.name, sizeof(v.name) },
+        {NGX_RTMP_AMF_STRING, ngx_string("streamName"), &v.name,
+         sizeof(v.name)},
     };
 
-    static ngx_rtmp_amf_elt_t       in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
         /* transaction is always 0 */
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          &in_obj, sizeof(in_obj) }
-    };
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, &in_obj, sizeof(in_obj)}};
 
     ngx_memzero(&v, sizeof(v));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     ngx_rtmp_cmd_fill_args(v.name, v.args);
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "play2: name='%s' args='%s' start=%i",
-                  v.name, v.args, (ngx_int_t) v.start);
+                  "play2: name='%s' args='%s' start=%i", v.name, v.args,
+                  (ngx_int_t)v.start);
 
     /* continue from current timestamp */
 
@@ -644,181 +533,143 @@ ngx_rtmp_cmd_play2_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_play(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_pause_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_pause_init(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    static ngx_rtmp_pause_t     v;
+    static ngx_rtmp_pause_t v;
 
-    static ngx_rtmp_amf_elt_t   in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_BOOLEAN,
-          ngx_null_string,
-          &v.pause, 0 },
+        {NGX_RTMP_AMF_BOOLEAN, ngx_null_string, &v.pause, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.position, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.position, 0},
     };
 
     ngx_memzero(&v, sizeof(v));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "pause: pause=%i position=%i",
-                    (ngx_int_t) v.pause, (ngx_int_t) v.position);
+                   "pause: pause=%i position=%i", (ngx_int_t)v.pause,
+                   (ngx_int_t)v.position);
 
     return ngx_rtmp_pause(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_pause(ngx_rtmp_session_t *s, ngx_rtmp_pause_t *v)
+static ngx_int_t ngx_rtmp_cmd_pause(ngx_rtmp_session_t *s, ngx_rtmp_pause_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_disconnect_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_disconnect_init(ngx_rtmp_session_t *s,
+                                              ngx_rtmp_header_t *h,
+                                              ngx_chain_t *in)
 {
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "disconnect");
 
     return ngx_rtmp_disconnect(s);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_disconnect(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_cmd_disconnect(ngx_rtmp_session_t *s)
 {
     return ngx_rtmp_delete_stream(s, NULL);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_seek_init(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_cmd_seek_init(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    static ngx_rtmp_seek_t         v;
+    static ngx_rtmp_seek_t v;
 
-    static ngx_rtmp_amf_elt_t      in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
         /* transaction is always 0 */
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.offset, sizeof(v.offset) },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.offset, sizeof(v.offset)},
     };
 
     ngx_memzero(&v, sizeof(v));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "seek: offset=%i", (ngx_int_t) v.offset);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "seek: offset=%i",
+                  (ngx_int_t)v.offset);
 
     return ngx_rtmp_seek(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_seek(ngx_rtmp_session_t *s, ngx_rtmp_seek_t *v)
+static ngx_int_t ngx_rtmp_cmd_seek(ngx_rtmp_session_t *s, ngx_rtmp_seek_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_stream_begin(ngx_rtmp_session_t *s, ngx_rtmp_stream_begin_t *v)
+static ngx_int_t ngx_rtmp_cmd_stream_begin(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_stream_begin_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_stream_eof(ngx_rtmp_session_t *s, ngx_rtmp_stream_eof_t *v)
+static ngx_int_t ngx_rtmp_cmd_stream_eof(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_stream_eof_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_stream_dry(ngx_rtmp_session_t *s, ngx_rtmp_stream_dry_t *v)
+static ngx_int_t ngx_rtmp_cmd_stream_dry(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_stream_dry_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_recorded(ngx_rtmp_session_t *s,
-                      ngx_rtmp_recorded_t *v)
+static ngx_int_t ngx_rtmp_cmd_recorded(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_recorded_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_set_buflen(ngx_rtmp_session_t *s, ngx_rtmp_set_buflen_t *v)
+static ngx_int_t ngx_rtmp_cmd_set_buflen(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_set_buflen_t *v)
 {
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_cmd_playlist(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v)
+static ngx_int_t ngx_rtmp_cmd_playlist(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_playlist_t *v)
 {
     return NGX_OK;
 }
-
-
 
 static ngx_rtmp_amf_handler_t ngx_rtmp_cmd_map[] = {
-    { ngx_string("connect"),            ngx_rtmp_cmd_connect_init           },
-    { ngx_string("createStream"),       ngx_rtmp_cmd_create_stream_init     },
-    { ngx_string("closeStream"),        ngx_rtmp_cmd_close_stream_init      },
-    { ngx_string("deleteStream"),       ngx_rtmp_cmd_delete_stream_init     },
-    { ngx_string("publish"),            ngx_rtmp_cmd_publish_init           },
-    { ngx_string("play"),               ngx_rtmp_cmd_play_init              },
-    { ngx_string("play2"),              ngx_rtmp_cmd_play2_init             },
-    { ngx_string("seek"),               ngx_rtmp_cmd_seek_init              },
-    { ngx_string("pause"),              ngx_rtmp_cmd_pause_init             },
-    { ngx_string("pauseraw"),           ngx_rtmp_cmd_pause_init             },
+    {ngx_string("connect"), ngx_rtmp_cmd_connect_init},
+    {ngx_string("createStream"), ngx_rtmp_cmd_create_stream_init},
+    {ngx_string("closeStream"), ngx_rtmp_cmd_close_stream_init},
+    {ngx_string("deleteStream"), ngx_rtmp_cmd_delete_stream_init},
+    {ngx_string("publish"), ngx_rtmp_cmd_publish_init},
+    {ngx_string("play"), ngx_rtmp_cmd_play_init},
+    {ngx_string("play2"), ngx_rtmp_cmd_play2_init},
+    {ngx_string("seek"), ngx_rtmp_cmd_seek_init},
+    {ngx_string("pause"), ngx_rtmp_cmd_pause_init},
+    {ngx_string("pauseraw"), ngx_rtmp_cmd_pause_init},
 };
 
-
-static ngx_int_t
-ngx_rtmp_cmd_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_cmd_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_core_main_conf_t          *cmcf;
-    ngx_rtmp_handler_pt                *h;
-    ngx_rtmp_amf_handler_t             *ch, *bh;
-    size_t                              n, ncalls;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_rtmp_handler_pt *h;
+    ngx_rtmp_amf_handler_t *ch, *bh;
+    size_t n, ncalls;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
@@ -844,25 +695,25 @@ ngx_rtmp_cmd_postconfiguration(ngx_conf_t *cf)
 
     bh = ngx_rtmp_cmd_map;
 
-    for(n = 0; n < ncalls; ++n, ++ch, ++bh) {
+    for (n = 0; n < ncalls; ++n, ++ch, ++bh) {
         *ch = *bh;
     }
 
-    ngx_rtmp_connect = ngx_rtmp_cmd_connect;
-    ngx_rtmp_disconnect = ngx_rtmp_cmd_disconnect;
+    ngx_rtmp_connect       = ngx_rtmp_cmd_connect;
+    ngx_rtmp_disconnect    = ngx_rtmp_cmd_disconnect;
     ngx_rtmp_create_stream = ngx_rtmp_cmd_create_stream;
-    ngx_rtmp_close_stream = ngx_rtmp_cmd_close_stream;
+    ngx_rtmp_close_stream  = ngx_rtmp_cmd_close_stream;
     ngx_rtmp_delete_stream = ngx_rtmp_cmd_delete_stream;
-    ngx_rtmp_publish = ngx_rtmp_cmd_publish;
-    ngx_rtmp_play = ngx_rtmp_cmd_play;
-    ngx_rtmp_seek = ngx_rtmp_cmd_seek;
-    ngx_rtmp_pause = ngx_rtmp_cmd_pause;
+    ngx_rtmp_publish       = ngx_rtmp_cmd_publish;
+    ngx_rtmp_play          = ngx_rtmp_cmd_play;
+    ngx_rtmp_seek          = ngx_rtmp_cmd_seek;
+    ngx_rtmp_pause         = ngx_rtmp_cmd_pause;
 
     ngx_rtmp_stream_begin = ngx_rtmp_cmd_stream_begin;
-    ngx_rtmp_stream_eof = ngx_rtmp_cmd_stream_eof;
-    ngx_rtmp_stream_dry = ngx_rtmp_cmd_stream_dry;
-    ngx_rtmp_recorded = ngx_rtmp_cmd_recorded;
-    ngx_rtmp_set_buflen = ngx_rtmp_cmd_set_buflen;
+    ngx_rtmp_stream_eof   = ngx_rtmp_cmd_stream_eof;
+    ngx_rtmp_stream_dry   = ngx_rtmp_cmd_stream_dry;
+    ngx_rtmp_recorded     = ngx_rtmp_cmd_recorded;
+    ngx_rtmp_set_buflen   = ngx_rtmp_cmd_set_buflen;
 
     ngx_rtmp_playlist = ngx_rtmp_cmd_playlist;
 

--- a/ngx_rtmp_cmd_module.h
+++ b/ngx_rtmp_cmd_module.h
@@ -3,157 +3,141 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_CMD_H_INCLUDED_
 #define _NGX_RTMP_CMD_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_event.h>
-#include "ngx_rtmp.h"
 
-
-#define NGX_RTMP_MAX_NAME           2048
-#define NGX_RTMP_MAX_URL            4096
-#define NGX_RTMP_MAX_ARGS           NGX_RTMP_MAX_NAME
-
+#define NGX_RTMP_MAX_NAME 2048
+#define NGX_RTMP_MAX_URL 4096
+#define NGX_RTMP_MAX_ARGS NGX_RTMP_MAX_NAME
 
 /* Basic RTMP call support */
 
 typedef struct {
-    double                          trans;
-    u_char                          app[NGX_RTMP_MAX_NAME];
-    u_char                          args[NGX_RTMP_MAX_ARGS];
-    u_char                          flashver[32];
-    u_char                          swf_url[NGX_RTMP_MAX_URL];
-    u_char                          tc_url[NGX_RTMP_MAX_URL];
-    double                          acodecs;
-    double                          vcodecs;
-    u_char                          page_url[NGX_RTMP_MAX_URL];
-    double                          object_encoding;
+    double trans;
+    u_char app[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    u_char flashver[32];
+    u_char swf_url[NGX_RTMP_MAX_URL];
+    u_char tc_url[NGX_RTMP_MAX_URL];
+    double acodecs;
+    double vcodecs;
+    u_char page_url[NGX_RTMP_MAX_URL];
+    double object_encoding;
 } ngx_rtmp_connect_t;
 
-
 typedef struct {
-    double                          trans;
-    double                          stream;
+    double trans;
+    double stream;
 } ngx_rtmp_create_stream_t;
 
-
 typedef struct {
-    double                          stream;
+    double stream;
 } ngx_rtmp_delete_stream_t;
 
-
 typedef struct {
-    double                          stream;
+    double stream;
 } ngx_rtmp_close_stream_t;
 
-
 typedef struct {
-    u_char                          name[NGX_RTMP_MAX_NAME];
-    u_char                          args[NGX_RTMP_MAX_ARGS];
-    u_char                          type[16];
-    int                             silent;
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    u_char type[16];
+    int silent;
 } ngx_rtmp_publish_t;
 
-
 typedef struct {
-    ngx_str_t                       playlist;
-    ngx_str_t                       module;
+    ngx_str_t playlist;
+    ngx_str_t module;
 } ngx_rtmp_playlist_t;
 
-
 typedef struct {
-    u_char                          name[NGX_RTMP_MAX_NAME];
-    u_char                          args[NGX_RTMP_MAX_ARGS];
-    double                          start;
-    double                          duration;
-    int                             reset;
-    int                             silent;
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    double start;
+    double duration;
+    int reset;
+    int silent;
 } ngx_rtmp_play_t;
 
-
 typedef struct {
-    double                          offset;
+    double offset;
 } ngx_rtmp_seek_t;
 
-
 typedef struct {
-    uint8_t                         pause;
-    double                          position;
+    uint8_t pause;
+    double position;
 } ngx_rtmp_pause_t;
 
-
 typedef struct {
-    uint32_t                        msid;
+    uint32_t msid;
 } ngx_rtmp_msid_t;
 
-
-typedef ngx_rtmp_msid_t             ngx_rtmp_stream_begin_t;
-typedef ngx_rtmp_msid_t             ngx_rtmp_stream_eof_t;
-typedef ngx_rtmp_msid_t             ngx_rtmp_stream_dry_t;
-typedef ngx_rtmp_msid_t             ngx_rtmp_recorded_t;
-
+typedef ngx_rtmp_msid_t ngx_rtmp_stream_begin_t;
+typedef ngx_rtmp_msid_t ngx_rtmp_stream_eof_t;
+typedef ngx_rtmp_msid_t ngx_rtmp_stream_dry_t;
+typedef ngx_rtmp_msid_t ngx_rtmp_recorded_t;
 
 typedef struct {
-    uint32_t                        msid;
-    uint32_t                        buflen;
+    uint32_t msid;
+    uint32_t buflen;
 } ngx_rtmp_set_buflen_t;
 
-
 void ngx_rtmp_cmd_fill_args(u_char name[NGX_RTMP_MAX_NAME],
-        u_char args[NGX_RTMP_MAX_ARGS]);
-
+                            u_char args[NGX_RTMP_MAX_ARGS]);
 
 typedef ngx_int_t (*ngx_rtmp_connect_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_connect_t *v);
+                                         ngx_rtmp_connect_t *v);
 typedef ngx_int_t (*ngx_rtmp_disconnect_pt)(ngx_rtmp_session_t *s);
 typedef ngx_int_t (*ngx_rtmp_create_stream_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_create_stream_t *v);
+                                               ngx_rtmp_create_stream_t *v);
 typedef ngx_int_t (*ngx_rtmp_close_stream_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_close_stream_t *v);
+                                              ngx_rtmp_close_stream_t *v);
 typedef ngx_int_t (*ngx_rtmp_delete_stream_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_delete_stream_t *v);
+                                               ngx_rtmp_delete_stream_t *v);
 typedef ngx_int_t (*ngx_rtmp_publish_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_publish_t *v);
+                                         ngx_rtmp_publish_t *v);
 typedef ngx_int_t (*ngx_rtmp_play_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_play_t *v);
+                                      ngx_rtmp_play_t *v);
 typedef ngx_int_t (*ngx_rtmp_seek_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_seek_t *v);
+                                      ngx_rtmp_seek_t *v);
 typedef ngx_int_t (*ngx_rtmp_pause_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_pause_t *v);
+                                       ngx_rtmp_pause_t *v);
 
 typedef ngx_int_t (*ngx_rtmp_stream_begin_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_stream_begin_t *v);
+                                              ngx_rtmp_stream_begin_t *v);
 typedef ngx_int_t (*ngx_rtmp_stream_eof_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_stream_eof_t *v);
+                                            ngx_rtmp_stream_eof_t *v);
 typedef ngx_int_t (*ngx_rtmp_stream_dry_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_stream_dry_t *v);
+                                            ngx_rtmp_stream_dry_t *v);
 typedef ngx_int_t (*ngx_rtmp_recorded_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_recorded_t *v);
+                                          ngx_rtmp_recorded_t *v);
 typedef ngx_int_t (*ngx_rtmp_set_buflen_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_set_buflen_t *v);
+                                            ngx_rtmp_set_buflen_t *v);
 
-typedef ngx_int_t (*ngx_rtmp_playlist_pt)(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v);
+typedef ngx_int_t (*ngx_rtmp_playlist_pt)(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_playlist_t *v);
 
-extern ngx_rtmp_connect_pt          ngx_rtmp_connect;
-extern ngx_rtmp_disconnect_pt       ngx_rtmp_disconnect;
-extern ngx_rtmp_create_stream_pt    ngx_rtmp_create_stream;
-extern ngx_rtmp_close_stream_pt     ngx_rtmp_close_stream;
-extern ngx_rtmp_delete_stream_pt    ngx_rtmp_delete_stream;
-extern ngx_rtmp_publish_pt          ngx_rtmp_publish;
-extern ngx_rtmp_play_pt             ngx_rtmp_play;
-extern ngx_rtmp_seek_pt             ngx_rtmp_seek;
-extern ngx_rtmp_pause_pt            ngx_rtmp_pause;
+extern ngx_rtmp_connect_pt ngx_rtmp_connect;
+extern ngx_rtmp_disconnect_pt ngx_rtmp_disconnect;
+extern ngx_rtmp_create_stream_pt ngx_rtmp_create_stream;
+extern ngx_rtmp_close_stream_pt ngx_rtmp_close_stream;
+extern ngx_rtmp_delete_stream_pt ngx_rtmp_delete_stream;
+extern ngx_rtmp_publish_pt ngx_rtmp_publish;
+extern ngx_rtmp_play_pt ngx_rtmp_play;
+extern ngx_rtmp_seek_pt ngx_rtmp_seek;
+extern ngx_rtmp_pause_pt ngx_rtmp_pause;
 
-extern ngx_rtmp_stream_begin_pt     ngx_rtmp_stream_begin;
-extern ngx_rtmp_stream_eof_pt       ngx_rtmp_stream_eof;
-extern ngx_rtmp_stream_dry_pt       ngx_rtmp_stream_dry;
-extern ngx_rtmp_set_buflen_pt       ngx_rtmp_set_buflen;
-extern ngx_rtmp_recorded_pt         ngx_rtmp_recorded;
+extern ngx_rtmp_stream_begin_pt ngx_rtmp_stream_begin;
+extern ngx_rtmp_stream_eof_pt ngx_rtmp_stream_eof;
+extern ngx_rtmp_stream_dry_pt ngx_rtmp_stream_dry;
+extern ngx_rtmp_set_buflen_pt ngx_rtmp_set_buflen;
+extern ngx_rtmp_recorded_pt ngx_rtmp_recorded;
 
-extern ngx_rtmp_playlist_pt         ngx_rtmp_playlist;
+extern ngx_rtmp_playlist_pt ngx_rtmp_playlist;
 
 #endif /*_NGX_RTMP_CMD_H_INCLUDED_ */

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -3,151 +3,121 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_codec_module.h"
+#include "ngx_rtmp_bitop.h"
+#include "ngx_rtmp_cmd_module.h"
+#include "ngx_rtmp_live_module.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_codec_module.h"
-#include "ngx_rtmp_live_module.h"
-#include "ngx_rtmp_cmd_module.h"
-#include "ngx_rtmp_bitop.h"
 
+#define NGX_RTMP_CODEC_META_OFF 0
+#define NGX_RTMP_CODEC_META_ON 1
+#define NGX_RTMP_CODEC_META_COPY 2
 
-#define NGX_RTMP_CODEC_META_OFF     0
-#define NGX_RTMP_CODEC_META_ON      1
-#define NGX_RTMP_CODEC_META_COPY    2
-
-
-static void * ngx_rtmp_codec_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_codec_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
+static void *ngx_rtmp_codec_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_codec_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                           void *child);
 static ngx_int_t ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf);
 static ngx_int_t ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s);
 static ngx_int_t ngx_rtmp_codec_copy_meta(ngx_rtmp_session_t *s,
-       ngx_rtmp_header_t *h, ngx_chain_t *in);
+                                          ngx_rtmp_header_t *h,
+                                          ngx_chain_t *in);
 static ngx_int_t ngx_rtmp_codec_prepare_meta(ngx_rtmp_session_t *s,
-       uint32_t timestamp);
+                                             uint32_t timestamp);
 static void ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s,
-       ngx_chain_t *in);
+                                            ngx_chain_t *in);
 static void ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s,
-       ngx_chain_t *in);
+                                            ngx_chain_t *in);
 #if (NGX_DEBUG)
 static void ngx_rtmp_codec_dump_header(ngx_rtmp_session_t *s, const char *type,
-       ngx_chain_t *in);
+                                       ngx_chain_t *in);
 #endif
 
-
 typedef struct {
-    ngx_uint_t                      meta;
+    ngx_uint_t meta;
 } ngx_rtmp_codec_app_conf_t;
 
-
 static ngx_conf_enum_t ngx_rtmp_codec_meta_slots[] = {
-    { ngx_string("off"),            NGX_RTMP_CODEC_META_OFF  },
-    { ngx_string("on"),             NGX_RTMP_CODEC_META_ON   },
-    { ngx_string("copy"),           NGX_RTMP_CODEC_META_COPY },
-    { ngx_null_string,              0 }
+    {ngx_string("off"), NGX_RTMP_CODEC_META_OFF},
+    {ngx_string("on"), NGX_RTMP_CODEC_META_ON},
+    {ngx_string("copy"), NGX_RTMP_CODEC_META_COPY},
+    {ngx_null_string, 0}};
+
+static ngx_command_t ngx_rtmp_codec_commands[] = {
+
+    {ngx_string("meta"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                             NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_enum_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_codec_app_conf_t, meta), &ngx_rtmp_codec_meta_slots},
+
+    ngx_null_command};
+
+static ngx_rtmp_module_t ngx_rtmp_codec_module_ctx = {
+    NULL,                             /* preconfiguration */
+    ngx_rtmp_codec_postconfiguration, /* postconfiguration */
+    NULL,                             /* create main configuration */
+    NULL,                             /* init main configuration */
+    NULL,                             /* create server configuration */
+    NULL,                             /* merge server configuration */
+    ngx_rtmp_codec_create_app_conf,   /* create app configuration */
+    ngx_rtmp_codec_merge_app_conf     /* merge app configuration */
 };
 
-
-static ngx_command_t  ngx_rtmp_codec_commands[] = {
-
-    { ngx_string("meta"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_enum_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_codec_app_conf_t, meta),
-      &ngx_rtmp_codec_meta_slots },
-
-      ngx_null_command
-};
-
-
-static ngx_rtmp_module_t  ngx_rtmp_codec_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_codec_postconfiguration,       /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    ngx_rtmp_codec_create_app_conf,         /* create app configuration */
-    ngx_rtmp_codec_merge_app_conf           /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_codec_module = {
+ngx_module_t ngx_rtmp_codec_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_codec_module_ctx,             /* module context */
-    ngx_rtmp_codec_commands,                /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
+    &ngx_rtmp_codec_module_ctx, /* module context */
+    ngx_rtmp_codec_commands,    /* module directives */
+    NGX_RTMP_MODULE,            /* module type */
+    NULL,                       /* init master */
+    NULL,                       /* init module */
+    NULL,                       /* init process */
+    NULL,                       /* init thread */
+    NULL,                       /* exit thread */
+    NULL,                       /* exit process */
+    NULL,                       /* exit master */
+    NGX_MODULE_V1_PADDING};
+
+static const char *audio_codecs[] = {"",
+                                     "ADPCM",
+                                     "MP3",
+                                     "LinearLE",
+                                     "Nellymoser16",
+                                     "Nellymoser8",
+                                     "Nellymoser",
+                                     "G711A",
+                                     "G711U",
+                                     "",
+                                     "AAC",
+                                     "Speex",
+                                     "",
+                                     "",
+                                     "MP3-8K",
+                                     "DeviceSpecific",
+                                     "Uncompressed"};
+
+static const char *video_codecs[] = {
+    "",        "Jpeg",          "Sorenson-H263", "ScreenVideo",
+    "On2-VP6", "On2-VP6-Alpha", "ScreenVideo2",  "H264",
 };
 
-
-static const char *
-audio_codecs[] = {
-    "",
-    "ADPCM",
-    "MP3",
-    "LinearLE",
-    "Nellymoser16",
-    "Nellymoser8",
-    "Nellymoser",
-    "G711A",
-    "G711U",
-    "",
-    "AAC",
-    "Speex",
-    "",
-    "",
-    "MP3-8K",
-    "DeviceSpecific",
-    "Uncompressed"
-};
-
-
-static const char *
-video_codecs[] = {
-    "",
-    "Jpeg",
-    "Sorenson-H263",
-    "ScreenVideo",
-    "On2-VP6",
-    "On2-VP6-Alpha",
-    "ScreenVideo2",
-    "H264",
-};
-
-
-u_char *
-ngx_rtmp_get_audio_codec_name(ngx_uint_t id)
+u_char *ngx_rtmp_get_audio_codec_name(ngx_uint_t id)
 {
     return (u_char *)(id < sizeof(audio_codecs) / sizeof(audio_codecs[0])
-        ? audio_codecs[id]
-        : "");
+                          ? audio_codecs[id]
+                          : "");
 }
 
-
-u_char *
-ngx_rtmp_get_video_codec_name(ngx_uint_t id)
+u_char *ngx_rtmp_get_video_codec_name(ngx_uint_t id)
 {
     return (u_char *)(id < sizeof(video_codecs) / sizeof(video_codecs[0])
-        ? video_codecs[id]
-        : "");
+                          ? video_codecs[id]
+                          : "");
 }
 
-
-static ngx_uint_t
-ngx_rtmp_codec_get_next_version()
+static ngx_uint_t ngx_rtmp_codec_get_next_version()
 {
-    ngx_uint_t          v;
-    static ngx_uint_t   version;
+    ngx_uint_t v;
+    static ngx_uint_t version;
 
     do {
         v = ++version;
@@ -156,13 +126,12 @@ ngx_rtmp_codec_get_next_version()
     return v;
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_codec_disconnect(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_header_t *h,
+                                           ngx_chain_t *in)
 {
-    ngx_rtmp_codec_ctx_t               *ctx;
-    ngx_rtmp_core_srv_conf_t           *cscf;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
     if (ctx == NULL) {
@@ -189,17 +158,14 @@ ngx_rtmp_codec_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_codec_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                                   ngx_chain_t *in)
 {
-    ngx_rtmp_core_srv_conf_t           *cscf;
-    ngx_rtmp_codec_ctx_t               *ctx;
-    ngx_chain_t                       **header;
-    uint8_t                             fmt;
-    static ngx_uint_t                   sample_rates[] =
-                                        { 5512, 11025, 22050, 44100 };
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_chain_t **header;
+    uint8_t fmt;
+    static ngx_uint_t sample_rates[] = {5512, 11025, 22050, 44100};
 
     if (h->type != NGX_RTMP_MSG_AUDIO && h->type != NGX_RTMP_MSG_VIDEO) {
         return NGX_OK;
@@ -216,11 +182,11 @@ ngx_rtmp_codec_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         return NGX_OK;
     }
 
-    fmt =  in->buf->pos[0];
+    fmt = in->buf->pos[0];
     if (h->type == NGX_RTMP_MSG_AUDIO) {
         ctx->audio_codec_id = (fmt & 0xf0) >> 4;
         ctx->audio_channels = (fmt & 0x01) + 1;
-        ctx->sample_size = (fmt & 0x02) ? 2 : 1;
+        ctx->sample_size    = (fmt & 0x02) ? 2 : 1;
 
         if (ctx->sample_rate == 0) {
             ctx->sample_rate = sample_rates[(fmt & 0x0c) >> 2];
@@ -239,7 +205,7 @@ ngx_rtmp_codec_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         return NGX_OK;
     }
 
-    cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
+    cscf   = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
     header = NULL;
 
     if (h->type == NGX_RTMP_MSG_AUDIO) {
@@ -267,19 +233,16 @@ ngx_rtmp_codec_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
+static void ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s,
+                                            ngx_chain_t *in)
 {
-    ngx_uint_t              idx;
-    ngx_rtmp_codec_ctx_t   *ctx;
-    ngx_rtmp_bit_reader_t   br;
+    ngx_uint_t idx;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_rtmp_bit_reader_t br;
 
-    static ngx_uint_t      aac_sample_rates[] =
-        { 96000, 88200, 64000, 48000,
-          44100, 32000, 24000, 22050,
-          16000, 12000, 11025,  8000,
-           7350,     0,     0,     0 };
+    static ngx_uint_t aac_sample_rates[] = {
+        96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050,
+        16000, 12000, 11025, 8000,  7350,  0,     0,     0};
 
 #if (NGX_DEBUG)
     ngx_rtmp_codec_dump_header(s, "aac", in);
@@ -291,38 +254,37 @@ ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
 
     ngx_rtmp_bit_read(&br, 16);
 
-    ctx->aac_profile = (ngx_uint_t) ngx_rtmp_bit_read(&br, 5);
+    ctx->aac_profile = (ngx_uint_t)ngx_rtmp_bit_read(&br, 5);
     if (ctx->aac_profile == 31) {
-        ctx->aac_profile = (ngx_uint_t) ngx_rtmp_bit_read(&br, 6) + 32;
+        ctx->aac_profile = (ngx_uint_t)ngx_rtmp_bit_read(&br, 6) + 32;
     }
 
-    idx = (ngx_uint_t) ngx_rtmp_bit_read(&br, 4);
+    idx = (ngx_uint_t)ngx_rtmp_bit_read(&br, 4);
     if (idx == 15) {
-        ctx->sample_rate = (ngx_uint_t) ngx_rtmp_bit_read(&br, 24);
+        ctx->sample_rate = (ngx_uint_t)ngx_rtmp_bit_read(&br, 24);
     } else {
         ctx->sample_rate = aac_sample_rates[idx];
     }
 
-    ctx->aac_chan_conf = (ngx_uint_t) ngx_rtmp_bit_read(&br, 4);
+    ctx->aac_chan_conf = (ngx_uint_t)ngx_rtmp_bit_read(&br, 4);
 
     if (ctx->aac_profile == 5 || ctx->aac_profile == 29) {
-        
         if (ctx->aac_profile == 29) {
             ctx->aac_ps = 1;
         }
 
         ctx->aac_sbr = 1;
 
-        idx = (ngx_uint_t) ngx_rtmp_bit_read(&br, 4);
+        idx = (ngx_uint_t)ngx_rtmp_bit_read(&br, 4);
         if (idx == 15) {
-            ctx->sample_rate = (ngx_uint_t) ngx_rtmp_bit_read(&br, 24);
+            ctx->sample_rate = (ngx_uint_t)ngx_rtmp_bit_read(&br, 24);
         } else {
             ctx->sample_rate = aac_sample_rates[idx];
         }
 
-        ctx->aac_profile = (ngx_uint_t) ngx_rtmp_bit_read(&br, 5);
+        ctx->aac_profile = (ngx_uint_t)ngx_rtmp_bit_read(&br, 5);
         if (ctx->aac_profile == 31) {
-            ctx->aac_profile = (ngx_uint_t) ngx_rtmp_bit_read(&br, 6) + 32;
+            ctx->aac_profile = (ngx_uint_t)ngx_rtmp_bit_read(&br, 6) + 32;
         }
     }
 
@@ -343,7 +305,7 @@ ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
            5 bits: object type
            if (object type == 31)
              6 bits + 32: object type
-             
+
        var bits: AOT Specific Config
      */
 
@@ -353,17 +315,16 @@ ngx_rtmp_codec_parse_aac_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
                    ctx->aac_profile, ctx->sample_rate, ctx->aac_chan_conf);
 }
 
-
-static void
-ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
+static void ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s,
+                                            ngx_chain_t *in)
 {
-    ngx_uint_t              profile_idc, width, height, crop_left, crop_right,
-                            crop_top, crop_bottom, frame_mbs_only, n, cf_n, cf_idc,
-//                            num_ref_frames;
-                            num_ref_frames, sl_size, sl_index, sl_udelta;
-    ngx_int_t               sl_last, sl_next, sl_delta;
-    ngx_rtmp_codec_ctx_t   *ctx;
-    ngx_rtmp_bit_reader_t   br;
+    ngx_uint_t profile_idc, width, height, crop_left, crop_right, crop_top,
+        crop_bottom, frame_mbs_only, n, cf_n, cf_idc,
+        //                            num_ref_frames;
+        num_ref_frames, sl_size, sl_index, sl_udelta;
+    ngx_int_t sl_last, sl_next, sl_delta;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_rtmp_bit_reader_t br;
 
 #if (NGX_DEBUG)
     ngx_rtmp_codec_dump_header(s, "avc", in);
@@ -375,12 +336,12 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
 
     ngx_rtmp_bit_read(&br, 48);
 
-    ctx->avc_profile = (ngx_uint_t) ngx_rtmp_bit_read_8(&br);
-    ctx->avc_compat = (ngx_uint_t) ngx_rtmp_bit_read_8(&br);
-    ctx->avc_level = (ngx_uint_t) ngx_rtmp_bit_read_8(&br);
+    ctx->avc_profile = (ngx_uint_t)ngx_rtmp_bit_read_8(&br);
+    ctx->avc_compat  = (ngx_uint_t)ngx_rtmp_bit_read_8(&br);
+    ctx->avc_level   = (ngx_uint_t)ngx_rtmp_bit_read_8(&br);
 
     /* nal bytes */
-    ctx->avc_nal_bytes = (ngx_uint_t) ((ngx_rtmp_bit_read_8(&br) & 0x03) + 1);
+    ctx->avc_nal_bytes = (ngx_uint_t)((ngx_rtmp_bit_read_8(&br) & 0x03) + 1);
 
     /* nnals */
     if ((ngx_rtmp_bit_read_8(&br) & 0x1f) == 0) {
@@ -398,7 +359,7 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
     /* SPS */
 
     /* profile idc */
-    profile_idc = (ngx_uint_t) ngx_rtmp_bit_read(&br, 8);
+    profile_idc = (ngx_uint_t)ngx_rtmp_bit_read(&br, 8);
 
     /* flags */
     ngx_rtmp_bit_read(&br, 8);
@@ -409,15 +370,13 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
     /* SPS id */
     ngx_rtmp_bit_read_golomb(&br);
 
-    if (profile_idc == 100 || profile_idc == 110 ||
-        profile_idc == 122 || profile_idc == 244 || profile_idc == 44 ||
-        profile_idc == 83 || profile_idc == 86 || profile_idc == 118)
-    {
+    if (profile_idc == 100 || profile_idc == 110 || profile_idc == 122 ||
+        profile_idc == 244 || profile_idc == 44 || profile_idc == 83 ||
+        profile_idc == 86 || profile_idc == 118) {
         /* chroma format idc */
-        cf_idc = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
-        
-        if (cf_idc == 3) {
+        cf_idc = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
+        if (cf_idc == 3) {
             /* separate color plane */
             ngx_rtmp_bit_read(&br, 1);
         }
@@ -433,12 +392,9 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
 
         /* seq scaling matrix present */
         if (ngx_rtmp_bit_read(&br, 1)) {
-
             for (n = 0, cf_n = (cf_idc != 3 ? 8u : 12u); n < cf_n; n++) {
-
                 /* seq scaling list present */
                 if (ngx_rtmp_bit_read(&br, 1)) {
-
                     /* scaling list */
                     if (n < 6) {
                         sl_size = 16;
@@ -450,12 +406,10 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
                     sl_next = 8;
 
                     for (sl_index = 0; sl_index < sl_size; sl_index++) {
-
                         if (sl_next != 0) {
-
                             /* convert to signed: (-1)**k+1 * ceil(k/2) */
                             sl_udelta = ngx_rtmp_bit_read_golomb(&br);
-                            sl_delta = (sl_udelta + 1) >> 1;
+                            sl_delta  = (sl_udelta + 1) >> 1;
                             if ((sl_udelta & 1) == 0) {
                                 sl_delta = -sl_delta;
                             }
@@ -495,32 +449,30 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
         ngx_rtmp_bit_read_golomb(&br);
 
         /* num ref frames in pic order */
-        num_ref_frames = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
+        num_ref_frames = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
         for (n = 0; n < num_ref_frames; n++) {
-
             /* offset for ref frame */
             ngx_rtmp_bit_read_golomb(&br);
         }
     }
 
     /* num ref frames */
-    ctx->avc_ref_frames = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
+    ctx->avc_ref_frames = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
     /* gaps in frame num allowed */
     ngx_rtmp_bit_read(&br, 1);
 
     /* pic width in mbs - 1 */
-    width = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
+    width = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
     /* pic height in map units - 1 */
-    height = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
+    height = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
     /* frame mbs only flag */
-    frame_mbs_only = (ngx_uint_t) ngx_rtmp_bit_read(&br, 1);
+    frame_mbs_only = (ngx_uint_t)ngx_rtmp_bit_read(&br, 1);
 
     if (!frame_mbs_only) {
-
         /* mbs adaprive frame field */
         ngx_rtmp_bit_read(&br, 1);
     }
@@ -530,46 +482,40 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
 
     /* frame cropping */
     if (ngx_rtmp_bit_read(&br, 1)) {
-
-        crop_left = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
-        crop_right = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
-        crop_top = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
-        crop_bottom = (ngx_uint_t) ngx_rtmp_bit_read_golomb(&br);
+        crop_left   = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
+        crop_right  = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
+        crop_top    = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
+        crop_bottom = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
 
     } else {
-
-        crop_left = 0;
-        crop_right = 0;
-        crop_top = 0;
+        crop_left   = 0;
+        crop_right  = 0;
+        crop_top    = 0;
         crop_bottom = 0;
     }
 
     ctx->width = (width + 1) * 16 - (crop_left + crop_right) * 2;
-    ctx->height = (2 - frame_mbs_only) * (height + 1) * 16 -
-                  (crop_top + crop_bottom) * 2;
+    ctx->height =
+        (2 - frame_mbs_only) * (height + 1) * 16 - (crop_top + crop_bottom) * 2;
 
     ngx_log_debug7(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "codec: avc header "
                    "profile=%ui, compat=%ui, level=%ui, "
                    "nal_bytes=%ui, ref_frames=%ui, width=%ui, height=%ui",
                    ctx->avc_profile, ctx->avc_compat, ctx->avc_level,
-                   ctx->avc_nal_bytes, ctx->avc_ref_frames,
-                   ctx->width, ctx->height);
+                   ctx->avc_nal_bytes, ctx->avc_ref_frames, ctx->width,
+                   ctx->height);
 }
 
-
 #if (NGX_DEBUG)
-static void
-ngx_rtmp_codec_dump_header(ngx_rtmp_session_t *s, const char *type,
-    ngx_chain_t *in)
+static void ngx_rtmp_codec_dump_header(ngx_rtmp_session_t *s, const char *type,
+                                       ngx_chain_t *in)
 {
     u_char buf[256], *p, *pp;
     u_char hex[] = "0123456789abcdef";
 
     for (pp = buf, p = in->buf->pos;
-         p < in->buf->last && pp < buf + sizeof(buf) - 1;
-         ++p)
-    {
+         p < in->buf->last && pp < buf + sizeof(buf) - 1; ++p) {
         *pp++ = hex[*p >> 4];
         *pp++ = hex[*p & 0x0f];
     }
@@ -581,95 +527,65 @@ ngx_rtmp_codec_dump_header(ngx_rtmp_session_t *s, const char *type,
 }
 #endif
 
-
-static ngx_int_t
-ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_codec_ctx_t           *ctx;
-    ngx_rtmp_core_srv_conf_t       *cscf;
-    ngx_int_t                       rc;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_int_t rc;
 
     static struct {
-        double                      width;
-        double                      height;
-        double                      duration;
-        double                      frame_rate;
-        double                      video_data_rate;
-        double                      video_codec_id;
-        double                      audio_data_rate;
-        double                      audio_codec_id;
-        u_char                      profile[32];
-        u_char                      level[32];
-    }                               v;
+        double width;
+        double height;
+        double duration;
+        double frame_rate;
+        double video_data_rate;
+        double video_codec_id;
+        double audio_data_rate;
+        double audio_codec_id;
+        u_char profile[32];
+        u_char level[32];
+    } v;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("Server"),
-          "NGINX RTMP (github.com/sergey-dryabzhinsky/nginx-rtmp-module)", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("Server"),
+         "NGINX RTMP (github.com/sergey-dryabzhinsky/nginx-rtmp-module)", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("width"),
-          &v.width, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("width"), &v.width, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("height"),
-          &v.height, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("height"), &v.height, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("displayWidth"),
-          &v.width, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("displayWidth"), &v.width, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("displayHeight"),
-          &v.height, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("displayHeight"), &v.height, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("duration"),
-          &v.duration, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("duration"), &v.duration, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("framerate"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("framerate"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("fps"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("fps"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videodatarate"),
-          &v.video_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videodatarate"), &v.video_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videocodecid"),
-          &v.video_codec_id, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videocodecid"), &v.video_codec_id, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audiodatarate"),
-          &v.audio_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audiodatarate"), &v.audio_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audiocodecid"),
-          &v.audio_codec_id, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audiocodecid"), &v.audio_codec_id, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("profile"),
-          &v.profile, sizeof(v.profile) },
+        {NGX_RTMP_AMF_STRING, ngx_string("profile"), &v.profile,
+         sizeof(v.profile)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onMetaData", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onMetaData", 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf, sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
@@ -684,14 +600,14 @@ ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s)
         ctx->meta = NULL;
     }
 
-    v.width = ctx->width;
-    v.height = ctx->height;
-    v.duration = ctx->duration;
-    v.frame_rate = ctx->frame_rate;
+    v.width           = ctx->width;
+    v.height          = ctx->height;
+    v.duration        = ctx->duration;
+    v.frame_rate      = ctx->frame_rate;
     v.video_data_rate = ctx->video_data_rate;
-    v.video_codec_id = ctx->video_codec_id;
+    v.video_codec_id  = ctx->video_codec_id;
     v.audio_data_rate = ctx->audio_data_rate;
-    v.audio_codec_id = ctx->audio_codec_id;
+    v.audio_codec_id  = ctx->audio_codec_id;
     ngx_memcpy(v.profile, ctx->profile, sizeof(ctx->profile));
     ngx_memcpy(v.level, ctx->level, sizeof(ctx->level));
 
@@ -704,13 +620,11 @@ ngx_rtmp_codec_reconstruct_meta(ngx_rtmp_session_t *s)
     return ngx_rtmp_codec_prepare_meta(s, 0);
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_copy_meta(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_codec_copy_meta(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_codec_ctx_t      *ctx;
-    ngx_rtmp_core_srv_conf_t  *cscf;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
@@ -729,19 +643,18 @@ ngx_rtmp_codec_copy_meta(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_codec_prepare_meta(s, h->timestamp);
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_prepare_meta(ngx_rtmp_session_t *s, uint32_t timestamp)
+static ngx_int_t ngx_rtmp_codec_prepare_meta(ngx_rtmp_session_t *s,
+                                             uint32_t timestamp)
 {
-    ngx_rtmp_header_t      h;
-    ngx_rtmp_codec_ctx_t  *ctx;
+    ngx_rtmp_header_t h;
+    ngx_rtmp_codec_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_codec_module);
 
     ngx_memzero(&h, sizeof(h));
-    h.csid = NGX_RTMP_CSID_AMF;
-    h.msid = NGX_RTMP_MSID;
-    h.type = NGX_RTMP_MSG_AMF_META;
+    h.csid      = NGX_RTMP_CSID_AMF;
+    h.msid      = NGX_RTMP_MSID;
+    h.type      = NGX_RTMP_MSG_AMF_META;
     h.timestamp = timestamp;
     ngx_rtmp_prepare_message(s, &h, NULL, ctx->meta);
 
@@ -750,109 +663,81 @@ ngx_rtmp_codec_prepare_meta(ngx_rtmp_session_t *s, uint32_t timestamp)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_codec_app_conf_t      *cacf;
-    ngx_rtmp_codec_ctx_t           *ctx;
-    ngx_uint_t                      skip;
+    ngx_rtmp_codec_app_conf_t *cacf;
+    ngx_rtmp_codec_ctx_t *ctx;
+    ngx_uint_t skip;
 
     static struct {
-        double                      width;
-        double                      height;
-        double                      duration;
-        double                      frame_rate;
-        double                      video_data_rate;
-        double                      video_codec_id_n;
-        u_char                      video_codec_id_s[32];
-        double                      audio_data_rate;
-        double                      audio_codec_id_n;
-        u_char                      audio_codec_id_s[32];
-        u_char                      profile[32];
-        u_char                      level[32];
-    }                               v;
+        double width;
+        double height;
+        double duration;
+        double frame_rate;
+        double video_data_rate;
+        double video_codec_id_n;
+        u_char video_codec_id_s[32];
+        double audio_data_rate;
+        double audio_codec_id_n;
+        u_char audio_codec_id_s[32];
+        u_char profile[32];
+        u_char level[32];
+    } v;
 
-    static ngx_rtmp_amf_elt_t       in_video_codec_id[] = {
+    static ngx_rtmp_amf_elt_t in_video_codec_id[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.video_codec_id_n, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.video_codec_id_n, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          &v.video_codec_id_s, sizeof(v.video_codec_id_s) },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, &v.video_codec_id_s,
+         sizeof(v.video_codec_id_s)},
     };
 
-    static ngx_rtmp_amf_elt_t       in_audio_codec_id[] = {
+    static ngx_rtmp_amf_elt_t in_audio_codec_id[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.audio_codec_id_n, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.audio_codec_id_n, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          &v.audio_codec_id_s, sizeof(v.audio_codec_id_s) },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, &v.audio_codec_id_s,
+         sizeof(v.audio_codec_id_s)},
     };
 
-    static ngx_rtmp_amf_elt_t       in_inf[] = {
+    static ngx_rtmp_amf_elt_t in_inf[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("width"),
-          &v.width, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("width"), &v.width, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("height"),
-          &v.height, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("height"), &v.height, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("duration"),
-          &v.duration, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("duration"), &v.duration, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("framerate"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("framerate"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("fps"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("fps"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videodatarate"),
-          &v.video_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videodatarate"), &v.video_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_VARIANT,
-          ngx_string("videocodecid"),
-          in_video_codec_id, sizeof(in_video_codec_id) },
+        {NGX_RTMP_AMF_VARIANT, ngx_string("videocodecid"), in_video_codec_id,
+         sizeof(in_video_codec_id)},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audiodatarate"),
-          &v.audio_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audiodatarate"), &v.audio_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_VARIANT,
-          ngx_string("audiocodecid"),
-          in_audio_codec_id, sizeof(in_audio_codec_id) },
+        {NGX_RTMP_AMF_VARIANT, ngx_string("audiocodecid"), in_audio_codec_id,
+         sizeof(in_audio_codec_id)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("profile"),
-          &v.profile, sizeof(v.profile) },
+        {NGX_RTMP_AMF_STRING, ngx_string("profile"), &v.profile,
+         sizeof(v.profile)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)},
     };
 
-    static ngx_rtmp_amf_elt_t       in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-       /* That string is passed by FFmpeg and possibly others (librtmp). It's skipped after at #880 */
-       { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 },
+        /* That string is passed by FFmpeg and possibly others (librtmp). It's
+           skipped after at #880 */
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
 
     cacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_codec_module);
@@ -866,55 +751,65 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ngx_memzero(&v, sizeof(v));
 
     /* use -1 as a sign of unchanged data */
-    v.width = -1;
-    v.height = -1;
-    v.duration = -1;
-    v.frame_rate = -1;
-    v.video_data_rate = -1;
+    v.width            = -1;
+    v.height           = -1;
+    v.duration         = -1;
+    v.frame_rate       = -1;
+    v.video_data_rate  = -1;
     v.video_codec_id_n = -1;
-    v.audio_data_rate = -1;
+    v.audio_data_rate  = -1;
     v.audio_codec_id_n = -1;
-    v.profile[0] = '\0';
-    v.level[0] = '\0';
+    v.profile[0]       = '\0';
+    v.level[0]         = '\0';
 
     /* FFmpeg sends a string in front of actual metadata; ignore it */
-    skip = !(in->buf->last > in->buf->pos
-            && *in->buf->pos == NGX_RTMP_AMF_STRING);
+    skip =
+        !(in->buf->last > in->buf->pos && *in->buf->pos == NGX_RTMP_AMF_STRING);
     if (ngx_rtmp_receive_amf(s, in, in_elts + skip,
-                sizeof(in_elts) / sizeof(in_elts[0]) - skip))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]) - skip)) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                "codec: error parsing data frame");
+                      "codec: error parsing data frame");
         return NGX_OK;
     }
 
-    if (v.width != -1) ctx->width = (ngx_uint_t) v.width;
-    if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
-    if (v.duration != -1) ctx->duration = (double) v.duration;
-    if (v.frame_rate != -1) ctx->frame_rate = (double) v.frame_rate;
-    if (v.video_data_rate != -1) ctx->video_data_rate = v.video_data_rate;
-    if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
-    if (v.audio_data_rate != -1) ctx->audio_data_rate = v.audio_data_rate;
-    if (v.audio_codec_id_n != -1) ctx->audio_codec_id = (v.audio_codec_id_n == 0
-            ? NGX_RTMP_AUDIO_UNCOMPRESSED : (ngx_uint_t) v.audio_codec_id_n);
-    if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
-    if (v.level[0] != '\0') ngx_memcpy(ctx->level, v.level, sizeof(v.level));
+    if (v.width != -1)
+        ctx->width = (ngx_uint_t)v.width;
+    if (v.height != -1)
+        ctx->height = (ngx_uint_t)v.height;
+    if (v.duration != -1)
+        ctx->duration = (double)v.duration;
+    if (v.frame_rate != -1)
+        ctx->frame_rate = (double)v.frame_rate;
+    if (v.video_data_rate != -1)
+        ctx->video_data_rate = v.video_data_rate;
+    if (v.video_codec_id_n != -1)
+        ctx->video_codec_id = (ngx_uint_t)v.video_codec_id_n;
+    if (v.audio_data_rate != -1)
+        ctx->audio_data_rate = v.audio_data_rate;
+    if (v.audio_codec_id_n != -1)
+        ctx->audio_codec_id =
+            (v.audio_codec_id_n == 0 ? NGX_RTMP_AUDIO_UNCOMPRESSED
+                                     : (ngx_uint_t)v.audio_codec_id_n);
+    if (v.profile[0] != '\0')
+        ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
+    if (v.level[0] != '\0')
+        ngx_memcpy(ctx->level, v.level, sizeof(v.level));
 
     ngx_log_debug8(NGX_LOG_DEBUG, s->connection->log, 0,
-            "codec: data frame: "
-            "width=%ui height=%ui duration=%.3f frame_rate=%.3f "
-            "video=%s (%ui) audio=%s (%ui)",
-            ctx->width, ctx->height, ctx->duration, ctx->frame_rate,
-            ngx_rtmp_get_video_codec_name(ctx->video_codec_id),
-            ctx->video_codec_id,
-            ngx_rtmp_get_audio_codec_name(ctx->audio_codec_id),
-            ctx->audio_codec_id);
+                   "codec: data frame: "
+                   "width=%ui height=%ui duration=%.3f frame_rate=%.3f "
+                   "video=%s (%ui) audio=%s (%ui)",
+                   ctx->width, ctx->height, ctx->duration, ctx->frame_rate,
+                   ngx_rtmp_get_video_codec_name(ctx->video_codec_id),
+                   ctx->video_codec_id,
+                   ngx_rtmp_get_audio_codec_name(ctx->audio_codec_id),
+                   ctx->audio_codec_id);
 
     switch (cacf->meta) {
-        case NGX_RTMP_CODEC_META_ON:
-            return ngx_rtmp_codec_reconstruct_meta(s);
-        case NGX_RTMP_CODEC_META_COPY:
-            return ngx_rtmp_codec_copy_meta(s, h, in);
+    case NGX_RTMP_CODEC_META_ON:
+        return ngx_rtmp_codec_reconstruct_meta(s);
+    case NGX_RTMP_CODEC_META_COPY:
+        return ngx_rtmp_codec_copy_meta(s, h, in);
     }
 
     /* NGX_RTMP_CODEC_META_OFF */
@@ -922,11 +817,9 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return NGX_OK;
 }
 
-
-static void *
-ngx_rtmp_codec_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_codec_create_app_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_codec_app_conf_t  *cacf;
+    ngx_rtmp_codec_app_conf_t *cacf;
 
     cacf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_codec_app_conf_t));
     if (cacf == NULL) {
@@ -938,9 +831,8 @@ ngx_rtmp_codec_create_app_conf(ngx_conf_t *cf)
     return cacf;
 }
 
-
-static char *
-ngx_rtmp_codec_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_codec_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                           void *child)
 {
     ngx_rtmp_codec_app_conf_t *prev = parent;
     ngx_rtmp_codec_app_conf_t *conf = child;
@@ -950,23 +842,21 @@ ngx_rtmp_codec_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_core_main_conf_t          *cmcf;
-    ngx_rtmp_handler_pt                *h;
-    ngx_rtmp_amf_handler_t             *ch;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_rtmp_handler_pt *h;
+    ngx_rtmp_amf_handler_t *ch;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AUDIO]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AUDIO]);
     *h = ngx_rtmp_codec_av;
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
     *h = ngx_rtmp_codec_av;
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
     *h = ngx_rtmp_codec_disconnect;
 
     /* register metadata handler */
@@ -976,7 +866,7 @@ ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
     }
     ngx_str_set(&ch->name, "@setDataFrame");
     ch->handler = ngx_rtmp_codec_meta_data;
-    
+
     // some encoders send setDataFrame instead of @setDataFrame
     ch = ngx_array_push(&cmcf->amf);
     if (ch == NULL) {
@@ -984,14 +874,13 @@ ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
     }
     ngx_str_set(&ch->name, "setDataFrame");
     ch->handler = ngx_rtmp_codec_meta_data;
-    
+
     ch = ngx_array_push(&cmcf->amf);
     if (ch == NULL) {
         return NGX_ERROR;
     }
     ngx_str_set(&ch->name, "onMetaData");
     ch->handler = ngx_rtmp_codec_meta_data;
-
 
     return NGX_OK;
 }

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -3,85 +3,77 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_CODEC_H_INCLUDED_
 #define _NGX_RTMP_CODEC_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-
 
 /* Audio codecs */
 enum {
     /* Uncompressed codec id is actually 0,
      * but we use another value for consistency */
-    NGX_RTMP_AUDIO_UNCOMPRESSED     = 16,
-    NGX_RTMP_AUDIO_ADPCM            = 1,
-    NGX_RTMP_AUDIO_MP3              = 2,
-    NGX_RTMP_AUDIO_LINEAR_LE        = 3,
-    NGX_RTMP_AUDIO_NELLY16          = 4,
-    NGX_RTMP_AUDIO_NELLY8           = 5,
-    NGX_RTMP_AUDIO_NELLY            = 6,
-    NGX_RTMP_AUDIO_G711A            = 7,
-    NGX_RTMP_AUDIO_G711U            = 8,
-    NGX_RTMP_AUDIO_AAC              = 10,
-    NGX_RTMP_AUDIO_SPEEX            = 11,
-    NGX_RTMP_AUDIO_MP3_8            = 14,
-    NGX_RTMP_AUDIO_DEVSPEC          = 15,
+    NGX_RTMP_AUDIO_UNCOMPRESSED = 16,
+    NGX_RTMP_AUDIO_ADPCM        = 1,
+    NGX_RTMP_AUDIO_MP3          = 2,
+    NGX_RTMP_AUDIO_LINEAR_LE    = 3,
+    NGX_RTMP_AUDIO_NELLY16      = 4,
+    NGX_RTMP_AUDIO_NELLY8       = 5,
+    NGX_RTMP_AUDIO_NELLY        = 6,
+    NGX_RTMP_AUDIO_G711A        = 7,
+    NGX_RTMP_AUDIO_G711U        = 8,
+    NGX_RTMP_AUDIO_AAC          = 10,
+    NGX_RTMP_AUDIO_SPEEX        = 11,
+    NGX_RTMP_AUDIO_MP3_8        = 14,
+    NGX_RTMP_AUDIO_DEVSPEC      = 15,
 };
-
 
 /* Video codecs */
 enum {
-    NGX_RTMP_VIDEO_JPEG             = 1,
-    NGX_RTMP_VIDEO_SORENSON_H263    = 2,
-    NGX_RTMP_VIDEO_SCREEN           = 3,
-    NGX_RTMP_VIDEO_ON2_VP6          = 4,
-    NGX_RTMP_VIDEO_ON2_VP6_ALPHA    = 5,
-    NGX_RTMP_VIDEO_SCREEN2          = 6,
-    NGX_RTMP_VIDEO_H264             = 7
+    NGX_RTMP_VIDEO_JPEG          = 1,
+    NGX_RTMP_VIDEO_SORENSON_H263 = 2,
+    NGX_RTMP_VIDEO_SCREEN        = 3,
+    NGX_RTMP_VIDEO_ON2_VP6       = 4,
+    NGX_RTMP_VIDEO_ON2_VP6_ALPHA = 5,
+    NGX_RTMP_VIDEO_SCREEN2       = 6,
+    NGX_RTMP_VIDEO_H264          = 7
 };
 
-
-u_char * ngx_rtmp_get_audio_codec_name(ngx_uint_t id);
-u_char * ngx_rtmp_get_video_codec_name(ngx_uint_t id);
-
+u_char *ngx_rtmp_get_audio_codec_name(ngx_uint_t id);
+u_char *ngx_rtmp_get_video_codec_name(ngx_uint_t id);
 
 typedef struct {
-    ngx_uint_t                  width;
-    ngx_uint_t                  height;
-    double                      duration;
-    double                      frame_rate;
-    double                      video_data_rate;
-    ngx_uint_t                  video_codec_id;
-    double                      audio_data_rate;
-    ngx_uint_t                  audio_codec_id;
-    ngx_uint_t                  aac_profile;
-    ngx_uint_t                  aac_chan_conf;
-    ngx_uint_t                  aac_sbr;
-    ngx_uint_t                  aac_ps;
-    ngx_uint_t                  avc_profile;
-    ngx_uint_t                  avc_compat;
-    ngx_uint_t                  avc_level;
-    ngx_uint_t                  avc_nal_bytes;
-    ngx_uint_t                  avc_ref_frames;
-    ngx_uint_t                  sample_rate;    /* 5512, 11025, 22050, 44100 */
-    ngx_uint_t                  sample_size;    /* 1=8bit, 2=16bit */
-    ngx_uint_t                  audio_channels; /* 1, 2 */
-    u_char                      profile[32];
-    u_char                      level[32];
+    ngx_uint_t width;
+    ngx_uint_t height;
+    double duration;
+    double frame_rate;
+    double video_data_rate;
+    ngx_uint_t video_codec_id;
+    double audio_data_rate;
+    ngx_uint_t audio_codec_id;
+    ngx_uint_t aac_profile;
+    ngx_uint_t aac_chan_conf;
+    ngx_uint_t aac_sbr;
+    ngx_uint_t aac_ps;
+    ngx_uint_t avc_profile;
+    ngx_uint_t avc_compat;
+    ngx_uint_t avc_level;
+    ngx_uint_t avc_nal_bytes;
+    ngx_uint_t avc_ref_frames;
+    ngx_uint_t sample_rate;    /* 5512, 11025, 22050, 44100 */
+    ngx_uint_t sample_size;    /* 1=8bit, 2=16bit */
+    ngx_uint_t audio_channels; /* 1, 2 */
+    u_char profile[32];
+    u_char level[32];
 
-    ngx_chain_t                *avc_header;
-    ngx_chain_t                *aac_header;
+    ngx_chain_t *avc_header;
+    ngx_chain_t *aac_header;
 
-    ngx_chain_t                *meta;
-    ngx_uint_t                  meta_version;
+    ngx_chain_t *meta;
+    ngx_uint_t meta_version;
 } ngx_rtmp_codec_ctx_t;
 
-
-extern ngx_module_t  ngx_rtmp_codec_module;
-
+extern ngx_module_t ngx_rtmp_codec_module;
 
 #endif /* _NGX_RTMP_LIVE_H_INCLUDED_ */

--- a/ngx_rtmp_eval.c
+++ b/ngx_rtmp_eval.c
@@ -3,65 +3,52 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_eval.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_eval.h"
 
+#define NGX_RTMP_EVAL_BUFLEN 16
 
-#define NGX_RTMP_EVAL_BUFLEN    16
-
-
-static void
-ngx_rtmp_eval_session_str(void *ctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
+static void ngx_rtmp_eval_session_str(void *ctx, ngx_rtmp_eval_t *e,
+                                      ngx_str_t *ret)
 {
-    *ret = *(ngx_str_t *) ((u_char *) ctx + e->offset);
+    *ret = *(ngx_str_t *)((u_char *)ctx + e->offset);
 }
 
-
-static void
-ngx_rtmp_eval_connection_str(void *ctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
+static void ngx_rtmp_eval_connection_str(void *ctx, ngx_rtmp_eval_t *e,
+                                         ngx_str_t *ret)
 {
-    ngx_rtmp_session_t  *s = ctx;
+    ngx_rtmp_session_t *s = ctx;
 
-    *ret = *(ngx_str_t *) ((u_char *) s->connection + e->offset);
+    *ret = *(ngx_str_t *)((u_char *)s->connection + e->offset);
 }
-
 
 ngx_rtmp_eval_t ngx_rtmp_eval_session[] = {
 
-    { ngx_string("app"),
-      ngx_rtmp_eval_session_str,
-      offsetof(ngx_rtmp_session_t, app) },
+    {ngx_string("app"), ngx_rtmp_eval_session_str,
+     offsetof(ngx_rtmp_session_t, app)},
 
-    { ngx_string("flashver"),
-      ngx_rtmp_eval_session_str,
-      offsetof(ngx_rtmp_session_t, flashver) },
+    {ngx_string("flashver"), ngx_rtmp_eval_session_str,
+     offsetof(ngx_rtmp_session_t, flashver)},
 
-    { ngx_string("swfurl"),
-      ngx_rtmp_eval_session_str,
-      offsetof(ngx_rtmp_session_t, swf_url) },
+    {ngx_string("swfurl"), ngx_rtmp_eval_session_str,
+     offsetof(ngx_rtmp_session_t, swf_url)},
 
-    { ngx_string("tcurl"),
-      ngx_rtmp_eval_session_str,
-      offsetof(ngx_rtmp_session_t, tc_url) },
+    {ngx_string("tcurl"), ngx_rtmp_eval_session_str,
+     offsetof(ngx_rtmp_session_t, tc_url)},
 
-    { ngx_string("pageurl"),
-      ngx_rtmp_eval_session_str,
-      offsetof(ngx_rtmp_session_t, page_url) },
+    {ngx_string("pageurl"), ngx_rtmp_eval_session_str,
+     offsetof(ngx_rtmp_session_t, page_url)},
 
-    { ngx_string("addr"),
-      ngx_rtmp_eval_connection_str,
-      offsetof(ngx_connection_t, addr_text) },
+    {ngx_string("addr"), ngx_rtmp_eval_connection_str,
+     offsetof(ngx_connection_t, addr_text)},
 
-    ngx_rtmp_null_eval
-};
+    ngx_rtmp_null_eval};
 
-
-static void
-ngx_rtmp_eval_append(ngx_buf_t *b, void *data, size_t len, ngx_log_t *log)
+static void ngx_rtmp_eval_append(ngx_buf_t *b, void *data, size_t len,
+                                 ngx_log_t *log)
 {
-    size_t  buf_len;
+    size_t buf_len;
 
     if (b->last + len > b->end) {
         buf_len = 2 * (b->last - b->pos) + len;
@@ -72,27 +59,25 @@ ngx_rtmp_eval_append(ngx_buf_t *b, void *data, size_t len, ngx_log_t *log)
         }
 
         b->last = ngx_cpymem(b->start, b->pos, b->last - b->pos);
-        b->pos = b->start;
-        b->end = b->start + buf_len;
+        b->pos  = b->start;
+        b->end  = b->start + buf_len;
     }
 
     b->last = ngx_cpymem(b->last, data, len);
 }
 
-
-static void
-ngx_rtmp_eval_append_var(void *ctx, ngx_buf_t *b, ngx_rtmp_eval_t **e,
-    ngx_str_t *name, ngx_log_t *log)
+static void ngx_rtmp_eval_append_var(void *ctx, ngx_buf_t *b,
+                                     ngx_rtmp_eval_t **e, ngx_str_t *name,
+                                     ngx_log_t *log)
 {
-    ngx_uint_t          k;
-    ngx_str_t           v;
-    ngx_rtmp_eval_t    *ee;
+    ngx_uint_t k;
+    ngx_str_t v;
+    ngx_rtmp_eval_t *ee;
 
     for (; *e; ++e) {
         for (k = 0, ee = *e; ee->handler; ++k, ++ee) {
             if (ee->name.len == name->len &&
-                ngx_memcmp(ee->name.data, name->data, name->len) == 0)
-            {
+                ngx_memcmp(ee->name.data, name->data, name->len) == 0) {
                 ee->handler(ctx, ee, &v);
                 ngx_rtmp_eval_append(b, v.data, v.len, log);
             }
@@ -100,29 +85,22 @@ ngx_rtmp_eval_append_var(void *ctx, ngx_buf_t *b, ngx_rtmp_eval_t **e,
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e, ngx_str_t *out,
-    ngx_log_t *log)
+ngx_int_t ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e,
+                        ngx_str_t *out, ngx_log_t *log)
 {
-    u_char      c, *p;
-    ngx_str_t   name;
-    ngx_buf_t   b;
-    ngx_uint_t  n;
+    u_char c, *p;
+    ngx_str_t name;
+    ngx_buf_t b;
+    ngx_uint_t n;
 
-    enum {
-        NORMAL,
-        ESCAPE,
-        NAME,
-        SNAME
-    } state = NORMAL;
+    enum { NORMAL, ESCAPE, NAME, SNAME } state = NORMAL;
 
     b.pos = b.last = b.start = ngx_alloc(NGX_RTMP_EVAL_BUFLEN, log);
     if (b.pos == NULL) {
         return NGX_ERROR;
     }
 
-    b.end = b.pos + NGX_RTMP_EVAL_BUFLEN;
+    b.end     = b.pos + NGX_RTMP_EVAL_BUFLEN;
     name.data = NULL;
 
     for (n = 0; n < in->len; ++n) {
@@ -130,52 +108,51 @@ ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e, ngx_str_t *out,
         c = *p;
 
         switch (state) {
-            case SNAME:
-                if (c != '}') {
-                    continue;
-                }
-
-                name.len = p - name.data;
-                ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
-
-                state = NORMAL;
-
+        case SNAME:
+            if (c != '}') {
                 continue;
+            }
 
-            case NAME:
-                if (c == '{' && name.data == p) {
-                    ++name.data;
-                    state = SNAME;
-                    continue;
-                }
-                if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
-                    continue;
-                }
+            name.len = p - name.data;
+            ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
 
-                name.len = p - name.data;
-                ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
+            state = NORMAL;
 
-            case NORMAL:
-                switch (c) {
-                    case '$':
-                        name.data = p + 1;
-                        state = NAME;
-                        continue;
-                    case '\\':
-                        state = ESCAPE;
-                        continue;
-                }
+            continue;
 
-            case ESCAPE:
-                ngx_rtmp_eval_append(&b, &c, 1, log);
-                state = NORMAL;
-                break;
+        case NAME:
+            if (c == '{' && name.data == p) {
+                ++name.data;
+                state = SNAME;
+                continue;
+            }
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+                continue;
+            }
 
+            name.len = p - name.data;
+            ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
+
+        case NORMAL:
+            switch (c) {
+            case '$':
+                name.data = p + 1;
+                state     = NAME;
+                continue;
+            case '\\':
+                state = ESCAPE;
+                continue;
+            }
+
+        case ESCAPE:
+            ngx_rtmp_eval_append(&b, &c, 1, log);
+            state = NORMAL;
+            break;
         }
     }
 
     if (state == NAME) {
-        p = &in->data[n];
+        p        = &in->data[n];
         name.len = p - name.data;
         ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
     }
@@ -189,14 +166,12 @@ ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e, ngx_str_t *out,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_eval_streams(ngx_str_t *in)
+ngx_int_t ngx_rtmp_eval_streams(ngx_str_t *in)
 {
 #if !(NGX_WIN32)
-    ngx_int_t   mode, create, v, close_src;
-    ngx_fd_t    dst, src;
-    u_char     *path;
+    ngx_int_t mode, create, v, close_src;
+    ngx_fd_t dst, src;
+    u_char *path;
 
     path = in->data;
 
@@ -204,65 +179,61 @@ ngx_rtmp_eval_streams(ngx_str_t *in)
         path++;
     }
 
-    switch ((char) *path) {
+    switch ((char)*path) {
+    case '>':
 
-        case '>':
+        v = (path == in->data ? 1 : ngx_atoi(in->data, path - in->data));
+        if (v == NGX_ERROR) {
+            return NGX_ERROR;
+        }
 
-            v = (path == in->data ? 1 : ngx_atoi(in->data, path - in->data));
-            if (v == NGX_ERROR) {
-                return NGX_ERROR;
-            }
+        dst    = (ngx_fd_t)v;
+        mode   = NGX_FILE_WRONLY;
+        create = NGX_FILE_TRUNCATE;
+        path++;
 
-            dst = (ngx_fd_t) v;
-            mode = NGX_FILE_WRONLY;
-            create = NGX_FILE_TRUNCATE;
+        if (*path == (u_char)'>') {
+            mode   = NGX_FILE_APPEND;
+            create = NGX_FILE_CREATE_OR_OPEN;
             path++;
+        }
 
-            if (*path == (u_char) '>') {
-                mode = NGX_FILE_APPEND;
-                create = NGX_FILE_CREATE_OR_OPEN;
-                path++;
-            }
+        break;
 
-            break;
+    case '<':
 
-        case '<':
+        v = (path == in->data ? 0 : ngx_atoi(in->data, path - in->data));
+        if (v == NGX_ERROR) {
+            return NGX_ERROR;
+        }
 
-            v = (path == in->data ? 0 : ngx_atoi(in->data, path - in->data));
-            if (v == NGX_ERROR) {
-                return NGX_ERROR;
-            }
+        dst    = (ngx_fd_t)v;
+        mode   = NGX_FILE_RDONLY;
+        create = NGX_FILE_OPEN;
+        path++;
 
-            dst = (ngx_fd_t) v;
-            mode = NGX_FILE_RDONLY;
-            create = NGX_FILE_OPEN;
-            path++;
+        break;
 
-            break;
+    default:
 
-        default:
-
-            return NGX_DONE;
+        return NGX_DONE;
     }
 
-    if (*path == (u_char) '&') {
-
+    if (*path == (u_char)'&') {
         path++;
         v = ngx_atoi(path, in->data + in->len - path);
         if (v == NGX_ERROR) {
             return NGX_ERROR;
         }
-        src = (ngx_fd_t) v;
+        src       = (ngx_fd_t)v;
         close_src = 0;
 
     } else {
-
         src = ngx_open_file(path, mode, create, NGX_FILE_DEFAULT_ACCESS);
         if (src == NGX_INVALID_FILE) {
             return NGX_ERROR;
         }
         close_src = 1;
-
     }
 
     if (src == dst) {

--- a/ngx_rtmp_eval.h
+++ b/ngx_rtmp_eval.h
@@ -3,42 +3,34 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_EVAL_H_INCLUDED_
 #define _NGX_RTMP_EVAL_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-
 
 typedef struct ngx_rtmp_eval_s ngx_rtmp_eval_t;
 
-
-typedef void (* ngx_rtmp_eval_pt)(void *ctx, ngx_rtmp_eval_t *e,
-                                  ngx_str_t *ret);
-
+typedef void (*ngx_rtmp_eval_pt)(void *ctx, ngx_rtmp_eval_t *e, ngx_str_t *ret);
 
 struct ngx_rtmp_eval_s {
-    ngx_str_t               name;
-    ngx_rtmp_eval_pt        handler;
-    ngx_uint_t              offset;
+    ngx_str_t name;
+    ngx_rtmp_eval_pt handler;
+    ngx_uint_t offset;
 };
 
-
-#define ngx_rtmp_null_eval  { ngx_null_string, NULL, 0 }
-
+#define ngx_rtmp_null_eval                                                     \
+    {                                                                          \
+        ngx_null_string, NULL, 0                                               \
+    }
 
 /* standard session eval variables */
-extern ngx_rtmp_eval_t      ngx_rtmp_eval_session[];
-
+extern ngx_rtmp_eval_t ngx_rtmp_eval_session[];
 
 ngx_int_t ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e,
-    ngx_str_t *out, ngx_log_t *log);
-
+                        ngx_str_t *out, ngx_log_t *log);
 
 ngx_int_t ngx_rtmp_eval_streams(ngx_str_t *in);
-
 
 #endif /* _NGX_RTMP_EVAL_H_INCLUDED_ */

--- a/ngx_rtmp_exec_module.c
+++ b/ngx_rtmp_exec_module.c
@@ -3,49 +3,42 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_cmd_module.h"
+#include "ngx_rtmp_eval.h"
+#include "ngx_rtmp_record_module.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_cmd_module.h"
-#include "ngx_rtmp_record_module.h"
-#include "ngx_rtmp_eval.h"
 #include <stdlib.h>
 
 #ifdef NGX_LINUX
 #include <unistd.h>
 #endif
 
-
 #if !(NGX_WIN32)
-static ngx_rtmp_publish_pt              next_publish;
-static ngx_rtmp_play_pt                 next_play;
-static ngx_rtmp_close_stream_pt         next_close_stream;
-static ngx_rtmp_record_done_pt          next_record_done;
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_play_pt next_play;
+static ngx_rtmp_close_stream_pt next_close_stream;
+static ngx_rtmp_record_done_pt next_record_done;
 #endif
-
 
 static ngx_int_t ngx_rtmp_exec_init_process(ngx_cycle_t *cycle);
 static ngx_int_t ngx_rtmp_exec_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_exec_create_main_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf);
-static void * ngx_rtmp_exec_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_exec_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
+static void *ngx_rtmp_exec_create_main_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf);
+static void *ngx_rtmp_exec_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_exec_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                          void *child);
 /*static char * ngx_rtmp_exec_block(ngx_conf_t *cf, ngx_command_t *cmd,
        void *conf);*/
-static char * ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+static char *ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_rtmp_exec_kill_signal(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+                                       void *conf);
 
+#define NGX_RTMP_EXEC_RESPAWN 0x01
+#define NGX_RTMP_EXEC_KILL 0x02
 
-#define NGX_RTMP_EXEC_RESPAWN           0x01
-#define NGX_RTMP_EXEC_KILL              0x02
-
-
-#define NGX_RTMP_EXEC_PUBLISHING        0x01
-#define NGX_RTMP_EXEC_PLAYING           0x02
-
+#define NGX_RTMP_EXEC_PUBLISHING 0x01
+#define NGX_RTMP_EXEC_PLAYING 0x02
 
 enum {
     NGX_RTMP_EXEC_PUSH,
@@ -62,79 +55,72 @@ enum {
     NGX_RTMP_EXEC_STATIC
 };
 
-
 typedef struct {
-    ngx_str_t                           id;
-    ngx_uint_t                          type;
-    ngx_str_t                           cmd;
-    ngx_array_t                         args;       /* ngx_str_t */
-    ngx_array_t                         names;
+    ngx_str_t id;
+    ngx_uint_t type;
+    ngx_str_t cmd;
+    ngx_array_t args; /* ngx_str_t */
+    ngx_array_t names;
 } ngx_rtmp_exec_conf_t;
 
-
 typedef struct {
-    ngx_rtmp_exec_conf_t               *conf;
-    ngx_log_t                          *log;
-    ngx_rtmp_eval_t                   **eval;
-    void                               *eval_ctx;
-    unsigned                            active:1;
-    unsigned                            managed:1;
-    ngx_pid_t                           pid;
-    ngx_pid_t                          *save_pid;
-    int                                 pipefd;
-    ngx_connection_t                    dummy_conn;  /*needed by ngx_xxx_event*/
-    ngx_event_t                         read_evt, write_evt;
-    ngx_event_t                         respawn_evt;
-    ngx_msec_t                          respawn_timeout;
-    ngx_int_t                           kill_signal;
+    ngx_rtmp_exec_conf_t *conf;
+    ngx_log_t *log;
+    ngx_rtmp_eval_t **eval;
+    void *eval_ctx;
+    unsigned active : 1;
+    unsigned managed : 1;
+    ngx_pid_t pid;
+    ngx_pid_t *save_pid;
+    int pipefd;
+    ngx_connection_t dummy_conn; /*needed by ngx_xxx_event*/
+    ngx_event_t read_evt, write_evt;
+    ngx_event_t respawn_evt;
+    ngx_msec_t respawn_timeout;
+    ngx_int_t kill_signal;
 } ngx_rtmp_exec_t;
 
-
 typedef struct {
-    ngx_array_t                         static_conf; /* ngx_rtmp_exec_conf_t */
-    ngx_array_t                         static_exec; /* ngx_rtmp_exec_t */
-    ngx_msec_t                          respawn_timeout;
-    ngx_int_t                           kill_signal;
-    ngx_log_t                          *log;
+    ngx_array_t static_conf; /* ngx_rtmp_exec_conf_t */
+    ngx_array_t static_exec; /* ngx_rtmp_exec_t */
+    ngx_msec_t respawn_timeout;
+    ngx_int_t kill_signal;
+    ngx_log_t *log;
 } ngx_rtmp_exec_main_conf_t;
 
-
-typedef struct ngx_rtmp_exec_pull_ctx_s  ngx_rtmp_exec_pull_ctx_t;
+typedef struct ngx_rtmp_exec_pull_ctx_s ngx_rtmp_exec_pull_ctx_t;
 
 struct ngx_rtmp_exec_pull_ctx_s {
-    ngx_pool_t                         *pool;
-    ngx_uint_t                          counter;
-    ngx_str_t                           name;
-    ngx_str_t                           app;
-    ngx_array_t                         pull_exec;   /* ngx_rtmp_exec_t */
-    ngx_rtmp_exec_pull_ctx_t           *next;
+    ngx_pool_t *pool;
+    ngx_uint_t counter;
+    ngx_str_t name;
+    ngx_str_t app;
+    ngx_array_t pull_exec; /* ngx_rtmp_exec_t */
+    ngx_rtmp_exec_pull_ctx_t *next;
 };
 
-
 typedef struct {
-    ngx_int_t                           active;
-    ngx_array_t                         conf[NGX_RTMP_EXEC_MAX];
-                                                     /* ngx_rtmp_exec_conf_t */
-    ngx_flag_t                          respawn;
-    ngx_flag_t                          options;
-    ngx_uint_t                          nbuckets;
-    ngx_rtmp_exec_pull_ctx_t          **pull;
+    ngx_int_t active;
+    ngx_array_t conf[NGX_RTMP_EXEC_MAX];
+    /* ngx_rtmp_exec_conf_t */
+    ngx_flag_t respawn;
+    ngx_flag_t options;
+    ngx_uint_t nbuckets;
+    ngx_rtmp_exec_pull_ctx_t **pull;
 } ngx_rtmp_exec_app_conf_t;
 
-
 typedef struct {
-    ngx_uint_t                          flags;
-    ngx_str_t                           path;     /* /tmp/rec/myfile-123.flv */
-    ngx_str_t                           filename; /* myfile-123.flv */
-    ngx_str_t                           basename; /* myfile-123 */
-    ngx_str_t                           dirname;  /* /tmp/rec */
-    ngx_str_t                           recorder;
-    u_char                              name[NGX_RTMP_MAX_NAME];
-    u_char                              args[NGX_RTMP_MAX_ARGS];
-    ngx_array_t                         push_exec;   /* ngx_rtmp_exec_t */
-    ngx_rtmp_exec_pull_ctx_t           *pull;
+    ngx_uint_t flags;
+    ngx_str_t path;     /* /tmp/rec/myfile-123.flv */
+    ngx_str_t filename; /* myfile-123.flv */
+    ngx_str_t basename; /* myfile-123 */
+    ngx_str_t dirname;  /* /tmp/rec */
+    ngx_str_t recorder;
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    ngx_array_t push_exec; /* ngx_rtmp_exec_t */
+    ngx_rtmp_exec_pull_ctx_t *pull;
 } ngx_rtmp_exec_ctx_t;
-
 
 #if !(NGX_WIN32)
 static void ngx_rtmp_exec_respawn(ngx_event_t *ev);
@@ -142,154 +128,129 @@ static ngx_int_t ngx_rtmp_exec_kill(ngx_rtmp_exec_t *e, ngx_int_t kill_signal);
 static ngx_int_t ngx_rtmp_exec_run(ngx_rtmp_exec_t *e);
 #endif
 
+static ngx_command_t ngx_rtmp_exec_commands[] = {
+    /*
+        { ngx_string("exec_block"),
+          NGX_RTMP_APP_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS|NGX_CONF_TAKE1,
+          ngx_rtmp_exec_block,
+          NGX_RTMP_APP_CONF_OFFSET,
+          0,
+          NULL },
+    */
+    {ngx_string("exec"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                             NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PUSH * sizeof(ngx_array_t),
+     NULL},
 
-static ngx_command_t  ngx_rtmp_exec_commands[] = {
-/*
-    { ngx_string("exec_block"),
-      NGX_RTMP_APP_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS|NGX_CONF_TAKE1,
-      ngx_rtmp_exec_block,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
-*/
-    { ngx_string("exec"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PUSH * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_push"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                  NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PUSH * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_push"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PUSH * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_pull"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                  NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PULL * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_pull"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PULL * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_publish"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                     NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PUBLISH * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_publish"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PUBLISH * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_publish_done"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                          NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PUBLISH_DONE * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_publish_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PUBLISH_DONE * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_play"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                  NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PLAY * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_play"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PLAY * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_play_done"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                       NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_PLAY_DONE * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_play_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_PLAY_DONE * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_record_done"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_RTMP_REC_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, conf) +
+         NGX_RTMP_EXEC_RECORD_DONE * sizeof(ngx_array_t),
+     NULL},
 
-    { ngx_string("exec_record_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_RTMP_REC_CONF|
-                         NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, conf) +
-      NGX_RTMP_EXEC_RECORD_DONE * sizeof(ngx_array_t),
-      NULL },
+    {ngx_string("exec_static"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                    NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_exec_conf, NGX_RTMP_MAIN_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_main_conf_t, static_conf), NULL},
 
-    { ngx_string("exec_static"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_exec_conf,
-      NGX_RTMP_MAIN_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_main_conf_t, static_conf),
-      NULL },
+    {ngx_string("respawn"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, respawn), NULL},
 
-    { ngx_string("respawn"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, respawn),
-      NULL },
+    {ngx_string("respawn_timeout"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                        NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_MAIN_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_main_conf_t, respawn_timeout), NULL},
 
-    { ngx_string("respawn_timeout"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_MAIN_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_main_conf_t, respawn_timeout),
-      NULL },
+    {ngx_string("exec_kill_signal"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                         NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_exec_kill_signal, NGX_RTMP_MAIN_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("exec_kill_signal"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_exec_kill_signal,
-      NGX_RTMP_MAIN_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("exec_options"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                     NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_exec_app_conf_t, options), NULL},
 
-    { ngx_string("exec_options"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_exec_app_conf_t, options),
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_exec_module_ctx = {
+    NULL,                            /* preconfiguration */
+    ngx_rtmp_exec_postconfiguration, /* postconfiguration */
+    ngx_rtmp_exec_create_main_conf,  /* create main configuration */
+    ngx_rtmp_exec_init_main_conf,    /* init main configuration */
+    NULL,                            /* create server configuration */
+    NULL,                            /* merge server configuration */
+    ngx_rtmp_exec_create_app_conf,   /* create app configuration */
+    ngx_rtmp_exec_merge_app_conf     /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_exec_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_exec_postconfiguration,        /* postconfiguration */
-    ngx_rtmp_exec_create_main_conf,         /* create main configuration */
-    ngx_rtmp_exec_init_main_conf,           /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    ngx_rtmp_exec_create_app_conf,          /* create app configuration */
-    ngx_rtmp_exec_merge_app_conf            /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_exec_module = {
+ngx_module_t ngx_rtmp_exec_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_exec_module_ctx,              /* module context */
-    ngx_rtmp_exec_commands,                 /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    ngx_rtmp_exec_init_process,             /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_exec_module_ctx,  /* module context */
+    ngx_rtmp_exec_commands,     /* module directives */
+    NGX_RTMP_MODULE,            /* module type */
+    NULL,                       /* init master */
+    NULL,                       /* init module */
+    ngx_rtmp_exec_init_process, /* init process */
+    NULL,                       /* init thread */
+    NULL,                       /* exit thread */
+    NULL,                       /* exit process */
+    NULL,                       /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void
-ngx_rtmp_exec_eval_ctx_cstr(void *sctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
+static void ngx_rtmp_exec_eval_ctx_cstr(void *sctx, ngx_rtmp_eval_t *e,
+                                        ngx_str_t *ret)
 {
-    ngx_rtmp_session_t  *s = sctx;
+    ngx_rtmp_session_t *s = sctx;
 
-    ngx_rtmp_exec_ctx_t  *ctx;
+    ngx_rtmp_exec_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
     if (ctx == NULL) {
@@ -297,17 +258,16 @@ ngx_rtmp_exec_eval_ctx_cstr(void *sctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
         return;
     }
 
-    ret->data = (u_char *) ctx + e->offset;
-    ret->len = ngx_strlen(ret->data);
+    ret->data = (u_char *)ctx + e->offset;
+    ret->len  = ngx_strlen(ret->data);
 }
 
-
-static void
-ngx_rtmp_exec_eval_ctx_str(void *sctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
+static void ngx_rtmp_exec_eval_ctx_str(void *sctx, ngx_rtmp_eval_t *e,
+                                       ngx_str_t *ret)
 {
-    ngx_rtmp_session_t  *s = sctx;
+    ngx_rtmp_session_t *s = sctx;
 
-    ngx_rtmp_exec_ctx_t  *ctx;
+    ngx_rtmp_exec_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
     if (ctx == NULL) {
@@ -315,103 +275,72 @@ ngx_rtmp_exec_eval_ctx_str(void *sctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
         return;
     }
 
-    *ret = * (ngx_str_t *) ((u_char *) ctx + e->offset);
+    *ret = *(ngx_str_t *)((u_char *)ctx + e->offset);
 }
 
-
-static void
-ngx_rtmp_exec_eval_pctx_str(void *ctx, ngx_rtmp_eval_t *e, ngx_str_t *ret)
+static void ngx_rtmp_exec_eval_pctx_str(void *ctx, ngx_rtmp_eval_t *e,
+                                        ngx_str_t *ret)
 {
-    *ret = *(ngx_str_t *) ((u_char *) ctx + e->offset);
+    *ret = *(ngx_str_t *)((u_char *)ctx + e->offset);
 }
-
 
 static ngx_rtmp_eval_t ngx_rtmp_exec_push_specific_eval[] = {
 
-    { ngx_string("name"),
-      ngx_rtmp_exec_eval_ctx_cstr,
-      offsetof(ngx_rtmp_exec_ctx_t, name) },
+    {ngx_string("name"), ngx_rtmp_exec_eval_ctx_cstr,
+     offsetof(ngx_rtmp_exec_ctx_t, name)},
 
-    { ngx_string("args"),
-      ngx_rtmp_exec_eval_ctx_cstr,
-      offsetof(ngx_rtmp_exec_ctx_t, args) },
+    {ngx_string("args"), ngx_rtmp_exec_eval_ctx_cstr,
+     offsetof(ngx_rtmp_exec_ctx_t, args)},
 
-    ngx_rtmp_null_eval
-};
+    ngx_rtmp_null_eval};
 
-
-static ngx_rtmp_eval_t * ngx_rtmp_exec_push_eval[] = {
-    ngx_rtmp_eval_session,
-    ngx_rtmp_exec_push_specific_eval,
-    NULL
-};
-
+static ngx_rtmp_eval_t *ngx_rtmp_exec_push_eval[] = {
+    ngx_rtmp_eval_session, ngx_rtmp_exec_push_specific_eval, NULL};
 
 static ngx_rtmp_eval_t ngx_rtmp_exec_pull_specific_eval[] = {
 
-    { ngx_string("name"),
-      ngx_rtmp_exec_eval_pctx_str,
-      offsetof(ngx_rtmp_exec_pull_ctx_t, name) },
+    {ngx_string("name"), ngx_rtmp_exec_eval_pctx_str,
+     offsetof(ngx_rtmp_exec_pull_ctx_t, name)},
 
-    { ngx_string("app"),
-      ngx_rtmp_exec_eval_pctx_str,
-      offsetof(ngx_rtmp_exec_pull_ctx_t, app) },
+    {ngx_string("app"), ngx_rtmp_exec_eval_pctx_str,
+     offsetof(ngx_rtmp_exec_pull_ctx_t, app)},
 
-    ngx_rtmp_null_eval
-};
+    ngx_rtmp_null_eval};
 
-
-static ngx_rtmp_eval_t * ngx_rtmp_exec_pull_eval[] = {
-    ngx_rtmp_exec_pull_specific_eval,
-    NULL
-};
-
+static ngx_rtmp_eval_t *ngx_rtmp_exec_pull_eval[] = {
+    ngx_rtmp_exec_pull_specific_eval, NULL};
 
 static ngx_rtmp_eval_t ngx_rtmp_exec_event_specific_eval[] = {
 
-    { ngx_string("name"),
-      ngx_rtmp_exec_eval_ctx_cstr,
-      offsetof(ngx_rtmp_exec_ctx_t, name) },
+    {ngx_string("name"), ngx_rtmp_exec_eval_ctx_cstr,
+     offsetof(ngx_rtmp_exec_ctx_t, name)},
 
-    { ngx_string("args"),
-      ngx_rtmp_exec_eval_ctx_cstr,
-      offsetof(ngx_rtmp_exec_ctx_t, args) },
+    {ngx_string("args"), ngx_rtmp_exec_eval_ctx_cstr,
+     offsetof(ngx_rtmp_exec_ctx_t, args)},
 
-    { ngx_string("path"),
-      ngx_rtmp_exec_eval_ctx_str,
-      offsetof(ngx_rtmp_exec_ctx_t, path) },
+    {ngx_string("path"), ngx_rtmp_exec_eval_ctx_str,
+     offsetof(ngx_rtmp_exec_ctx_t, path)},
 
-    { ngx_string("filename"),
-      ngx_rtmp_exec_eval_ctx_str,
-      offsetof(ngx_rtmp_exec_ctx_t, filename) },
+    {ngx_string("filename"), ngx_rtmp_exec_eval_ctx_str,
+     offsetof(ngx_rtmp_exec_ctx_t, filename)},
 
-    { ngx_string("basename"),
-      ngx_rtmp_exec_eval_ctx_str,
-      offsetof(ngx_rtmp_exec_ctx_t, basename) },
+    {ngx_string("basename"), ngx_rtmp_exec_eval_ctx_str,
+     offsetof(ngx_rtmp_exec_ctx_t, basename)},
 
-    { ngx_string("dirname"),
-      ngx_rtmp_exec_eval_ctx_str,
-      offsetof(ngx_rtmp_exec_ctx_t, dirname) },
+    {ngx_string("dirname"), ngx_rtmp_exec_eval_ctx_str,
+     offsetof(ngx_rtmp_exec_ctx_t, dirname)},
 
-    { ngx_string("recorder"),
-      ngx_rtmp_exec_eval_ctx_str,
-      offsetof(ngx_rtmp_exec_ctx_t, recorder) },
+    {ngx_string("recorder"), ngx_rtmp_exec_eval_ctx_str,
+     offsetof(ngx_rtmp_exec_ctx_t, recorder)},
 
-    ngx_rtmp_null_eval
-};
+    ngx_rtmp_null_eval};
 
+static ngx_rtmp_eval_t *ngx_rtmp_exec_event_eval[] = {
+    ngx_rtmp_eval_session, ngx_rtmp_exec_event_specific_eval, NULL};
 
-static ngx_rtmp_eval_t * ngx_rtmp_exec_event_eval[] = {
-    ngx_rtmp_eval_session,
-    ngx_rtmp_exec_event_specific_eval,
-    NULL
-};
-
-
-static void *
-ngx_rtmp_exec_create_main_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_exec_create_main_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_exec_main_conf_t     *emcf;
+    ngx_rtmp_exec_main_conf_t *emcf;
 
     emcf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_exec_main_conf_t));
     if (emcf == NULL) {
@@ -419,25 +348,22 @@ ngx_rtmp_exec_create_main_conf(ngx_conf_t *cf)
     }
 
     emcf->respawn_timeout = NGX_CONF_UNSET_MSEC;
-    emcf->kill_signal = NGX_CONF_UNSET;
+    emcf->kill_signal     = NGX_CONF_UNSET;
 
     if (ngx_array_init(&emcf->static_conf, cf->pool, 1,
-                       sizeof(ngx_rtmp_exec_conf_t)) != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_exec_conf_t)) != NGX_OK) {
         return NULL;
     }
 
     return emcf;
 }
 
-
-static char *
-ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf)
+static char *ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf)
 {
-    ngx_rtmp_exec_main_conf_t  *emcf = conf;
-    ngx_rtmp_exec_conf_t       *ec;
-    ngx_rtmp_exec_t            *e;
-    ngx_uint_t                  n;
+    ngx_rtmp_exec_main_conf_t *emcf = conf;
+    ngx_rtmp_exec_conf_t *ec;
+    ngx_rtmp_exec_t *e;
+    ngx_uint_t n;
 
     if (emcf->respawn_timeout == NGX_CONF_UNSET_MSEC) {
         emcf->respawn_timeout = 5000;
@@ -449,10 +375,8 @@ ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf)
     }
 #endif
 
-    if (ngx_array_init(&emcf->static_exec, cf->pool,
-                       emcf->static_conf.nelts,
-                       sizeof(ngx_rtmp_exec_t)) != NGX_OK)
-    {
+    if (ngx_array_init(&emcf->static_exec, cf->pool, emcf->static_conf.nelts,
+                       sizeof(ngx_rtmp_exec_t)) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 
@@ -467,40 +391,36 @@ ngx_rtmp_exec_init_main_conf(ngx_conf_t *cf, void *conf)
 
     for (n = 0; n < emcf->static_conf.nelts; n++, e++, ec++) {
         ngx_memzero(e, sizeof(*e));
-        e->conf = ec;
-        e->managed = 1;
-        e->log = emcf->log;
+        e->conf            = ec;
+        e->managed         = 1;
+        e->log             = emcf->log;
         e->respawn_timeout = emcf->respawn_timeout;
-        e->kill_signal = emcf->kill_signal;
+        e->kill_signal     = emcf->kill_signal;
     }
 
     return NGX_CONF_OK;
 }
 
-
-static void *
-ngx_rtmp_exec_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_exec_create_app_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_exec_app_conf_t      *eacf;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
     eacf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_exec_app_conf_t));
     if (eacf == NULL) {
         return NULL;
     }
 
-    eacf->respawn = NGX_CONF_UNSET;
-    eacf->options = NGX_CONF_UNSET;
+    eacf->respawn  = NGX_CONF_UNSET;
+    eacf->options  = NGX_CONF_UNSET;
     eacf->nbuckets = NGX_CONF_UNSET_UINT;
 
     return eacf;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_merge_confs(ngx_array_t *conf, ngx_array_t *prev)
+static ngx_int_t ngx_rtmp_exec_merge_confs(ngx_array_t *conf, ngx_array_t *prev)
 {
-    size_t                 n;
-    ngx_rtmp_exec_conf_t  *ec, *pec;
+    size_t n;
+    ngx_rtmp_exec_conf_t *ec, *pec;
 
     if (prev->nelts == 0) {
         return NGX_OK;
@@ -524,21 +444,20 @@ ngx_rtmp_exec_merge_confs(ngx_array_t *conf, ngx_array_t *prev)
     return NGX_OK;
 }
 
-
-static char *
-ngx_rtmp_exec_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_exec_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                          void *child)
 {
-    ngx_rtmp_exec_app_conf_t   *prev = parent;
-    ngx_rtmp_exec_app_conf_t   *conf = child;
+    ngx_rtmp_exec_app_conf_t *prev = parent;
+    ngx_rtmp_exec_app_conf_t *conf = child;
 
-    ngx_uint_t  n;
+    ngx_uint_t n;
 
     ngx_conf_merge_value(conf->respawn, prev->respawn, 1);
     ngx_conf_merge_uint_value(conf->nbuckets, prev->nbuckets, 1024);
 
     for (n = 0; n < NGX_RTMP_EXEC_MAX; n++) {
-        if (ngx_rtmp_exec_merge_confs(&conf->conf[n], &prev->conf[n]) != NGX_OK)
-        {
+        if (ngx_rtmp_exec_merge_confs(&conf->conf[n], &prev->conf[n]) !=
+            NGX_OK) {
             return NGX_CONF_ERROR;
         }
 
@@ -558,17 +477,15 @@ ngx_rtmp_exec_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_init_process(ngx_cycle_t *cycle)
+static ngx_int_t ngx_rtmp_exec_init_process(ngx_cycle_t *cycle)
 {
 #if !(NGX_WIN32)
-    ngx_rtmp_core_main_conf_t  *cmcf = ngx_rtmp_core_main_conf;
-    ngx_rtmp_core_srv_conf_t  **cscf;
-    ngx_rtmp_conf_ctx_t        *cctx;
-    ngx_rtmp_exec_main_conf_t  *emcf;
-    ngx_rtmp_exec_t            *e;
-    ngx_uint_t                  n;
+    ngx_rtmp_core_main_conf_t *cmcf = ngx_rtmp_core_main_conf;
+    ngx_rtmp_core_srv_conf_t **cscf;
+    ngx_rtmp_conf_ctx_t *cctx;
+    ngx_rtmp_exec_main_conf_t *emcf;
+    ngx_rtmp_exec_t *e;
+    ngx_uint_t n;
 
     if (cmcf == NULL || cmcf->servers.nelts == 0) {
         return NGX_OK;
@@ -596,8 +513,8 @@ ngx_rtmp_exec_init_process(ngx_cycle_t *cycle)
 
     e = emcf->static_exec.elts;
     for (n = 0; n < emcf->static_exec.nelts; ++n, ++e) {
-        e->respawn_evt.data = e;
-        e->respawn_evt.log = e->log;
+        e->respawn_evt.data    = e;
+        e->respawn_evt.log     = e->log;
         e->respawn_evt.handler = ngx_rtmp_exec_respawn;
         ngx_post_event((&e->respawn_evt), &ngx_rtmp_init_queue);
     }
@@ -606,27 +523,23 @@ ngx_rtmp_exec_init_process(ngx_cycle_t *cycle)
     return NGX_OK;
 }
 
-
 #if !(NGX_WIN32)
-static void
-ngx_rtmp_exec_respawn(ngx_event_t *ev)
+static void ngx_rtmp_exec_respawn(ngx_event_t *ev)
 {
-    ngx_rtmp_exec_run((ngx_rtmp_exec_t *) ev->data);
+    ngx_rtmp_exec_run((ngx_rtmp_exec_t *)ev->data);
 }
 
-
-static void
-ngx_rtmp_exec_child_dead(ngx_event_t *ev)
+static void ngx_rtmp_exec_child_dead(ngx_event_t *ev)
 {
-    ngx_connection_t   *dummy_conn = ev->data;
-    ngx_rtmp_exec_t    *e;
+    ngx_connection_t *dummy_conn = ev->data;
+    ngx_rtmp_exec_t *e;
 
     e = dummy_conn->data;
 
-    ngx_log_error(NGX_LOG_INFO, e->log, 0,
-                  "exec: child %ui exited; %s", (ngx_int_t) e->pid,
-                  e->respawn_timeout == NGX_CONF_UNSET_MSEC ? "respawning" :
-                                                               "ignoring");
+    ngx_log_error(NGX_LOG_INFO, e->log, 0, "exec: child %ui exited; %s",
+                  (ngx_int_t)e->pid,
+                  e->respawn_timeout == NGX_CONF_UNSET_MSEC ? "respawning"
+                                                            : "ignoring");
 
     ngx_rtmp_exec_kill(e, 0);
 
@@ -642,16 +555,14 @@ ngx_rtmp_exec_child_dead(ngx_event_t *ev)
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, e->log, 0,
                    "exec: shedule respawn %Mmsec", e->respawn_timeout);
 
-    e->respawn_evt.data = e;
-    e->respawn_evt.log = e->log;
+    e->respawn_evt.data    = e;
+    e->respawn_evt.log     = e->log;
     e->respawn_evt.handler = ngx_rtmp_exec_respawn;
 
     ngx_add_timer(&e->respawn_evt, e->respawn_timeout);
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_kill(ngx_rtmp_exec_t *e, ngx_int_t kill_signal)
+static ngx_int_t ngx_rtmp_exec_kill(ngx_rtmp_exec_t *e, ngx_int_t kill_signal)
 {
     if (e->respawn_evt.timer_set) {
         ngx_del_timer(&e->respawn_evt);
@@ -665,8 +576,8 @@ ngx_rtmp_exec_kill(ngx_rtmp_exec_t *e, ngx_int_t kill_signal)
         return NGX_OK;
     }
 
-    ngx_log_error(NGX_LOG_INFO, e->log, 0,
-                  "exec: terminating child %ui", (ngx_int_t) e->pid);
+    ngx_log_error(NGX_LOG_INFO, e->log, 0, "exec: terminating child %ui",
+                  (ngx_int_t)e->pid);
 
     e->active = 0;
     close(e->pipefd);
@@ -680,37 +591,33 @@ ngx_rtmp_exec_kill(ngx_rtmp_exec_t *e, ngx_int_t kill_signal)
 
     if (kill(e->pid, kill_signal) == -1) {
         ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno,
-                      "exec: kill failed pid=%i", (ngx_int_t) e->pid);
+                      "exec: kill failed pid=%i", (ngx_int_t)e->pid);
     } else {
-        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, e->log, 0,
-                       "exec: killed pid=%i", (ngx_int_t) e->pid);
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, e->log, 0, "exec: killed pid=%i",
+                       (ngx_int_t)e->pid);
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
+static ngx_int_t ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
 {
-    int                     fd, ret, maxfd, pipefd[2];
-    char                  **args, **arg_out;
-    ngx_pid_t               pid;
-    ngx_str_t              *arg_in, a;
-    ngx_uint_t              n;
-    ngx_rtmp_exec_conf_t   *ec;
+    int fd, ret, maxfd, pipefd[2];
+    char **args, **arg_out;
+    ngx_pid_t pid;
+    ngx_str_t *arg_in, a;
+    ngx_uint_t n;
+    ngx_rtmp_exec_conf_t *ec;
 
     ec = e->conf;
 
-    ngx_log_error(NGX_LOG_INFO, e->log, 0,
-                  "exec: starting %s child '%V'",
+    ngx_log_error(NGX_LOG_INFO, e->log, 0, "exec: starting %s child '%V'",
                   e->managed ? "managed" : "unmanaged", &ec->cmd);
 
     pipefd[0] = -1;
     pipefd[1] = -1;
 
     if (e->managed) {
-
         if (e->active) {
             ngx_log_debug1(NGX_LOG_DEBUG_RTMP, e->log, 0,
                            "exec: already active '%V'", &ec->cmd);
@@ -718,8 +625,7 @@ ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
         }
 
         if (pipe(pipefd) == -1) {
-            ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno,
-                          "exec: pipe failed");
+            ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno, "exec: pipe failed");
             return NGX_ERROR;
         }
 
@@ -733,7 +639,6 @@ ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
         }
 
         if (ret == -1) {
-
             close(pipefd[0]);
             close(pipefd[1]);
 
@@ -747,160 +652,156 @@ ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
     pid = fork();
 
     switch (pid) {
+    case -1:
 
-        case -1:
+        /* failure */
 
-            /* failure */
+        if (pipefd[0] != -1) {
+            close(pipefd[0]);
+        }
 
-            if (pipefd[0] != -1) {
-                close(pipefd[0]);
-            }
+        if (pipefd[1] != -1) {
+            close(pipefd[1]);
+        }
 
-            if (pipefd[1] != -1) {
-                close(pipefd[1]);
-            }
+        ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno, "exec: fork failed");
 
-            ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno,
-                          "exec: fork failed");
+        return NGX_ERROR;
 
-            return NGX_ERROR;
+    case 0:
 
-        case 0:
-
-            /* child */
+/* child */
 
 #if (NGX_LINUX)
-            if (e->managed) {
-                prctl(PR_SET_PDEATHSIG, e->kill_signal, 0, 0, 0);
-            }
+        if (e->managed) {
+            prctl(PR_SET_PDEATHSIG, e->kill_signal, 0, 0, 0);
+        }
 #endif
 
-            /* close all descriptors but pipe write end */
+        /* close all descriptors but pipe write end */
 
-            maxfd = sysconf(_SC_OPEN_MAX);
-            for (fd = 0; fd < maxfd; ++fd) {
-                if (fd == pipefd[1]) {
-                    continue;
-                }
-
-                close(fd);
+        maxfd = sysconf(_SC_OPEN_MAX);
+        for (fd = 0; fd < maxfd; ++fd) {
+            if (fd == pipefd[1]) {
+                continue;
             }
 
-            fd = open("/dev/null", O_RDWR);
+            close(fd);
+        }
 
-            dup2(fd, STDIN_FILENO);
-            dup2(fd, STDOUT_FILENO);
-            dup2(fd, STDERR_FILENO);
+        fd = open("/dev/null", O_RDWR);
 
-            args = ngx_alloc((ec->args.nelts + 2) * sizeof(char *), e->log);
-            if (args == NULL) {
-                exit(1);
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+
+        args = ngx_alloc((ec->args.nelts + 2) * sizeof(char *), e->log);
+        if (args == NULL) {
+            exit(1);
+        }
+
+        arg_in     = ec->args.elts;
+        arg_out    = args;
+        *arg_out++ = (char *)ec->cmd.data;
+
+        for (n = 0; n < ec->args.nelts; n++, ++arg_in) {
+            if (e->eval == NULL) {
+                a = *arg_in;
+            } else {
+                ngx_rtmp_eval(e->eval_ctx, arg_in, e->eval, &a, e->log);
             }
 
-            arg_in = ec->args.elts;
-            arg_out = args;
-            *arg_out++ = (char *) ec->cmd.data;
-
-            for (n = 0; n < ec->args.nelts; n++, ++arg_in) {
-
-                if (e->eval == NULL) {
-                    a = *arg_in;
-                } else {
-                    ngx_rtmp_eval(e->eval_ctx, arg_in, e->eval, &a, e->log);
-                }
-
-                if (ngx_rtmp_eval_streams(&a) != NGX_DONE) {
-                    continue;
-                }
-
-                *arg_out++ = (char *) a.data;
+            if (ngx_rtmp_eval_streams(&a) != NGX_DONE) {
+                continue;
             }
 
-            *arg_out = NULL;
+            *arg_out++ = (char *)a.data;
+        }
+
+        *arg_out = NULL;
 
 #if (NGX_DEBUG)
-            {
-                char    **p;
+        {
+            char **p;
 
-                for (p = args; *p; p++) {
-                    ngx_write_fd(STDERR_FILENO, "'", 1);
-                    ngx_write_fd(STDERR_FILENO, *p, strlen(*p));
-                    ngx_write_fd(STDERR_FILENO, "' ", 2);
-                }
-
-                ngx_write_fd(STDERR_FILENO, "\n", 1);
+            for (p = args; *p; p++) {
+                ngx_write_fd(STDERR_FILENO, "'", 1);
+                ngx_write_fd(STDERR_FILENO, *p, strlen(*p));
+                ngx_write_fd(STDERR_FILENO, "' ", 2);
             }
+
+            ngx_write_fd(STDERR_FILENO, "\n", 1);
+        }
 #endif
 
-            if (execvp((char *) ec->cmd.data, args) == -1) {
-                char    *msg;
+        if (execvp((char *)ec->cmd.data, args) == -1) {
+            char *msg;
 
-                msg = strerror(errno);
+            msg = strerror(errno);
 
-                ngx_write_fd(STDERR_FILENO, "execvp error: ", 14);
-                ngx_write_fd(STDERR_FILENO, msg, strlen(msg));
-                ngx_write_fd(STDERR_FILENO, "\n", 1);
+            ngx_write_fd(STDERR_FILENO, "execvp error: ", 14);
+            ngx_write_fd(STDERR_FILENO, msg, strlen(msg));
+            ngx_write_fd(STDERR_FILENO, "\n", 1);
 
-                exit(1);
+            exit(1);
+        }
+
+        break;
+
+    default:
+
+        /* parent */
+
+        if (pipefd[1] != -1) {
+            close(pipefd[1]);
+        }
+
+        if (pipefd[0] != -1) {
+            e->active = 1;
+            e->pid    = pid;
+            e->pipefd = pipefd[0];
+
+            if (e->save_pid) {
+                *e->save_pid = pid;
             }
 
-            break;
+            e->dummy_conn.fd    = e->pipefd;
+            e->dummy_conn.data  = e;
+            e->dummy_conn.read  = &e->read_evt;
+            e->dummy_conn.write = &e->write_evt;
+            e->read_evt.data    = &e->dummy_conn;
+            e->write_evt.data   = &e->dummy_conn;
 
-        default:
+            e->read_evt.log     = e->log;
+            e->read_evt.handler = ngx_rtmp_exec_child_dead;
 
-            /* parent */
-
-            if (pipefd[1] != -1) {
-                close(pipefd[1]);
+            if (ngx_add_event(&e->read_evt, NGX_READ_EVENT, 0) != NGX_OK) {
+                ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno,
+                              "exec: failed to add child control event");
             }
+        }
 
-            if (pipefd[0] != -1) {
-
-                e->active = 1;
-                e->pid = pid;
-                e->pipefd = pipefd[0];
-
-                if (e->save_pid) {
-                    *e->save_pid = pid;
-                }
-
-                e->dummy_conn.fd = e->pipefd;
-                e->dummy_conn.data = e;
-                e->dummy_conn.read  = &e->read_evt;
-                e->dummy_conn.write = &e->write_evt;
-                e->read_evt.data  = &e->dummy_conn;
-                e->write_evt.data = &e->dummy_conn;
-
-                e->read_evt.log = e->log;
-                e->read_evt.handler = ngx_rtmp_exec_child_dead;
-
-                if (ngx_add_event(&e->read_evt, NGX_READ_EVENT, 0) != NGX_OK) {
-                    ngx_log_error(NGX_LOG_INFO, e->log, ngx_errno,
-                                  "exec: failed to add child control event");
-                }
-            }
-
-            ngx_log_debug2(NGX_LOG_DEBUG_RTMP, e->log, 0,
-                           "exec: child '%V' started pid=%i",
-                           &ec->cmd, (ngx_int_t) pid);
-            break;
+        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, e->log, 0,
+                       "exec: child '%V' started pid=%i", &ec->cmd,
+                       (ngx_int_t)pid);
+        break;
     }
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_init_ctx(ngx_rtmp_session_t *s, u_char name[NGX_RTMP_MAX_NAME],
-    u_char args[NGX_RTMP_MAX_ARGS], ngx_uint_t flags)
+static ngx_int_t ngx_rtmp_exec_init_ctx(ngx_rtmp_session_t *s,
+                                        u_char name[NGX_RTMP_MAX_NAME],
+                                        u_char args[NGX_RTMP_MAX_ARGS],
+                                        ngx_uint_t flags)
 {
-    ngx_uint_t                  n;
-    ngx_array_t                *push_conf;
-    ngx_rtmp_exec_t            *e;
-    ngx_rtmp_exec_ctx_t        *ctx;
-    ngx_rtmp_exec_conf_t       *ec;
-    ngx_rtmp_exec_app_conf_t   *eacf;
-    ngx_rtmp_exec_main_conf_t  *emcf;
+    ngx_uint_t n;
+    ngx_array_t *push_conf;
+    ngx_rtmp_exec_t *e;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_conf_t *ec;
+    ngx_rtmp_exec_app_conf_t *eacf;
+    ngx_rtmp_exec_main_conf_t *emcf;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
 
@@ -923,11 +824,9 @@ ngx_rtmp_exec_init_ctx(ngx_rtmp_session_t *s, u_char name[NGX_RTMP_MAX_NAME],
     push_conf = &eacf->conf[NGX_RTMP_EXEC_PUSH];
 
     if (push_conf->nelts > 0) {
-
         if (ngx_array_init(&ctx->push_exec, s->connection->pool,
                            push_conf->nelts,
-                           sizeof(ngx_rtmp_exec_t)) != NGX_OK)
-        {
+                           sizeof(ngx_rtmp_exec_t)) != NGX_OK) {
             return NGX_ERROR;
         }
 
@@ -941,14 +840,14 @@ ngx_rtmp_exec_init_ctx(ngx_rtmp_session_t *s, u_char name[NGX_RTMP_MAX_NAME],
 
         for (n = 0; n < push_conf->nelts; n++, e++, ec++) {
             ngx_memzero(e, sizeof(*e));
-            e->conf = ec;
-            e->managed = 1;
-            e->log = s->connection->log;
-            e->eval = ngx_rtmp_exec_push_eval;
-            e->eval_ctx = s;
+            e->conf        = ec;
+            e->managed     = 1;
+            e->log         = s->connection->log;
+            e->eval        = ngx_rtmp_exec_push_eval;
+            e->eval_ctx    = s;
             e->kill_signal = emcf->kill_signal;
-            e->respawn_timeout = (eacf->respawn ? emcf->respawn_timeout :
-                                  NGX_CONF_UNSET_MSEC);
+            e->respawn_timeout =
+                (eacf->respawn ? emcf->respawn_timeout : NGX_CONF_UNSET_MSEC);
         }
     }
 
@@ -962,21 +861,19 @@ done:
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
-    u_char name[NGX_RTMP_MAX_NAME])
+static ngx_int_t ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
+                                             u_char name[NGX_RTMP_MAX_NAME])
 {
-    size_t                      len;
-    ngx_uint_t                  n;
-    ngx_pool_t                 *pool;
-    ngx_array_t                *pull_conf;
-    ngx_rtmp_exec_t            *e;
-    ngx_rtmp_exec_ctx_t        *ctx;
-    ngx_rtmp_exec_conf_t       *ec;
-    ngx_rtmp_exec_pull_ctx_t   *pctx, **ppctx;
-    ngx_rtmp_exec_app_conf_t   *eacf;
-    ngx_rtmp_exec_main_conf_t  *emcf;
+    size_t len;
+    ngx_uint_t n;
+    ngx_pool_t *pool;
+    ngx_array_t *pull_conf;
+    ngx_rtmp_exec_t *e;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_conf_t *ec;
+    ngx_rtmp_exec_pull_ctx_t *pctx, **ppctx;
+    ngx_rtmp_exec_app_conf_t *eacf;
+    ngx_rtmp_exec_main_conf_t *emcf;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
     if (ctx->pull != NULL) {
@@ -1001,8 +898,7 @@ ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
         pctx = *ppctx;
 
         if (pctx->name.len == len &&
-            ngx_strncmp(name, pctx->name.data, len) == 0)
-        {
+            ngx_strncmp(name, pctx->name.data, len) == 0) {
             goto done;
         }
     }
@@ -1017,8 +913,8 @@ ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
         goto error;
     }
 
-    pctx->pool = pool;
-    pctx->name.len = len;
+    pctx->pool      = pool;
+    pctx->name.len  = len;
     pctx->name.data = ngx_palloc(pool, len);
 
     if (pctx->name.data == NULL) {
@@ -1027,7 +923,7 @@ ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
 
     ngx_memcpy(pctx->name.data, name, len);
 
-    pctx->app.len = s->app.len;
+    pctx->app.len  = s->app.len;
     pctx->app.data = ngx_palloc(pool, s->app.len);
 
     if (pctx->app.data == NULL) {
@@ -1037,8 +933,7 @@ ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
     ngx_memcpy(pctx->app.data, s->app.data, s->app.len);
 
     if (ngx_array_init(&pctx->pull_exec, pool, pull_conf->nelts,
-                       sizeof(ngx_rtmp_exec_t)) != NGX_OK)
-    {
+                       sizeof(ngx_rtmp_exec_t)) != NGX_OK) {
         goto error;
     }
 
@@ -1050,14 +945,14 @@ ngx_rtmp_exec_init_pull_ctx(ngx_rtmp_session_t *s,
     ec = pull_conf->elts;
     for (n = 0; n < pull_conf->nelts; n++, e++, ec++) {
         ngx_memzero(e, sizeof(*e));
-        e->conf = ec;
-        e->managed = 1;
-        e->log = emcf->log;
-        e->eval = ngx_rtmp_exec_pull_eval;
-        e->eval_ctx = pctx;
+        e->conf        = ec;
+        e->managed     = 1;
+        e->log         = emcf->log;
+        e->eval        = ngx_rtmp_exec_pull_eval;
+        e->eval_ctx    = pctx;
         e->kill_signal = emcf->kill_signal;
-        e->respawn_timeout = (eacf->respawn ? emcf->respawn_timeout :
-                                              NGX_CONF_UNSET_MSEC);
+        e->respawn_timeout =
+            (eacf->respawn ? emcf->respawn_timeout : NGX_CONF_UNSET_MSEC);
     }
 
     *ppctx = pctx;
@@ -1076,14 +971,13 @@ error:
     return NGX_ERROR;
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_filter(ngx_rtmp_session_t *s, ngx_rtmp_exec_conf_t *ec)
+static ngx_int_t ngx_rtmp_exec_filter(ngx_rtmp_session_t *s,
+                                      ngx_rtmp_exec_conf_t *ec)
 {
-    size_t                len;
-    ngx_str_t            *v;
-    ngx_uint_t            n;
-    ngx_rtmp_exec_ctx_t  *ctx;
+    size_t len;
+    ngx_str_t *v;
+    ngx_uint_t n;
+    ngx_rtmp_exec_ctx_t *ctx;
 
     if (ec->names.nelts == 0) {
         return NGX_OK;
@@ -1103,13 +997,12 @@ ngx_rtmp_exec_filter(ngx_rtmp_session_t *s, ngx_rtmp_exec_conf_t *ec)
     return NGX_DECLINED;
 }
 
-
-static void
-ngx_rtmp_exec_unmanaged(ngx_rtmp_session_t *s, ngx_array_t *e, const char *op)
+static void ngx_rtmp_exec_unmanaged(ngx_rtmp_session_t *s, ngx_array_t *e,
+                                    const char *op)
 {
-    ngx_uint_t             n;
-    ngx_rtmp_exec_t        en;
-    ngx_rtmp_exec_conf_t  *ec;
+    ngx_uint_t n;
+    ngx_rtmp_exec_t en;
+    ngx_rtmp_exec_conf_t *ec;
 
     if (e->nelts == 0) {
         return;
@@ -1126,21 +1019,20 @@ ngx_rtmp_exec_unmanaged(ngx_rtmp_session_t *s, ngx_array_t *e, const char *op)
 
         ngx_memzero(&en, sizeof(ngx_rtmp_exec_t));
 
-        en.conf = ec;
-        en.eval = ngx_rtmp_exec_event_eval;
+        en.conf     = ec;
+        en.eval     = ngx_rtmp_exec_event_eval;
         en.eval_ctx = s;
-        en.log = s->connection->log;
+        en.log      = s->connection->log;
 
         ngx_rtmp_exec_run(&en);
     }
 }
 
-
-static void
-ngx_rtmp_exec_managed(ngx_rtmp_session_t *s, ngx_array_t *e, const char *op)
+static void ngx_rtmp_exec_managed(ngx_rtmp_session_t *s, ngx_array_t *e,
+                                  const char *op)
 {
-    ngx_uint_t        n;
-    ngx_rtmp_exec_t  *en;
+    ngx_uint_t n;
+    ngx_rtmp_exec_t *en;
 
     if (e->nelts == 0) {
         return;
@@ -1157,12 +1049,11 @@ ngx_rtmp_exec_managed(ngx_rtmp_session_t *s, ngx_array_t *e, const char *op)
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_exec_publish(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_publish_t *v)
 {
-    ngx_rtmp_exec_ctx_t       *ctx;
-    ngx_rtmp_exec_app_conf_t  *eacf;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
     eacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_exec_module);
 
@@ -1174,9 +1065,8 @@ ngx_rtmp_exec_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-    if (ngx_rtmp_exec_init_ctx(s, v->name, v->args, NGX_RTMP_EXEC_PUBLISHING)
-        != NGX_OK)
-    {
+    if (ngx_rtmp_exec_init_ctx(s, v->name, v->args, NGX_RTMP_EXEC_PUBLISHING) !=
+        NGX_OK) {
         goto next;
     }
 
@@ -1190,16 +1080,14 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
+static ngx_int_t ngx_rtmp_exec_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
                   "exec: ngx_rtmp_exec_play");
 
-    ngx_rtmp_exec_ctx_t       *ctx;
-    ngx_rtmp_exec_pull_ctx_t  *pctx;
-    ngx_rtmp_exec_app_conf_t  *eacf;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_pull_ctx_t *pctx;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
     eacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_exec_module);
 
@@ -1207,9 +1095,8 @@ ngx_rtmp_exec_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         goto next;
     }
 
-    if (ngx_rtmp_exec_init_ctx(s, v->name, v->args, NGX_RTMP_EXEC_PLAYING)
-        != NGX_OK)
-    {
+    if (ngx_rtmp_exec_init_ctx(s, v->name, v->args, NGX_RTMP_EXEC_PLAYING) !=
+        NGX_OK) {
         goto next;
     }
 
@@ -1219,7 +1106,7 @@ ngx_rtmp_exec_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         goto next;
     }
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
     pctx = ctx->pull;
 
     if (pctx && pctx->counter == 1) {
@@ -1228,19 +1115,18 @@ ngx_rtmp_exec_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 
 next:
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
-              "exec: ngx_rtmp_exec_play: next");
+                  "exec: ngx_rtmp_exec_play: next");
     return next_play(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_close_stream(ngx_rtmp_session_t *s, ngx_rtmp_close_stream_t *v)
+static ngx_int_t ngx_rtmp_exec_close_stream(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_close_stream_t *v)
 {
-    size_t                     n;
-    ngx_rtmp_exec_t           *e;
-    ngx_rtmp_exec_ctx_t       *ctx;
-    ngx_rtmp_exec_pull_ctx_t  *pctx, **ppctx;
-    ngx_rtmp_exec_app_conf_t  *eacf;
+    size_t n;
+    ngx_rtmp_exec_t *e;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_pull_ctx_t *pctx, **ppctx;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
     eacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_exec_module);
     if (eacf == NULL) {
@@ -1306,14 +1192,13 @@ next:
     return next_close_stream(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_record_done(ngx_rtmp_session_t *s, ngx_rtmp_record_done_t *v)
+static ngx_int_t ngx_rtmp_exec_record_done(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_record_done_t *v)
 {
-    u_char                     c;
-    ngx_uint_t                 ext, dir;
-    ngx_rtmp_exec_ctx_t       *ctx;
-    ngx_rtmp_exec_app_conf_t  *eacf;
+    u_char c;
+    ngx_uint_t ext, dir;
+    ngx_rtmp_exec_ctx_t *ctx;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
     if (s->auto_pushed) {
         goto next;
@@ -1330,10 +1215,10 @@ ngx_rtmp_exec_record_done(ngx_rtmp_session_t *s, ngx_rtmp_record_done_t *v)
     }
 
     ctx->recorder = v->recorder;
-    ctx->path = v->path;
+    ctx->path     = v->path;
 
     ctx->dirname.data = ctx->path.data;
-    ctx->dirname.len = 0;
+    ctx->dirname.len  = 0;
 
     for (dir = ctx->path.len; dir > 0; dir--) {
         c = ctx->path.data[dir - 1];
@@ -1344,7 +1229,7 @@ ngx_rtmp_exec_record_done(ngx_rtmp_session_t *s, ngx_rtmp_record_done_t *v)
     }
 
     ctx->filename.data = ctx->path.data + dir;
-    ctx->filename.len = ctx->path.len - dir;
+    ctx->filename.len  = ctx->path.len - dir;
 
     ctx->basename = ctx->filename;
 
@@ -1366,26 +1251,23 @@ next:
 }
 #endif /* NGX_WIN32 */
 
-
-static char *
-ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    char  *p = conf;
+    char *p = conf;
 
-    size_t                     n, nargs;
-    ngx_str_t                 *s, *value, v;
-    ngx_array_t               *confs;
-    ngx_rtmp_exec_conf_t      *ec;
-    ngx_rtmp_exec_app_conf_t  *eacf;
+    size_t n, nargs;
+    ngx_str_t *s, *value, v;
+    ngx_array_t *confs;
+    ngx_rtmp_exec_conf_t *ec;
+    ngx_rtmp_exec_app_conf_t *eacf;
 
-    confs = (ngx_array_t *) (p + cmd->offset);
+    confs = (ngx_array_t *)(p + cmd->offset);
 
     eacf = ngx_rtmp_conf_get_module_app_conf(cf, ngx_rtmp_exec_module);
 
-    if (confs->nalloc == 0 && ngx_array_init(confs, cf->pool, 1,
-                                             sizeof(ngx_rtmp_exec_conf_t))
-                              != NGX_OK)
-    {
+    if (confs->nalloc == 0 &&
+        ngx_array_init(confs, cf->pool, 1, sizeof(ngx_rtmp_exec_conf_t)) !=
+            NGX_OK) {
         return NGX_CONF_ERROR;
     }
 
@@ -1401,7 +1283,7 @@ ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     /* type is undefined for explicit execs */
 
     ec->type = NGX_CONF_UNSET_UINT;
-    ec->cmd = value[1];
+    ec->cmd  = value[1];
 
     if (ngx_array_init(&ec->names, cf->pool, 1, sizeof(ngx_str_t)) != NGX_OK) {
         return NGX_CONF_ERROR;
@@ -1412,19 +1294,16 @@ ngx_rtmp_exec_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     nargs = cf->args->nelts - 2;
-    if (ngx_array_init(&ec->args, cf->pool, nargs, sizeof(ngx_str_t)) != NGX_OK)
-    {
+    if (ngx_array_init(&ec->args, cf->pool, nargs, sizeof(ngx_str_t)) !=
+        NGX_OK) {
         return NGX_CONF_ERROR;
     }
 
     for (n = 2; n < cf->args->nelts; n++) {
-
         v = value[n];
 
         if (eacf->options == 1) {
-
             if (v.len >= 5 && ngx_strncmp(v.data, "name=", 5) == 0) {
-
                 s = ngx_array_push(&ec->names);
                 if (s == NULL) {
                     return NGX_CONF_ERROR;
@@ -1533,12 +1412,12 @@ ngx_rtmp_exec_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 */
 
-static char *
-ngx_rtmp_exec_kill_signal(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_exec_kill_signal(ngx_conf_t *cf, ngx_command_t *cmd,
+                                       void *conf)
 {
-    ngx_rtmp_exec_main_conf_t  *emcf = conf;
+    ngx_rtmp_exec_main_conf_t *emcf = conf;
 
-    ngx_str_t  *value;
+    ngx_str_t *value;
 
     value = cf->args->elts;
     value++;
@@ -1548,15 +1427,14 @@ ngx_rtmp_exec_kill_signal(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_OK;
     }
 
-#define NGX_RMTP_EXEC_SIGNAL(name)                                          \
-    if (value->len == sizeof(#name) - 1 &&                                  \
-        ngx_strncasecmp(value->data, (u_char *) #name, value->len) == 0)    \
-    {                                                                       \
-        emcf->kill_signal = SIG##name;                                      \
-        return NGX_CONF_OK;                                                 \
+#define NGX_RMTP_EXEC_SIGNAL(name)                                             \
+    if (value->len == sizeof(#name) - 1 &&                                     \
+        ngx_strncasecmp(value->data, (u_char *)#name, value->len) == 0) {      \
+        emcf->kill_signal = SIG##name;                                         \
+        return NGX_CONF_OK;                                                    \
     }
 
-    /* POSIX.1-1990 signals */
+/* POSIX.1-1990 signals */
 
 #if !(NGX_WIN32)
     NGX_RMTP_EXEC_SIGNAL(HUP);
@@ -1585,22 +1463,20 @@ ngx_rtmp_exec_kill_signal(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return "unknown signal";
 }
 
-
-static ngx_int_t
-ngx_rtmp_exec_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_exec_postconfiguration(ngx_conf_t *cf)
 {
 #if !(NGX_WIN32)
 
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_exec_publish;
 
-    next_play = ngx_rtmp_play;
+    next_play     = ngx_rtmp_play;
     ngx_rtmp_play = ngx_rtmp_exec_play;
 
-    next_close_stream = ngx_rtmp_close_stream;
+    next_close_stream     = ngx_rtmp_close_stream;
     ngx_rtmp_close_stream = ngx_rtmp_exec_close_stream;
 
-    next_record_done = ngx_rtmp_record_done;
+    next_record_done     = ngx_rtmp_record_done;
     ngx_rtmp_record_done = ngx_rtmp_exec_record_done;
 
 #endif /* NGX_WIN32 */

--- a/ngx_rtmp_flv_module.c
+++ b/ngx_rtmp_flv_module.c
@@ -3,94 +3,83 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_codec_module.h"
+#include "ngx_rtmp_play_module.h"
+#include "ngx_rtmp_streams.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_play_module.h"
-#include "ngx_rtmp_codec_module.h"
-#include "ngx_rtmp_streams.h"
-
 
 static ngx_int_t ngx_rtmp_flv_postconfiguration(ngx_conf_t *cf);
 static void ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f);
 static ngx_int_t ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s,
-       ngx_file_t *f, ngx_int_t timestamp);
+                                                  ngx_file_t *f,
+                                                  ngx_int_t timestamp);
 static ngx_int_t ngx_rtmp_flv_init(ngx_rtmp_session_t *s, ngx_file_t *f,
-       ngx_int_t aindex, ngx_int_t vindex);
+                                   ngx_int_t aindex, ngx_int_t vindex);
 static ngx_int_t ngx_rtmp_flv_start(ngx_rtmp_session_t *s, ngx_file_t *f);
 static ngx_int_t ngx_rtmp_flv_seek(ngx_rtmp_session_t *s, ngx_file_t *f,
-       ngx_uint_t offset);
+                                   ngx_uint_t offset);
 static ngx_int_t ngx_rtmp_flv_stop(ngx_rtmp_session_t *s, ngx_file_t *f);
 static ngx_int_t ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f,
                                    ngx_uint_t *ts);
 
-
 typedef struct {
-    ngx_uint_t                          nelts;
-    ngx_uint_t                          offset;
+    ngx_uint_t nelts;
+    ngx_uint_t offset;
 } ngx_rtmp_flv_index_t;
 
-
 typedef struct {
-    ngx_int_t                           offset;
-    ngx_int_t                           start_timestamp;
-    ngx_event_t                         write_evt;
-    uint32_t                            last_audio;
-    uint32_t                            last_video;
-    ngx_uint_t                          msg_mask;
-    uint32_t                            epoch;
+    ngx_int_t offset;
+    ngx_int_t start_timestamp;
+    ngx_event_t write_evt;
+    uint32_t last_audio;
+    uint32_t last_video;
+    ngx_uint_t msg_mask;
+    uint32_t epoch;
 
-    unsigned                            meta_read:1;
-    ngx_rtmp_flv_index_t                filepositions;
-    ngx_rtmp_flv_index_t                times;
+    unsigned meta_read : 1;
+    ngx_rtmp_flv_index_t filepositions;
+    ngx_rtmp_flv_index_t times;
 } ngx_rtmp_flv_ctx_t;
 
+#define NGX_RTMP_FLV_BUFFER (1024 * 1024)
+#define NGX_RTMP_FLV_BUFLEN_ADDON 1000
+#define NGX_RTMP_FLV_TAG_HEADER 11
+#define NGX_RTMP_FLV_DATA_OFFSET 13
 
-#define NGX_RTMP_FLV_BUFFER             (1024*1024)
-#define NGX_RTMP_FLV_BUFLEN_ADDON       1000
-#define NGX_RTMP_FLV_TAG_HEADER         11
-#define NGX_RTMP_FLV_DATA_OFFSET        13
+static u_char ngx_rtmp_flv_buffer[NGX_RTMP_FLV_BUFFER];
+static u_char ngx_rtmp_flv_header[NGX_RTMP_FLV_TAG_HEADER];
 
-
-static u_char                           ngx_rtmp_flv_buffer[
-                                        NGX_RTMP_FLV_BUFFER];
-static u_char                           ngx_rtmp_flv_header[
-                                        NGX_RTMP_FLV_TAG_HEADER];
-
-
-static ngx_rtmp_module_t  ngx_rtmp_flv_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_flv_postconfiguration,         /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    NULL,                                   /* create app configuration */
-    NULL                                    /* merge app configuration */
+static ngx_rtmp_module_t ngx_rtmp_flv_module_ctx = {
+    NULL,                           /* preconfiguration */
+    ngx_rtmp_flv_postconfiguration, /* postconfiguration */
+    NULL,                           /* create main configuration */
+    NULL,                           /* init main configuration */
+    NULL,                           /* create server configuration */
+    NULL,                           /* merge server configuration */
+    NULL,                           /* create app configuration */
+    NULL                            /* merge app configuration */
 };
 
-
-ngx_module_t  ngx_rtmp_flv_module = {
+ngx_module_t ngx_rtmp_flv_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_flv_module_ctx,               /* module context */
-    NULL,                                   /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_flv_module_ctx, /* module context */
+    NULL,                     /* module directives */
+    NGX_RTMP_MODULE,          /* module type */
+    NULL,                     /* init master */
+    NULL,                     /* init module */
+    NULL,                     /* init process */
+    NULL,                     /* init thread */
+    NULL,                     /* exit thread */
+    NULL,                     /* exit process */
+    NULL,                     /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static ngx_int_t
-ngx_rtmp_flv_fill_index(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_flv_index_t *idx)
+static ngx_int_t ngx_rtmp_flv_fill_index(ngx_rtmp_amf_ctx_t *ctx,
+                                         ngx_rtmp_flv_index_t *idx)
 {
-    uint32_t                        nelts;
-    ngx_buf_t                      *b;
+    uint32_t nelts;
+    ngx_buf_t *b;
 
     /* we have AMF array pointed by context;
      * need to extract its size (4 bytes) &
@@ -98,54 +87,43 @@ ngx_rtmp_flv_fill_index(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_flv_index_t *idx)
 
     b = ctx->link->buf;
 
-    if (b->last - b->pos < (ngx_int_t) ctx->offset + 4) {
+    if (b->last - b->pos < (ngx_int_t)ctx->offset + 4) {
         return NGX_ERROR;
     }
 
     ngx_rtmp_rmemcpy(&nelts, b->pos + ctx->offset, 4);
 
-    idx->nelts = nelts;
+    idx->nelts  = nelts;
     idx->offset = ctx->offset + 4;
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_init_index(ngx_rtmp_session_t *s, ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_flv_init_index(ngx_rtmp_session_t *s, ngx_chain_t *in)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
+    ngx_rtmp_flv_ctx_t *ctx;
 
-    static ngx_rtmp_amf_ctx_t       filepositions_ctx;
-    static ngx_rtmp_amf_ctx_t       times_ctx;
+    static ngx_rtmp_amf_ctx_t filepositions_ctx;
+    static ngx_rtmp_amf_ctx_t times_ctx;
 
-    static ngx_rtmp_amf_elt_t       in_keyframes[] = {
+    static ngx_rtmp_amf_elt_t in_keyframes[] = {
 
-        { NGX_RTMP_AMF_ARRAY | NGX_RTMP_AMF_CONTEXT,
-          ngx_string("filepositions"),
-          &filepositions_ctx, 0 },
+        {NGX_RTMP_AMF_ARRAY | NGX_RTMP_AMF_CONTEXT, ngx_string("filepositions"),
+         &filepositions_ctx, 0},
 
-        { NGX_RTMP_AMF_ARRAY | NGX_RTMP_AMF_CONTEXT,
-          ngx_string("times"),
-          &times_ctx, 0 }
-    };
+        {NGX_RTMP_AMF_ARRAY | NGX_RTMP_AMF_CONTEXT, ngx_string("times"),
+         &times_ctx, 0}};
 
-    static ngx_rtmp_amf_elt_t       in_inf[] = {
+    static ngx_rtmp_amf_elt_t in_inf[] = {
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_string("keyframes"),
-          in_keyframes, sizeof(in_keyframes) }
-    };
+        {NGX_RTMP_AMF_OBJECT, ngx_string("keyframes"), in_keyframes,
+         sizeof(in_keyframes)}};
 
-    static ngx_rtmp_amf_elt_t       in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
@@ -155,68 +133,61 @@ ngx_rtmp_flv_init_index(ngx_rtmp_session_t *s, ngx_chain_t *in)
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: init index");
+                   "flv: init index");
 
     ngx_memzero(&filepositions_ctx, sizeof(filepositions_ctx));
     ngx_memzero(&times_ctx, sizeof(times_ctx));
 
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                             sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: init index error");
+                      "flv: init index error");
         return NGX_OK;
     }
 
-    if (filepositions_ctx.link && ngx_rtmp_flv_fill_index(&filepositions_ctx,
-                                                          &ctx->filepositions)
-        != NGX_OK)
-    {
+    if (filepositions_ctx.link &&
+        ngx_rtmp_flv_fill_index(&filepositions_ctx, &ctx->filepositions) !=
+            NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: failed to init filepositions");
+                      "flv: failed to init filepositions");
         return NGX_ERROR;
     }
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: filepositions nelts=%ui offset=%ui",
+                   "flv: filepositions nelts=%ui offset=%ui",
                    ctx->filepositions.nelts, ctx->filepositions.offset);
 
-    if (times_ctx.link && ngx_rtmp_flv_fill_index(&times_ctx,
-                                                  &ctx->times)
-        != NGX_OK)
-    {
+    if (times_ctx.link &&
+        ngx_rtmp_flv_fill_index(&times_ctx, &ctx->times) != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: failed to init times");
+                      "flv: failed to init times");
         return NGX_ERROR;
     }
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: times nelts=%ui offset=%ui",
-                   ctx->times.nelts, ctx->times.offset);
+                   "flv: times nelts=%ui offset=%ui", ctx->times.nelts,
+                   ctx->times.offset);
 
-    return  NGX_OK;
+    return NGX_OK;
 }
 
-
-static double
-ngx_rtmp_flv_index_value(void *src)
+static double ngx_rtmp_flv_index_value(void *src)
 {
-    double      v;
+    double v;
 
     ngx_rtmp_rmemcpy(&v, src, 8);
 
     return v;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s, ngx_file_t *f,
-    ngx_int_t timestamp)
+static ngx_int_t ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s,
+                                                  ngx_file_t *f,
+                                                  ngx_int_t timestamp)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
-    ssize_t                         n, size;
-    ngx_uint_t                      offset, index, ret, nelts;
-    double                          v;
+    ngx_rtmp_flv_ctx_t *ctx;
+    ssize_t n, size;
+    ngx_uint_t offset, index, ret, nelts;
+    double v;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
 
@@ -225,47 +196,45 @@ ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s, ngx_file_t *f,
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: lookup index start timestamp=%i",
-                   timestamp);
+                   "flv: lookup index start timestamp=%i", timestamp);
 
     if (ctx->meta_read == 0) {
         ngx_rtmp_flv_read_meta(s, f);
         ctx->meta_read = 1;
     }
 
-    if (timestamp <= 0 || ctx->filepositions.nelts == 0
-                       || ctx->times.nelts == 0)
-    {
+    if (timestamp <= 0 || ctx->filepositions.nelts == 0 ||
+        ctx->times.nelts == 0) {
         goto rewind;
     }
 
     /* read index table from file given offset */
-    offset = NGX_RTMP_FLV_DATA_OFFSET + NGX_RTMP_FLV_TAG_HEADER +
-             ctx->times.offset;
+    offset =
+        NGX_RTMP_FLV_DATA_OFFSET + NGX_RTMP_FLV_TAG_HEADER + ctx->times.offset;
 
     /* index should fit in the buffer */
     nelts = ngx_min(ctx->times.nelts, sizeof(ngx_rtmp_flv_buffer) / 9);
-    size = nelts * 9;
+    size  = nelts * 9;
 
     n = ngx_read_file(f, ngx_rtmp_flv_buffer, size, offset);
 
     if (n != size) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: could not read times index");
+                      "flv: could not read times index");
         goto rewind;
     }
 
     /*TODO: implement binary search */
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: lookup times nelts=%ui", nelts);
+                   "flv: lookup times nelts=%ui", nelts);
 
     for (index = 0; index < nelts - 1; ++index) {
-        v = ngx_rtmp_flv_index_value(ngx_rtmp_flv_buffer +
-                                     index * 9 + 1) * 1000;
+        v = ngx_rtmp_flv_index_value(ngx_rtmp_flv_buffer + index * 9 + 1) *
+            1000;
 
         ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                      "flv: lookup times index=%ui value=%ui",
-                      index, (ngx_uint_t) v);
+                       "flv: lookup times index=%ui value=%ui", index,
+                       (ngx_uint_t)v);
 
         if (timestamp < v) {
             break;
@@ -274,8 +243,8 @@ ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s, ngx_file_t *f,
 
     if (index >= ctx->filepositions.nelts) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: index out of bounds: %ui>=%ui",
-                     index, ctx->filepositions.nelts);
+                      "flv: index out of bounds: %ui>=%ui", index,
+                      ctx->filepositions.nelts);
         goto rewind;
     }
 
@@ -287,37 +256,33 @@ ngx_rtmp_flv_timestamp_to_offset(ngx_rtmp_session_t *s, ngx_file_t *f,
 
     if (n != 8) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: could not read filepositions index");
+                      "flv: could not read filepositions index");
         goto rewind;
     }
 
-    ret = (ngx_uint_t) ngx_rtmp_flv_index_value(ngx_rtmp_flv_buffer);
+    ret = (ngx_uint_t)ngx_rtmp_flv_index_value(ngx_rtmp_flv_buffer);
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: lookup index timestamp=%i offset=%ui",
-                   timestamp, ret);
+                   "flv: lookup index timestamp=%i offset=%ui", timestamp, ret);
 
     return ret;
 
 rewind:
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: lookup index timestamp=%i offset=begin",
-                   timestamp);
+                   "flv: lookup index timestamp=%i offset=begin", timestamp);
 
     return NGX_RTMP_FLV_DATA_OFFSET;
 }
 
-
-static void
-ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
+static void ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
-    ssize_t                         n;
-    ngx_rtmp_header_t               h;
-    ngx_chain_t                    *out, in;
-    ngx_buf_t                       in_buf;
-    ngx_rtmp_core_srv_conf_t       *cscf;
-    uint32_t                        size;
+    ngx_rtmp_flv_ctx_t *ctx;
+    ssize_t n;
+    ngx_rtmp_header_t h;
+    ngx_chain_t *out, in;
+    ngx_buf_t in_buf;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    uint32_t size;
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
@@ -327,8 +292,7 @@ ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
         return;
     }
 
-    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: read meta");
+    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "flv: read meta");
 
     /* read tag header */
     n = ngx_read_file(f, ngx_rtmp_flv_header, sizeof(ngx_rtmp_flv_header),
@@ -336,13 +300,13 @@ ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
 
     if (n != sizeof(ngx_rtmp_flv_header)) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: could not read metadata tag header");
+                      "flv: could not read metadata tag header");
         return;
     }
 
     if (ngx_rtmp_flv_header[0] != NGX_RTMP_MSG_AMF_META) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                      "flv: first tag is not metadata, giving up");
+                       "flv: first tag is not metadata, giving up");
         return;
     }
 
@@ -356,20 +320,19 @@ ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
     ngx_rtmp_rmemcpy(&size, ngx_rtmp_flv_header + 1, 3);
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: metadata size=%D", size);
+                   "flv: metadata size=%D", size);
 
     if (size > sizeof(ngx_rtmp_flv_buffer)) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: too big metadata");
+                      "flv: too big metadata");
         return;
     }
 
     /* read metadata */
     n = ngx_read_file(f, ngx_rtmp_flv_buffer, size,
-                      sizeof(ngx_rtmp_flv_header) +
-                      NGX_RTMP_FLV_DATA_OFFSET);
+                      sizeof(ngx_rtmp_flv_header) + NGX_RTMP_FLV_DATA_OFFSET);
 
-    if (n != (ssize_t) size) {
+    if (n != (ssize_t)size) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                       "flv: could not read metadata");
         return;
@@ -379,7 +342,7 @@ ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
     ngx_memzero(&in, sizeof(in));
     ngx_memzero(&in_buf, sizeof(in_buf));
 
-    in.buf = &in_buf;
+    in.buf      = &in_buf;
     in_buf.pos  = ngx_rtmp_flv_buffer;
     in_buf.last = ngx_rtmp_flv_buffer + size;
 
@@ -393,19 +356,18 @@ ngx_rtmp_flv_read_meta(ngx_rtmp_session_t *s, ngx_file_t *f)
     ngx_rtmp_free_shared_chain(cscf, out);
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t *ts)
+static ngx_int_t ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                   ngx_uint_t *ts)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
-    uint32_t                        last_timestamp;
-    ngx_rtmp_header_t               h, lh;
-    ngx_rtmp_core_srv_conf_t       *cscf;
-    ngx_chain_t                    *out, in;
-    ngx_buf_t                       in_buf;
-    ngx_int_t                       rc;
-    ssize_t                         n;
-    uint32_t                        buflen, end_timestamp, size;
+    ngx_rtmp_flv_ctx_t *ctx;
+    uint32_t last_timestamp;
+    ngx_rtmp_header_t h, lh;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_chain_t *out, in;
+    ngx_buf_t in_buf;
+    ngx_int_t rc;
+    ssize_t n;
+    uint32_t buflen, end_timestamp, size;
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
@@ -416,21 +378,21 @@ ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t *ts)
     }
 
     if (ctx->offset == -1) {
-        ctx->offset = ngx_rtmp_flv_timestamp_to_offset(s, f,
-                                                       ctx->start_timestamp);
+        ctx->offset =
+            ngx_rtmp_flv_timestamp_to_offset(s, f, ctx->start_timestamp);
         ctx->start_timestamp = -1; /* set later from actual timestamp */
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: read tag at offset=%i", ctx->offset);
+                   "flv: read tag at offset=%i", ctx->offset);
 
     /* read tag header */
-    n = ngx_read_file(f, ngx_rtmp_flv_header,
-                      sizeof(ngx_rtmp_flv_header), ctx->offset);
+    n = ngx_read_file(f, ngx_rtmp_flv_header, sizeof(ngx_rtmp_flv_header),
+                      ctx->offset);
 
     if (n != sizeof(ngx_rtmp_flv_header)) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: could not read flv tag header");
+                      "flv: could not read flv tag header");
         return NGX_DONE;
     }
 
@@ -445,52 +407,50 @@ ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t *ts)
     ngx_rtmp_rmemcpy(&size, ngx_rtmp_flv_header + 1, 3);
     ngx_rtmp_rmemcpy(&h.timestamp, ngx_rtmp_flv_header + 4, 3);
 
-    ((u_char *) &h.timestamp)[3] = ngx_rtmp_flv_header[7];
+    ((u_char *)&h.timestamp)[3] = ngx_rtmp_flv_header[7];
 
     ctx->offset += (sizeof(ngx_rtmp_flv_header) + size + 4);
 
     last_timestamp = 0;
 
     switch (h.type) {
+    case NGX_RTMP_MSG_AUDIO:
+        h.csid          = NGX_RTMP_CSID_AUDIO;
+        last_timestamp  = ctx->last_audio;
+        ctx->last_audio = h.timestamp;
+        break;
 
-        case NGX_RTMP_MSG_AUDIO:
-            h.csid = NGX_RTMP_CSID_AUDIO;
-            last_timestamp = ctx->last_audio;
-            ctx->last_audio = h.timestamp;
-            break;
+    case NGX_RTMP_MSG_VIDEO:
+        h.csid          = NGX_RTMP_CSID_VIDEO;
+        last_timestamp  = ctx->last_video;
+        ctx->last_video = h.timestamp;
+        break;
 
-        case NGX_RTMP_MSG_VIDEO:
-            h.csid = NGX_RTMP_CSID_VIDEO;
-            last_timestamp = ctx->last_video;
-            ctx->last_video = h.timestamp;
-            break;
-
-        default:
-            return NGX_OK;
+    default:
+        return NGX_OK;
     }
 
     ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: read tag type=%i size=%uD timestamp=%uD "
-                  "last_timestamp=%uD",
-                  (ngx_int_t) h.type,size, h.timestamp, last_timestamp);
+                   "flv: read tag type=%i size=%uD timestamp=%uD "
+                   "last_timestamp=%uD",
+                   (ngx_int_t)h.type, size, h.timestamp, last_timestamp);
 
-    lh = h;
+    lh           = h;
     lh.timestamp = last_timestamp;
 
     if (size > sizeof(ngx_rtmp_flv_buffer)) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: too big message: %D>%uz", size,
+                      "flv: too big message: %D>%uz", size,
                       sizeof(ngx_rtmp_flv_buffer));
         goto next;
     }
 
     /* read tag body */
-    n = ngx_read_file(f, ngx_rtmp_flv_buffer, size,
-                      ctx->offset - size - 4);
+    n = ngx_read_file(f, ngx_rtmp_flv_buffer, size, ctx->offset - size - 4);
 
-    if (n != (ssize_t) size) {
+    if (n != (ssize_t)size) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                     "flv: could not read flv tag");
+                      "flv: could not read flv tag");
         return NGX_ERROR;
     }
 
@@ -498,15 +458,15 @@ ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t *ts)
     ngx_memzero(&in, sizeof(in));
     ngx_memzero(&in_buf, sizeof(in_buf));
 
-    in.buf = &in_buf;
+    in.buf      = &in_buf;
     in_buf.pos  = ngx_rtmp_flv_buffer;
     in_buf.last = ngx_rtmp_flv_buffer + size;
 
     /* output chain */
     out = ngx_rtmp_append_shared_bufs(cscf, NULL, &in);
 
-    ngx_rtmp_prepare_message(s, &h, ctx->msg_mask & (1 << h.type) ?
-                             &lh : NULL, out);
+    ngx_rtmp_prepare_message(s, &h, ctx->msg_mask & (1 << h.type) ? &lh : NULL,
+                             out);
     rc = ngx_rtmp_send_message(s, out, 0);
     ngx_rtmp_free_shared_chain(cscf, out);
 
@@ -523,23 +483,24 @@ ngx_rtmp_flv_send(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t *ts)
 next:
     if (ctx->start_timestamp == -1) {
         ctx->start_timestamp = h.timestamp;
-        ctx->epoch = ngx_current_msec;
+        ctx->epoch           = ngx_current_msec;
 
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                      "flv: start_timestamp=%i", ctx->start_timestamp);
+                       "flv: start_timestamp=%i", ctx->start_timestamp);
         return NGX_OK;
     }
 
     buflen = s->buflen + NGX_RTMP_FLV_BUFLEN_ADDON;
 
-    end_timestamp = (ngx_current_msec - ctx->epoch) +
-                     ctx->start_timestamp + buflen;
+    end_timestamp =
+        (ngx_current_msec - ctx->epoch) + ctx->start_timestamp + buflen;
 
     ngx_log_debug5(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-           "flv: %s wait=%D timestamp=%D end_timestamp=%D bufen=%i",
-            h.timestamp > end_timestamp ? "schedule" : "advance",
-            h.timestamp > end_timestamp ? h.timestamp - end_timestamp : 0,
-            h.timestamp, end_timestamp, (ngx_int_t) buflen);
+                   "flv: %s wait=%D timestamp=%D end_timestamp=%D bufen=%i",
+                   h.timestamp > end_timestamp ? "schedule" : "advance",
+                   h.timestamp > end_timestamp ? h.timestamp - end_timestamp
+                                               : 0,
+                   h.timestamp, end_timestamp, (ngx_int_t)buflen);
 
     s->current_time = h.timestamp;
 
@@ -551,12 +512,10 @@ next:
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_init(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_int_t aindex,
-                  ngx_int_t vindex)
+static ngx_int_t ngx_rtmp_flv_init(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                   ngx_int_t aindex, ngx_int_t vindex)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
+    ngx_rtmp_flv_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
 
@@ -575,11 +534,9 @@ ngx_rtmp_flv_init(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_int_t aindex,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_start(ngx_rtmp_session_t *s, ngx_file_t *f)
+static ngx_int_t ngx_rtmp_flv_start(ngx_rtmp_session_t *s, ngx_file_t *f)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
+    ngx_rtmp_flv_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
 
@@ -587,20 +544,18 @@ ngx_rtmp_flv_start(ngx_rtmp_session_t *s, ngx_file_t *f)
         return NGX_OK;
     }
 
-    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: start");
+    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "flv: start");
 
-    ctx->offset = -1;
+    ctx->offset   = -1;
     ctx->msg_mask = 0;
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_seek(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t timestamp)
+static ngx_int_t ngx_rtmp_flv_seek(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                   ngx_uint_t timestamp)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
+    ngx_rtmp_flv_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
 
@@ -609,21 +564,19 @@ ngx_rtmp_flv_seek(ngx_rtmp_session_t *s, ngx_file_t *f, ngx_uint_t timestamp)
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: seek timestamp=%ui", timestamp);
+                   "flv: seek timestamp=%ui", timestamp);
 
     ctx->start_timestamp = timestamp;
-    ctx->epoch = ngx_current_msec;
-    ctx->offset = -1;
-    ctx->msg_mask = 0;
+    ctx->epoch           = ngx_current_msec;
+    ctx->offset          = -1;
+    ctx->msg_mask        = 0;
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_stop(ngx_rtmp_session_t *s, ngx_file_t *f)
+static ngx_int_t ngx_rtmp_flv_stop(ngx_rtmp_session_t *s, ngx_file_t *f)
 {
-    ngx_rtmp_flv_ctx_t             *ctx;
+    ngx_rtmp_flv_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_flv_module);
 
@@ -631,18 +584,15 @@ ngx_rtmp_flv_stop(ngx_rtmp_session_t *s, ngx_file_t *f)
         return NGX_OK;
     }
 
-    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                  "flv: stop");
+    ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "flv: stop");
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_flv_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_flv_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_play_main_conf_t      *pmcf;
-    ngx_rtmp_play_fmt_t           **pfmt, *fmt;
+    ngx_rtmp_play_main_conf_t *pmcf;
+    ngx_rtmp_play_fmt_t **pfmt, *fmt;
 
     pmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_play_module);
 

--- a/ngx_rtmp_handler.c
+++ b/ngx_rtmp_handler.c
@@ -3,117 +3,75 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_amf.h"
-
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 static void ngx_rtmp_recv(ngx_event_t *rev);
 static void ngx_rtmp_send(ngx_event_t *rev);
 static void ngx_rtmp_ping(ngx_event_t *rev);
 static ngx_int_t ngx_rtmp_finalize_set_chunk_size(ngx_rtmp_session_t *s);
 
+ngx_uint_t ngx_rtmp_naccepted;
 
-ngx_uint_t                  ngx_rtmp_naccepted;
-
-
-ngx_rtmp_bandwidth_t        ngx_rtmp_bw_out;
-ngx_rtmp_bandwidth_t        ngx_rtmp_bw_in;
-
+ngx_rtmp_bandwidth_t ngx_rtmp_bw_out;
+ngx_rtmp_bandwidth_t ngx_rtmp_bw_in;
 
 #ifdef NGX_DEBUG
-char*
-ngx_rtmp_message_type(uint8_t type)
+char *ngx_rtmp_message_type(uint8_t type)
 {
-    static char*    types[] = {
-        "?",
-        "chunk_size",
-        "abort",
-        "ack",
-        "user",
-        "ack_size",
-        "bandwidth",
-        "edge",
-        "audio",
-        "video",
-        "?",
-        "?",
-        "?",
-        "?",
-        "?",
-        "amf3_meta",
-        "amf3_shared",
-        "amf3_cmd",
-        "amf_meta",
-        "amf_shared",
-        "amf_cmd",
-        "?",
-        "aggregate"
-    };
+    static char *types[] = {
+        "?",         "chunk_size",  "abort",    "ack",      "user",
+        "ack_size",  "bandwidth",   "edge",     "audio",    "video",
+        "?",         "?",           "?",        "?",        "?",
+        "amf3_meta", "amf3_shared", "amf3_cmd", "amf_meta", "amf_shared",
+        "amf_cmd",   "?",           "aggregate"};
 
-    return type < sizeof(types) / sizeof(types[0])
-        ? types[type]
-        : "?";
+    return type < sizeof(types) / sizeof(types[0]) ? types[type] : "?";
 }
 
-
-char*
-ngx_rtmp_user_message_type(uint16_t evt)
+char *ngx_rtmp_user_message_type(uint16_t evt)
 {
-    static char*    evts[] = {
-        "stream_begin",
-        "stream_eof",
-        "stream dry",
-        "set_buflen",
-        "recorded",
-        "",
-        "ping_request",
-        "ping_response",
+    static char *evts[] = {
+        "stream_begin", "stream_eof", "stream dry",   "set_buflen",
+        "recorded",     "",           "ping_request", "ping_response",
     };
 
-    return evt < sizeof(evts) / sizeof(evts[0])
-        ? evts[evt]
-        : "?";
+    return evt < sizeof(evts) / sizeof(evts[0]) ? evts[evt] : "?";
 }
 #endif
 
-
-void
-ngx_rtmp_cycle(ngx_rtmp_session_t *s)
+void ngx_rtmp_cycle(ngx_rtmp_session_t *s)
 {
-    ngx_connection_t           *c;
+    ngx_connection_t *c;
 
-    c = s->connection;
-    c->read->handler =  ngx_rtmp_recv;
+    c                 = s->connection;
+    c->read->handler  = ngx_rtmp_recv;
     c->write->handler = ngx_rtmp_send;
 
-    s->ping_evt.data = c;
-    s->ping_evt.log = c->log;
+    s->ping_evt.data    = c;
+    s->ping_evt.log     = c->log;
     s->ping_evt.handler = ngx_rtmp_ping;
     ngx_rtmp_reset_ping(s);
 
     ngx_rtmp_recv(c->read);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_alloc_in_buf(ngx_rtmp_session_t *s)
+static ngx_chain_t *ngx_rtmp_alloc_in_buf(ngx_rtmp_session_t *s)
 {
-    ngx_chain_t        *cl;
-    ngx_buf_t          *b;
-    size_t              size;
+    ngx_chain_t *cl;
+    ngx_buf_t *b;
+    size_t size;
 
-    if ((cl = ngx_alloc_chain_link(s->in_pool)) == NULL
-       || (cl->buf = ngx_calloc_buf(s->in_pool)) == NULL)
-    {
+    if ((cl = ngx_alloc_chain_link(s->in_pool)) == NULL ||
+        (cl->buf = ngx_calloc_buf(s->in_pool)) == NULL) {
         return NULL;
     }
 
     cl->next = NULL;
-    b = cl->buf;
-    size = s->in_chunk_size + NGX_RTMP_MAX_CHUNK_HEADER;
+    b        = cl->buf;
+    size     = s->in_chunk_size + NGX_RTMP_MAX_CHUNK_HEADER;
 
     b->start = b->last = b->pos = ngx_palloc(s->in_pool, size);
     if (b->start == NULL) {
@@ -124,11 +82,9 @@ ngx_rtmp_alloc_in_buf(ngx_rtmp_session_t *s)
     return cl;
 }
 
-
-void
-ngx_rtmp_reset_ping(ngx_rtmp_session_t *s)
+void ngx_rtmp_reset_ping(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_core_srv_conf_t   *cscf;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
     if (cscf->ping == 0) {
@@ -136,20 +92,18 @@ ngx_rtmp_reset_ping(ngx_rtmp_session_t *s)
     }
 
     s->ping_active = 0;
-    s->ping_reset = 0;
+    s->ping_reset  = 0;
     ngx_add_timer(&s->ping_evt, cscf->ping);
 
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "ping: wait %Mms", cscf->ping);
+    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "ping: wait %Mms",
+                   cscf->ping);
 }
 
-
-static void
-ngx_rtmp_ping(ngx_event_t *pev)
+static void ngx_rtmp_ping(ngx_event_t *pev)
 {
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
-    ngx_rtmp_core_srv_conf_t   *cscf;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     c = pev->data;
     s = c->data;
@@ -163,21 +117,19 @@ ngx_rtmp_ping(ngx_event_t *pev)
     }
 
     if (s->ping_active) {
-        ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                "ping: unresponded");
+        ngx_log_error(NGX_LOG_INFO, c->log, 0, "ping: unresponded");
         ngx_rtmp_finalize_session(s);
         return;
     }
 
     if (cscf->busy) {
-        ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                "ping: not busy between pings");
+        ngx_log_error(NGX_LOG_INFO, c->log, 0, "ping: not busy between pings");
         ngx_rtmp_finalize_session(s);
         return;
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "ping: schedule %Mms", cscf->ping_timeout);
+                   "ping: schedule %Mms", cscf->ping_timeout);
 
     if (ngx_rtmp_send_ping_request(s, (uint32_t)ngx_current_msec) != NGX_OK) {
         ngx_rtmp_finalize_session(s);
@@ -188,44 +140,40 @@ ngx_rtmp_ping(ngx_event_t *pev)
     ngx_add_timer(pev, cscf->ping_timeout);
 }
 
-
-static void
-ngx_rtmp_recv(ngx_event_t *rev)
+static void ngx_rtmp_recv(ngx_event_t *rev)
 {
-    ngx_int_t                   n;
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_rtmp_header_t          *h;
-    ngx_rtmp_stream_t          *st, *st0;
-    ngx_chain_t                *in, *head;
-    ngx_buf_t                  *b;
-    u_char                     *p, *pp, *old_pos;
-    size_t                      size, fsize, old_size;
-    uint8_t                     fmt, ext;
-    uint32_t                    csid, timestamp;
+    ngx_int_t n;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_rtmp_header_t *h;
+    ngx_rtmp_stream_t *st, *st0;
+    ngx_chain_t *in, *head;
+    ngx_buf_t *b;
+    u_char *p, *pp, *old_pos;
+    size_t size, fsize, old_size;
+    uint8_t fmt, ext;
+    uint32_t csid, timestamp;
 
-    c = rev->data;
-    s = c->data;
-    b = NULL;
-    old_pos = NULL;
+    c        = rev->data;
+    s        = c->data;
+    b        = NULL;
+    old_pos  = NULL;
     old_size = 0;
-    cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
+    cscf     = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     if (c->destroyed) {
         return;
     }
 
-    for( ;; ) {
-
+    for (;;) {
         st = &s->in_streams[s->in_csid];
 
         /* allocate new buffer */
         if (st->in == NULL) {
             st->in = ngx_rtmp_alloc_in_buf(s);
             if (st->in == NULL) {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "in buf alloc failed");
+                ngx_log_error(NGX_LOG_INFO, c->log, 0, "in buf alloc failed");
                 ngx_rtmp_finalize_session(s);
                 return;
             }
@@ -236,11 +184,10 @@ ngx_rtmp_recv(ngx_event_t *rev)
         b  = in->buf;
 
         if (old_size) {
-
             ngx_log_debug1(NGX_LOG_DEBUG_RTMP, c->log, 0,
-                    "reusing formerly read data: %d", old_size);
+                           "reusing formerly read data: %d", old_size);
 
-            b->pos = b->start;
+            b->pos  = b->start;
             b->last = ngx_movemem(b->pos, old_pos, old_size);
 
             if (s->in_chunk_size_changing) {
@@ -248,7 +195,6 @@ ngx_rtmp_recv(ngx_event_t *rev)
             }
 
         } else {
-
             if (old_pos) {
                 b->pos = b->last = b->start;
             }
@@ -275,16 +221,15 @@ ngx_rtmp_recv(ngx_event_t *rev)
             if (s->in_bytes >= 0xf0000000) {
                 ngx_log_debug0(NGX_LOG_DEBUG_RTMP, c->log, 0,
                                "resetting byte counter");
-                s->in_bytes = 0;
+                s->in_bytes    = 0;
                 s->in_last_ack = 0;
             }
 
             if (s->ack_size && s->in_bytes - s->in_last_ack >= s->ack_size) {
-
                 s->in_last_ack = s->in_bytes;
 
                 ngx_log_debug1(NGX_LOG_DEBUG_RTMP, c->log, 0,
-                        "sending RTMP ACK(%uD)", s->in_bytes);
+                               "sending RTMP ACK(%uD)", s->in_bytes);
 
                 if (ngx_rtmp_send_ack(s, s->in_bytes)) {
                     ngx_rtmp_finalize_session(s);
@@ -293,7 +238,7 @@ ngx_rtmp_recv(ngx_event_t *rev)
             }
         }
 
-        old_pos = NULL;
+        old_pos  = NULL;
         old_size = 0;
 
         /* parse headers */
@@ -308,56 +253,54 @@ ngx_rtmp_recv(ngx_event_t *rev)
                 if (b->last - p < 1)
                     continue;
                 csid = 64;
-                csid += *(uint8_t*)p++;
+                csid += *(uint8_t *)p++;
 
             } else if (csid == 1) {
                 if (b->last - p < 2)
                     continue;
                 csid = 64;
-                csid += *(uint8_t*)p++;
-                csid += (uint32_t)256 * (*(uint8_t*)p++);
+                csid += *(uint8_t *)p++;
+                csid += (uint32_t)256 * (*(uint8_t *)p++);
             }
 
             ngx_log_debug2(NGX_LOG_DEBUG_RTMP, c->log, 0,
-                    "RTMP bheader fmt=%d csid=%D",
-                    (int)fmt, csid);
+                           "RTMP bheader fmt=%d csid=%D", (int)fmt, csid);
 
             if (csid >= (uint32_t)cscf->max_streams) {
                 ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                    "RTMP in chunk stream too big: %D >= %D",
-                    csid, cscf->max_streams);
+                              "RTMP in chunk stream too big: %D >= %D", csid,
+                              cscf->max_streams);
                 ngx_rtmp_finalize_session(s);
                 return;
             }
 
             /* link orphan */
             if (s->in_csid == 0) {
-
                 /* unlink from stream #0 */
                 st->in = st->in->next;
 
                 /* link to new stream */
                 s->in_csid = csid;
-                st = &s->in_streams[csid];
+                st         = &s->in_streams[csid];
                 if (st->in == NULL) {
                     in->next = in;
                 } else {
-                    in->next = st->in->next;
+                    in->next     = st->in->next;
                     st->in->next = in;
                 }
-                st->in = in;
-                h = &st->hdr;
+                st->in  = in;
+                h       = &st->hdr;
                 h->csid = csid;
             }
 
-            ext = st->ext;
+            ext       = st->ext;
             timestamp = st->dtime;
-            if (fmt <= 2 ) {
+            if (fmt <= 2) {
                 if (b->last - p < 3)
                     continue;
                 /* timestamp:
                  *  big-endian 3b -> little-endian 4b */
-                pp = (u_char*)&timestamp;
+                pp    = (u_char *)&timestamp;
                 pp[2] = *p++;
                 pp[1] = *p++;
                 pp[0] = *p++;
@@ -372,19 +315,19 @@ ngx_rtmp_recv(ngx_event_t *rev)
                      *  big-endian 3b -> little-endian 4b
                      * type:
                      *  1b -> 1b*/
-                    pp = (u_char*)&h->mlen;
-                    pp[2] = *p++;
-                    pp[1] = *p++;
-                    pp[0] = *p++;
-                    pp[3] = 0;
-                    h->type = *(uint8_t*)p++;
+                    pp      = (u_char *)&h->mlen;
+                    pp[2]   = *p++;
+                    pp[1]   = *p++;
+                    pp[0]   = *p++;
+                    pp[3]   = 0;
+                    h->type = *(uint8_t *)p++;
 
                     if (fmt == 0) {
                         if (b->last - p < 4)
                             continue;
                         /* stream:
                          *  little-endian 4b -> little-endian 4b */
-                        pp = (u_char*)&h->msid;
+                        pp    = (u_char *)&h->msid;
                         pp[0] = *p++;
                         pp[1] = *p++;
                         pp[2] = *p++;
@@ -397,7 +340,7 @@ ngx_rtmp_recv(ngx_event_t *rev)
             if (ext) {
                 if (b->last - p < 4)
                     continue;
-                pp = (u_char*)&timestamp;
+                pp    = (u_char *)&timestamp;
                 pp[3] = *p++;
                 pp[2] = *p++;
                 pp[1] = *p++;
@@ -415,28 +358,29 @@ ngx_rtmp_recv(ngx_event_t *rev)
                     st->dtime = timestamp;
                 } else {
                     h->timestamp = timestamp;
-                    st->dtime = 0;
+                    st->dtime    = 0;
                 }
             }
 
             ngx_log_debug8(NGX_LOG_DEBUG_RTMP, c->log, 0,
-                    "RTMP mheader fmt=%d %s (%d) "
-                    "time=%uD+%uD mlen=%D len=%D msid=%D",
-                    (int)fmt, ngx_rtmp_message_type(h->type), (int)h->type,
-                    h->timestamp, st->dtime, h->mlen, st->len, h->msid);
+                           "RTMP mheader fmt=%d %s (%d) "
+                           "time=%uD+%uD mlen=%D len=%D msid=%D",
+                           (int)fmt, ngx_rtmp_message_type(h->type),
+                           (int)h->type, h->timestamp, st->dtime, h->mlen,
+                           st->len, h->msid);
 
             /* header done */
             b->pos = p;
 
             if (h->mlen > cscf->max_message) {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "too big message: %uz", cscf->max_message);
+                ngx_log_error(NGX_LOG_INFO, c->log, 0, "too big message: %uz",
+                              cscf->max_message);
                 ngx_rtmp_finalize_session(s);
                 return;
             }
         }
 
-        size = b->last - b->pos;
+        size  = b->last - b->pos;
         fsize = h->mlen - st->len;
 
         if (size < ngx_min(fsize, s->in_chunk_size))
@@ -447,18 +391,18 @@ ngx_rtmp_recv(ngx_event_t *rev)
         if (fsize > s->in_chunk_size) {
             /* collect fragmented chunks */
             st->len += s->in_chunk_size;
-            b->last = b->pos + s->in_chunk_size;
-            old_pos = b->last;
+            b->last  = b->pos + s->in_chunk_size;
+            old_pos  = b->last;
             old_size = size - s->in_chunk_size;
 
         } else {
             /* handle! */
-            head = st->in->next;
+            head         = st->in->next;
             st->in->next = NULL;
-            b->last = b->pos + fsize;
-            old_pos = b->last;
-            old_size = size - fsize;
-            st->len = 0;
+            b->last      = b->pos + fsize;
+            old_pos      = b->last;
+            old_size     = size - fsize;
+            st->len      = 0;
             h->timestamp += st->dtime;
 
             if (ngx_rtmp_receive_message(s, h, head) != NGX_OK) {
@@ -474,10 +418,10 @@ ngx_rtmp_recv(ngx_event_t *rev)
 
             } else {
                 /* add used bufs to stream #0 */
-                st0 = &s->in_streams[0];
+                st0          = &s->in_streams[0];
                 st->in->next = st0->in;
-                st0->in = head;
-                st->in = NULL;
+                st0->in      = head;
+                st->in       = NULL;
             }
         }
 
@@ -485,14 +429,12 @@ ngx_rtmp_recv(ngx_event_t *rev)
     }
 }
 
-
-static void
-ngx_rtmp_send(ngx_event_t *wev)
+static void ngx_rtmp_send(ngx_event_t *wev)
 {
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
-    ngx_int_t                   n;
-    ngx_rtmp_core_srv_conf_t   *cscf;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
+    ngx_int_t n;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     c = wev->data;
     s = c->data;
@@ -502,8 +444,7 @@ ngx_rtmp_send(ngx_event_t *wev)
     }
 
     if (wev->timedout) {
-        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT,
-                "client timed out");
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
         c->timedout = 1;
         ngx_rtmp_finalize_session(s);
         return;
@@ -515,7 +456,7 @@ ngx_rtmp_send(ngx_event_t *wev)
 
     if (s->out_chain == NULL && s->out_pos != s->out_last) {
         s->out_chain = s->out[s->out_pos];
-        s->out_bpos = s->out_chain->buf->pos;
+        s->out_bpos  = s->out_chain->buf->pos;
     }
 
     while (s->out_chain) {
@@ -559,42 +500,41 @@ ngx_rtmp_send(ngx_event_t *wev)
     }
 
 #if (nginx_version >= 1007012)
-    ngx_event_process_posted((ngx_cycle_t *) ngx_cycle,(ngx_queue_t *) &s->posted_dry_events);
+    ngx_event_process_posted((ngx_cycle_t *)ngx_cycle,
+                             (ngx_queue_t *)&s->posted_dry_events);
 #else
-    ngx_event_process_posted((ngx_cycle_t *) ngx_cycle, &s->posted_dry_events);
+    ngx_event_process_posted((ngx_cycle_t *)ngx_cycle, &s->posted_dry_events);
 #endif
 }
 
-
-void
-ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_rtmp_header_t *lh, ngx_chain_t *out)
+void ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                              ngx_rtmp_header_t *lh, ngx_chain_t *out)
 {
-    ngx_chain_t                *l;
-    u_char                     *p, *pp;
-    ngx_int_t                   hsize, thsize, nbufs;
-    uint32_t                    mlen, timestamp, ext_timestamp;
-    static uint8_t              hdrsize[] = { 12, 8, 4, 1 };
-    u_char                      th[7];
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    uint8_t                     fmt;
-    ngx_connection_t           *c;
+    ngx_chain_t *l;
+    u_char *p, *pp;
+    ngx_int_t hsize, thsize, nbufs;
+    uint32_t mlen, timestamp, ext_timestamp;
+    static uint8_t hdrsize[] = {12, 8, 4, 1};
+    u_char th[7];
+    ngx_rtmp_core_srv_conf_t *cscf;
+    uint8_t fmt;
+    ngx_connection_t *c;
 
-    c = s->connection;
+    c    = s->connection;
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     if (h->csid >= (uint32_t)cscf->max_streams) {
         ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                "RTMP out chunk stream too big: %D >= %D",
-                h->csid, cscf->max_streams);
+                      "RTMP out chunk stream too big: %D >= %D", h->csid,
+                      cscf->max_streams);
         ngx_rtmp_finalize_session(s);
         return;
     }
 
     /* detect packet size */
-    mlen = 0;
+    mlen  = 0;
     nbufs = 0;
-    for(l = out; l; l = l->next) {
+    for (l = out; l; l = l->next) {
         mlen += (l->buf->last - l->buf->pos);
         ++nbufs;
     }
@@ -621,15 +561,15 @@ ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     hsize = hdrsize[fmt];
 
     ngx_log_debug8(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "RTMP prep %s (%d) fmt=%d csid=%uD timestamp=%uD "
-            "mlen=%uD msid=%uD nbufs=%d",
-            ngx_rtmp_message_type(h->type), (int)h->type, (int)fmt,
-            h->csid, timestamp, mlen, h->msid, nbufs);
+                   "RTMP prep %s (%d) fmt=%d csid=%uD timestamp=%uD "
+                   "mlen=%uD msid=%uD nbufs=%d",
+                   ngx_rtmp_message_type(h->type), (int)h->type, (int)fmt,
+                   h->csid, timestamp, mlen, h->msid, nbufs);
 
     ext_timestamp = 0;
     if (timestamp >= 0x00ffffff) {
         ext_timestamp = timestamp;
-        timestamp = 0x00ffffff;
+        timestamp     = 0x00ffffff;
         hsize += 4;
     }
 
@@ -664,18 +604,18 @@ ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     /* message header */
     if (fmt <= 2) {
-        pp = (u_char*)&timestamp;
+        pp   = (u_char *)&timestamp;
         *p++ = pp[2];
         *p++ = pp[1];
         *p++ = pp[0];
         if (fmt <= 1) {
-            pp = (u_char*)&mlen;
+            pp   = (u_char *)&mlen;
             *p++ = pp[2];
             *p++ = pp[1];
             *p++ = pp[0];
             *p++ = h->type;
             if (fmt == 0) {
-                pp = (u_char*)&h->msid;
+                pp   = (u_char *)&h->msid;
                 *p++ = pp[0];
                 *p++ = pp[1];
                 *p++ = pp[2];
@@ -686,7 +626,7 @@ ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     /* extended header */
     if (ext_timestamp) {
-        pp = (u_char*)&ext_timestamp;
+        pp   = (u_char *)&ext_timestamp;
         *p++ = pp[3];
         *p++ = pp[2];
         *p++ = pp[1];
@@ -703,18 +643,16 @@ ngx_rtmp_prepare_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     }
 
     /* append headers to successive fragments */
-    for(out = out->next; out; out = out->next) {
+    for (out = out->next; out; out = out->next) {
         out->buf->pos -= thsize;
         ngx_memcpy(out->buf->pos, th, thsize);
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
-        ngx_uint_t priority)
+ngx_int_t ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
+                                ngx_uint_t priority)
 {
-    ngx_uint_t                      nmsg;
+    ngx_uint_t nmsg;
 
     nmsg = (s->out_last - s->out_pos) % s->out_queue + 1;
 
@@ -726,8 +664,8 @@ ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
      * Note we always leave 1 slot free */
     if (nmsg + priority * s->out_queue / 4 >= s->out_queue) {
         ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "RTMP drop message bufs=%ui, priority=%ui",
-                nmsg, priority);
+                       "RTMP drop message bufs=%ui, priority=%ui", nmsg,
+                       priority);
         return NGX_AGAIN;
     }
 
@@ -737,8 +675,8 @@ ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
     ngx_rtmp_acquire_shared_chain(out);
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "RTMP send nmsg=%ui, priority=%ui #%ui",
-            nmsg, priority, s->out_last);
+                   "RTMP send nmsg=%ui, priority=%ui #%ui", nmsg, priority,
+                   s->out_last);
 
     if (priority && s->out_buffer && nmsg < s->out_cork) {
         return NGX_OK;
@@ -746,97 +684,93 @@ ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
 
     if (!s->connection->write->active) {
         ngx_rtmp_send(s->connection->write);
-        /*return ngx_add_event(s->connection->write, NGX_WRITE_EVENT, NGX_CLEAR_EVENT);*/
+        /*return ngx_add_event(s->connection->write, NGX_WRITE_EVENT,
+         * NGX_CLEAR_EVENT);*/
     }
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_receive_message(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in)
+ngx_int_t ngx_rtmp_receive_message(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                                   ngx_chain_t *in)
 {
-    ngx_rtmp_core_main_conf_t  *cmcf;
-    ngx_array_t                *evhs;
-    size_t                      n;
-    ngx_rtmp_handler_pt        *evh;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_array_t *evhs;
+    size_t n;
+    ngx_rtmp_handler_pt *evh;
 
     cmcf = ngx_rtmp_get_module_main_conf(s, ngx_rtmp_core_module);
 
 #ifdef NGX_DEBUG
     {
-        int             nbufs;
-        ngx_chain_t    *ch;
+        int nbufs;
+        ngx_chain_t *ch;
 
-        for(nbufs = 1, ch = in;
-                ch->next;
-                ch = ch->next, ++nbufs);
+        for (nbufs = 1, ch = in; ch->next; ch = ch->next, ++nbufs)
+            ;
 
         ngx_log_debug7(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "RTMP recv %s (%d) csid=%D timestamp=%D "
-                "mlen=%D msid=%D nbufs=%d",
-                ngx_rtmp_message_type(h->type), (int)h->type,
-                h->csid, h->timestamp, h->mlen, h->msid, nbufs);
+                       "RTMP recv %s (%d) csid=%D timestamp=%D "
+                       "mlen=%D msid=%D nbufs=%d",
+                       ngx_rtmp_message_type(h->type), (int)h->type, h->csid,
+                       h->timestamp, h->mlen, h->msid, nbufs);
     }
 #endif
 
     if (h->type > NGX_RTMP_MSG_MAX) {
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "unexpected RTMP message type: %d", (int)h->type);
+                       "unexpected RTMP message type: %d", (int)h->type);
         return NGX_OK;
     }
 
     evhs = &cmcf->events[h->type];
-    evh = evhs->elts;
+    evh  = evhs->elts;
 
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "nhandlers: %d", evhs->nelts);
+    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "nhandlers: %d",
+                   evhs->nelts);
 
-    for(n = 0; n < evhs->nelts; ++n, ++evh) {
+    for (n = 0; n < evhs->nelts; ++n, ++evh) {
         if (!evh) {
             continue;
         }
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "calling handler %d", n);
+                       "calling handler %d", n);
 
         switch ((*evh)(s, h, in)) {
-            case NGX_ERROR:
-                ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                        "handler %d failed", n);
-                return NGX_ERROR;
-            case NGX_DONE:
-                return NGX_OK;
+        case NGX_ERROR:
+            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                           "handler %d failed", n);
+            return NGX_ERROR;
+        case NGX_DONE:
+            return NGX_OK;
         }
     }
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
+ngx_int_t ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
 {
-    ngx_rtmp_core_srv_conf_t           *cscf;
-    ngx_chain_t                        *li, *fli, *lo, *flo;
-    ngx_buf_t                          *bi, *bo;
-    ngx_int_t                           n;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_chain_t *li, *fli, *lo, *flo;
+    ngx_buf_t *bi, *bo;
+    ngx_int_t n;
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-        "setting chunk_size=%ui", size);
+                   "setting chunk_size=%ui", size);
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
-    s->in_old_pool = s->in_pool;
+    s->in_old_pool   = s->in_pool;
     s->in_chunk_size = size;
-    s->in_pool = ngx_create_pool(4096, s->connection->log);
+    s->in_pool       = ngx_create_pool(4096, s->connection->log);
 
     /* copy existing chunk data */
     if (s->in_old_pool) {
         s->in_chunk_size_changing = 1;
-        s->in_streams[0].in = NULL;
+        s->in_streams[0].in       = NULL;
 
-        for(n = 1; n < cscf->max_streams; ++n) {
+        for (n = 1; n < cscf->max_streams; ++n) {
             /* stream buffer is circular
              * for all streams except for the current one
              * (which caused this chunk size change);
@@ -847,34 +781,34 @@ ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
                 continue;
             }
             /* move from last to the first */
-            li = li->next;
+            li  = li->next;
             fli = li;
-            lo = ngx_rtmp_alloc_in_buf(s);
+            lo  = ngx_rtmp_alloc_in_buf(s);
             if (lo == NULL) {
                 return NGX_ERROR;
             }
             flo = lo;
-            for ( ;; ) {
+            for (;;) {
                 bi = li->buf;
                 bo = lo->buf;
 
                 if (bo->end - bo->last >= bi->last - bi->pos) {
-                    bo->last = ngx_cpymem(bo->last, bi->pos,
-                            bi->last - bi->pos);
+                    bo->last =
+                        ngx_cpymem(bo->last, bi->pos, bi->last - bi->pos);
                     li = li->next;
-                    if (li == fli)  {
-                        lo->next = flo;
+                    if (li == fli) {
+                        lo->next            = flo;
                         s->in_streams[n].in = lo;
                         break;
                     }
                     continue;
                 }
 
-                bi->pos += (ngx_cpymem(bo->last, bi->pos,
-                            bo->end - bo->last) - bo->last);
+                bi->pos += (ngx_cpymem(bo->last, bi->pos, bo->end - bo->last) -
+                            bo->last);
                 bo->last = bo->end;
                 lo->next = ngx_rtmp_alloc_in_buf(s);
-                lo = lo->next;
+                lo       = lo->next;
                 if (lo == NULL) {
                     return NGX_ERROR;
                 }
@@ -885,16 +819,12 @@ ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_finalize_set_chunk_size(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_finalize_set_chunk_size(ngx_rtmp_session_t *s)
 {
     if (s->in_chunk_size_changing && s->in_old_pool) {
         ngx_destroy_pool(s->in_old_pool);
-        s->in_old_pool = NULL;
+        s->in_old_pool            = NULL;
         s->in_chunk_size_changing = 0;
     }
     return NGX_OK;
 }
-
-

--- a/ngx_rtmp_handshake.c
+++ b/ngx_rtmp_handshake.c
@@ -3,19 +3,16 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
 
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
 
-
 static void ngx_rtmp_handshake_send(ngx_event_t *wev);
 static void ngx_rtmp_handshake_recv(ngx_event_t *rev);
 static void ngx_rtmp_handshake_done(ngx_rtmp_session_t *s);
-
 
 /* RTMP handshake :
  *
@@ -32,81 +29,58 @@ static void ngx_rtmp_handshake_done(ngx_rtmp_session_t *s);
  * digest2: HMAC_SHA256(packet, HMAC_SHA256(digest1, peer2_full_key))
  */
 
-
 /* Handshake keys */
-static u_char
-ngx_rtmp_server_key[] = {
-    'G', 'e', 'n', 'u', 'i', 'n', 'e', ' ', 'A', 'd', 'o', 'b', 'e', ' ',
-    'F', 'l', 'a', 's', 'h', ' ', 'M', 'e', 'd', 'i', 'a', ' ',
-    'S', 'e', 'r', 'v', 'e', 'r', ' ',
-    '0', '0', '1',
+static u_char ngx_rtmp_server_key[] = {
+    'G',  'e',  'n',  'u',  'i',  'n',  'e',  ' ',  'A',  'd',  'o',  'b',
+    'e',  ' ',  'F',  'l',  'a',  's',  'h',  ' ',  'M',  'e',  'd',  'i',
+    'a',  ' ',  'S',  'e',  'r',  'v',  'e',  'r',  ' ',  '0',  '0',  '1',
 
     0xF0, 0xEE, 0xC2, 0x4A, 0x80, 0x68, 0xBE, 0xE8, 0x2E, 0x00, 0xD0, 0xD1,
     0x02, 0x9E, 0x7E, 0x57, 0x6E, 0xEC, 0x5D, 0x2D, 0x29, 0x80, 0x6F, 0xAB,
-    0x93, 0xB8, 0xE6, 0x36, 0xCF, 0xEB, 0x31, 0xAE
-};
+    0x93, 0xB8, 0xE6, 0x36, 0xCF, 0xEB, 0x31, 0xAE};
 
+static u_char ngx_rtmp_client_key[] = {
+    'G',  'e',  'n',  'u',  'i',  'n',  'e',  ' ',  'A',  'd',  'o',
+    'b',  'e',  ' ',  'F',  'l',  'a',  's',  'h',  ' ',  'P',  'l',
+    'a',  'y',  'e',  'r',  ' ',  '0',  '0',  '1',
 
-static u_char
-ngx_rtmp_client_key[] = {
-    'G', 'e', 'n', 'u', 'i', 'n', 'e', ' ', 'A', 'd', 'o', 'b', 'e', ' ',
-    'F', 'l', 'a', 's', 'h', ' ', 'P', 'l', 'a', 'y', 'e', 'r', ' ',
-    '0', '0', '1',
+    0xF0, 0xEE, 0xC2, 0x4A, 0x80, 0x68, 0xBE, 0xE8, 0x2E, 0x00, 0xD0,
+    0xD1, 0x02, 0x9E, 0x7E, 0x57, 0x6E, 0xEC, 0x5D, 0x2D, 0x29, 0x80,
+    0x6F, 0xAB, 0x93, 0xB8, 0xE6, 0x36, 0xCF, 0xEB, 0x31, 0xAE};
 
-    0xF0, 0xEE, 0xC2, 0x4A, 0x80, 0x68, 0xBE, 0xE8, 0x2E, 0x00, 0xD0, 0xD1,
-    0x02, 0x9E, 0x7E, 0x57, 0x6E, 0xEC, 0x5D, 0x2D, 0x29, 0x80, 0x6F, 0xAB,
-    0x93, 0xB8, 0xE6, 0x36, 0xCF, 0xEB, 0x31, 0xAE
-};
+static const u_char ngx_rtmp_server_version[4] = {0x0D, 0x0E, 0x0A, 0x0D};
 
+static const u_char ngx_rtmp_client_version[4] = {0x0C, 0x00, 0x0D, 0x0E};
 
-static const u_char
-ngx_rtmp_server_version[4] = {
-    0x0D, 0x0E, 0x0A, 0x0D
-};
+#define NGX_RTMP_HANDSHAKE_KEYLEN SHA256_DIGEST_LENGTH
+#define NGX_RTMP_HANDSHAKE_BUFSIZE 1537
 
+#define NGX_RTMP_HANDSHAKE_SERVER_RECV_CHALLENGE 1
+#define NGX_RTMP_HANDSHAKE_SERVER_SEND_CHALLENGE 2
+#define NGX_RTMP_HANDSHAKE_SERVER_SEND_RESPONSE 3
+#define NGX_RTMP_HANDSHAKE_SERVER_RECV_RESPONSE 4
+#define NGX_RTMP_HANDSHAKE_SERVER_DONE 5
 
-static const u_char
-ngx_rtmp_client_version[4] = {
-    0x0C, 0x00, 0x0D, 0x0E
-};
+#define NGX_RTMP_HANDSHAKE_CLIENT_SEND_CHALLENGE 6
+#define NGX_RTMP_HANDSHAKE_CLIENT_RECV_CHALLENGE 7
+#define NGX_RTMP_HANDSHAKE_CLIENT_RECV_RESPONSE 8
+#define NGX_RTMP_HANDSHAKE_CLIENT_SEND_RESPONSE 9
+#define NGX_RTMP_HANDSHAKE_CLIENT_DONE 10
 
+static ngx_str_t ngx_rtmp_server_full_key = {sizeof(ngx_rtmp_server_key),
+                                             ngx_rtmp_server_key};
+static ngx_str_t ngx_rtmp_server_partial_key = {36, ngx_rtmp_server_key};
 
-#define NGX_RTMP_HANDSHAKE_KEYLEN                   SHA256_DIGEST_LENGTH
-#define NGX_RTMP_HANDSHAKE_BUFSIZE                  1537
+static ngx_str_t ngx_rtmp_client_full_key = {sizeof(ngx_rtmp_client_key),
+                                             ngx_rtmp_client_key};
+static ngx_str_t ngx_rtmp_client_partial_key = {30, ngx_rtmp_client_key};
 
-
-#define NGX_RTMP_HANDSHAKE_SERVER_RECV_CHALLENGE    1
-#define NGX_RTMP_HANDSHAKE_SERVER_SEND_CHALLENGE    2
-#define NGX_RTMP_HANDSHAKE_SERVER_SEND_RESPONSE     3
-#define NGX_RTMP_HANDSHAKE_SERVER_RECV_RESPONSE     4
-#define NGX_RTMP_HANDSHAKE_SERVER_DONE              5
-
-
-#define NGX_RTMP_HANDSHAKE_CLIENT_SEND_CHALLENGE    6
-#define NGX_RTMP_HANDSHAKE_CLIENT_RECV_CHALLENGE    7
-#define NGX_RTMP_HANDSHAKE_CLIENT_RECV_RESPONSE     8
-#define NGX_RTMP_HANDSHAKE_CLIENT_SEND_RESPONSE     9
-#define NGX_RTMP_HANDSHAKE_CLIENT_DONE              10
-
-
-static ngx_str_t            ngx_rtmp_server_full_key
-    = { sizeof(ngx_rtmp_server_key), ngx_rtmp_server_key };
-static ngx_str_t            ngx_rtmp_server_partial_key
-    = { 36, ngx_rtmp_server_key };
-
-static ngx_str_t            ngx_rtmp_client_full_key
-    = { sizeof(ngx_rtmp_client_key), ngx_rtmp_client_key };
-static ngx_str_t            ngx_rtmp_client_partial_key
-    = { 30, ngx_rtmp_client_key };
-
-
-static ngx_int_t
-ngx_rtmp_make_digest(ngx_str_t *key, ngx_buf_t *src,
-        u_char *skip, u_char *dst, ngx_log_t *log)
+static ngx_int_t ngx_rtmp_make_digest(ngx_str_t *key, ngx_buf_t *src,
+                                      u_char *skip, u_char *dst, ngx_log_t *log)
 {
-    static HMAC_CTX         hmac;
-    static unsigned         hmac_initialized;
-    unsigned int            len;
+    static HMAC_CTX hmac;
+    static unsigned hmac_initialized;
+    unsigned int len;
 
     if (!hmac_initialized) {
         HMAC_CTX_init(&hmac);
@@ -121,7 +95,7 @@ ngx_rtmp_make_digest(ngx_str_t *key, ngx_buf_t *src,
         }
         if (src->last != skip + NGX_RTMP_HANDSHAKE_KEYLEN) {
             HMAC_Update(&hmac, skip + NGX_RTMP_HANDSHAKE_KEYLEN,
-                    src->last - skip - NGX_RTMP_HANDSHAKE_KEYLEN);
+                        src->last - skip - NGX_RTMP_HANDSHAKE_KEYLEN);
         }
     } else {
         HMAC_Update(&hmac, src->pos, src->last - src->pos);
@@ -132,20 +106,19 @@ ngx_rtmp_make_digest(ngx_str_t *key, ngx_buf_t *src,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_find_digest(ngx_buf_t *b, ngx_str_t *key, size_t base, ngx_log_t *log)
+static ngx_int_t ngx_rtmp_find_digest(ngx_buf_t *b, ngx_str_t *key, size_t base,
+                                      ngx_log_t *log)
 {
-    size_t                  n, offs;
-    u_char                  digest[NGX_RTMP_HANDSHAKE_KEYLEN];
-    u_char                 *p;
+    size_t n, offs;
+    u_char digest[NGX_RTMP_HANDSHAKE_KEYLEN];
+    u_char *p;
 
     offs = 0;
     for (n = 0; n < 4; ++n) {
         offs += b->pos[base + n];
     }
     offs = (offs % 728) + base + 4;
-    p = b->pos + offs;
+    p    = b->pos + offs;
 
     if (ngx_rtmp_make_digest(key, b, p, digest, log) != NGX_OK) {
         return NGX_ERROR;
@@ -158,20 +131,18 @@ ngx_rtmp_find_digest(ngx_buf_t *b, ngx_str_t *key, size_t base, ngx_log_t *log)
     return NGX_ERROR;
 }
 
-
-static ngx_int_t
-ngx_rtmp_write_digest(ngx_buf_t *b, ngx_str_t *key, size_t base,
-        ngx_log_t *log)
+static ngx_int_t ngx_rtmp_write_digest(ngx_buf_t *b, ngx_str_t *key,
+                                       size_t base, ngx_log_t *log)
 {
-    size_t                  n, offs;
-    u_char                 *p;
+    size_t n, offs;
+    u_char *p;
 
     offs = 0;
     for (n = 8; n < 12; ++n) {
         offs += b->pos[base + n];
     }
     offs = (offs % 728) + base + 12;
-    p = b->pos + offs;
+    p    = b->pos + offs;
 
     if (ngx_rtmp_make_digest(key, b, p, p, log) != NGX_OK) {
         return NGX_ERROR;
@@ -180,31 +151,27 @@ ngx_rtmp_write_digest(ngx_buf_t *b, ngx_str_t *key, size_t base,
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_fill_random_buffer(ngx_buf_t *b)
+static void ngx_rtmp_fill_random_buffer(ngx_buf_t *b)
 {
     for (; b->last != b->end; ++b->last) {
-        *b->last = (u_char) rand();
+        *b->last = (u_char)rand();
     }
 }
 
-
-static ngx_buf_t *
-ngx_rtmp_alloc_handshake_buffer(ngx_rtmp_session_t *s)
+static ngx_buf_t *ngx_rtmp_alloc_handshake_buffer(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_chain_t                *cl;
-    ngx_buf_t                  *b;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_chain_t *cl;
+    ngx_buf_t *b;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: allocating buffer");
+                   "handshake: allocating buffer");
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     if (cscf->free_hs) {
-        cl = cscf->free_hs;
-        b = cl->buf;
+        cl            = cscf->free_hs;
+        b             = cl->buf;
         cscf->free_hs = cl->next;
         ngx_free_chain(cscf->pool, cl);
 
@@ -214,7 +181,7 @@ ngx_rtmp_alloc_handshake_buffer(ngx_rtmp_session_t *s)
             return NULL;
         }
         b->memory = 1;
-        b->start = ngx_pcalloc(cscf->pool, NGX_RTMP_HANDSHAKE_BUFSIZE);
+        b->start  = ngx_pcalloc(cscf->pool, NGX_RTMP_HANDSHAKE_BUFSIZE);
         if (b->start == NULL) {
             return NULL;
         }
@@ -226,39 +193,36 @@ ngx_rtmp_alloc_handshake_buffer(ngx_rtmp_session_t *s)
     return b;
 }
 
-
-void
-ngx_rtmp_free_handshake_buffers(ngx_rtmp_session_t *s)
+void ngx_rtmp_free_handshake_buffers(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_chain_t                *cl;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_chain_t *cl;
 
     if (s->hs_buf == NULL) {
         return;
     }
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
-    cl = ngx_alloc_chain_link(cscf->pool);
+    cl   = ngx_alloc_chain_link(cscf->pool);
     if (cl == NULL) {
         return;
     }
-    cl->buf = s->hs_buf;
-    cl->next = cscf->free_hs;
+    cl->buf       = s->hs_buf;
+    cl->next      = cscf->free_hs;
     cscf->free_hs = cl;
-    s->hs_buf = NULL;
+    s->hs_buf     = NULL;
 }
 
-
-static ngx_int_t
-ngx_rtmp_handshake_create_challenge(ngx_rtmp_session_t *s,
-        const u_char version[4], ngx_str_t *key)
+static ngx_int_t ngx_rtmp_handshake_create_challenge(ngx_rtmp_session_t *s,
+                                                     const u_char version[4],
+                                                     ngx_str_t *key)
 {
-    ngx_buf_t          *b;
+    ngx_buf_t *b;
 
-    b = s->hs_buf;
+    b       = s->hs_buf;
     b->last = b->pos = b->start;
-    *b->last++ = '\x03';
-    b->last = ngx_rtmp_rcpymem(b->last, &s->epoch, 4);
-    b->last = ngx_cpymem(b->last, version, 4);
+    *b->last++       = '\x03';
+    b->last          = ngx_rtmp_rcpymem(b->last, &s->epoch, 4);
+    b->last          = ngx_cpymem(b->last, version, 4);
     ngx_rtmp_fill_random_buffer(b);
     ++b->pos;
     if (ngx_rtmp_write_digest(b, key, 0, s->connection->log) != NGX_OK) {
@@ -268,20 +232,19 @@ ngx_rtmp_handshake_create_challenge(ngx_rtmp_session_t *s,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_handshake_parse_challenge(ngx_rtmp_session_t *s,
-        ngx_str_t *peer_key, ngx_str_t *key)
+static ngx_int_t ngx_rtmp_handshake_parse_challenge(ngx_rtmp_session_t *s,
+                                                    ngx_str_t *peer_key,
+                                                    ngx_str_t *key)
 {
-    ngx_buf_t              *b;
-    u_char                 *p;
-    ngx_int_t               offs;
+    ngx_buf_t *b;
+    u_char *p;
+    ngx_int_t offs;
 
     b = s->hs_buf;
     if (*b->pos != '\x03') {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "handshake: unexpected RTMP version: %i",
-                (ngx_int_t)*b->pos);
+                      "handshake: unexpected RTMP version: %i",
+                      (ngx_int_t)*b->pos);
         return NGX_ERROR;
     }
     ++b->pos;
@@ -290,10 +253,9 @@ ngx_rtmp_handshake_parse_challenge(ngx_rtmp_session_t *s,
 
     p = b->pos + 4;
     ngx_log_debug5(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: peer version=%i.%i.%i.%i epoch=%uD",
-            (ngx_int_t)p[3], (ngx_int_t)p[2],
-            (ngx_int_t)p[1], (ngx_int_t)p[0],
-            (uint32_t)s->peer_epoch);
+                   "handshake: peer version=%i.%i.%i.%i epoch=%uD",
+                   (ngx_int_t)p[3], (ngx_int_t)p[2], (ngx_int_t)p[1],
+                   (ngx_int_t)p[0], (uint32_t)s->peer_epoch);
     if (*(uint32_t *)p == 0) {
         s->hs_old = 1;
         return NGX_OK;
@@ -305,38 +267,35 @@ ngx_rtmp_handshake_parse_challenge(ngx_rtmp_session_t *s,
     }
     if (offs == NGX_ERROR) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "handshake: digest not found");
+                      "handshake: digest not found");
         s->hs_old = 1;
         return NGX_OK;
     }
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: digest found at pos=%i", offs);
+                   "handshake: digest found at pos=%i", offs);
     b->pos += offs;
-    b->last = b->pos + NGX_RTMP_HANDSHAKE_KEYLEN;
+    b->last      = b->pos + NGX_RTMP_HANDSHAKE_KEYLEN;
     s->hs_digest = ngx_palloc(s->connection->pool, NGX_RTMP_HANDSHAKE_KEYLEN);
-    if (ngx_rtmp_make_digest(key, b, NULL, s->hs_digest, s->connection->log)
-            != NGX_OK)
-    {
+    if (ngx_rtmp_make_digest(key, b, NULL, s->hs_digest, s->connection->log) !=
+        NGX_OK) {
         return NGX_ERROR;
     }
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_handshake_create_response(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_handshake_create_response(ngx_rtmp_session_t *s)
 {
-    ngx_buf_t          *b;
-    u_char             *p;
-    ngx_str_t           key;
+    ngx_buf_t *b;
+    u_char *p;
+    ngx_str_t key;
 
-    b = s->hs_buf;
+    b      = s->hs_buf;
     b->pos = b->last = b->start + 1;
     ngx_rtmp_fill_random_buffer(b);
     if (s->hs_digest) {
-        p = b->last - NGX_RTMP_HANDSHAKE_KEYLEN;
+        p        = b->last - NGX_RTMP_HANDSHAKE_KEYLEN;
         key.data = s->hs_digest;
-        key.len = NGX_RTMP_HANDSHAKE_KEYLEN;
+        key.len  = NGX_RTMP_HANDSHAKE_KEYLEN;
         if (ngx_rtmp_make_digest(&key, b, p, p, s->connection->log) != NGX_OK) {
             return NGX_ERROR;
         }
@@ -345,18 +304,14 @@ ngx_rtmp_handshake_create_response(ngx_rtmp_session_t *s)
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_handshake_done(ngx_rtmp_session_t *s)
+static void ngx_rtmp_handshake_done(ngx_rtmp_session_t *s)
 {
     ngx_rtmp_free_handshake_buffers(s);
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: done");
+                   "handshake: done");
 
-    if (ngx_rtmp_fire_event(s, NGX_RTMP_HANDSHAKE_DONE,
-                NULL, NULL) != NGX_OK)
-    {
+    if (ngx_rtmp_fire_event(s, NGX_RTMP_HANDSHAKE_DONE, NULL, NULL) != NGX_OK) {
         ngx_rtmp_finalize_session(s);
         return;
     }
@@ -364,14 +319,12 @@ ngx_rtmp_handshake_done(ngx_rtmp_session_t *s)
     ngx_rtmp_cycle(s);
 }
 
-
-static void
-ngx_rtmp_handshake_recv(ngx_event_t *rev)
+static void ngx_rtmp_handshake_recv(ngx_event_t *rev)
 {
-    ssize_t                     n;
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
-    ngx_buf_t                  *b;
+    ssize_t n;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
+    ngx_buf_t *b;
 
     c = rev->data;
     s = c->data;
@@ -382,7 +335,7 @@ ngx_rtmp_handshake_recv(ngx_event_t *rev)
 
     if (rev->timedout) {
         ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT,
-                "handshake: recv: client timed out");
+                      "handshake: recv: client timed out");
         c->timedout = 1;
         ngx_rtmp_finalize_session(s);
         return;
@@ -419,74 +372,68 @@ ngx_rtmp_handshake_recv(ngx_event_t *rev)
 
     ++s->hs_stage;
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: stage %ui", s->hs_stage);
+                   "handshake: stage %ui", s->hs_stage);
 
     switch (s->hs_stage) {
-        case NGX_RTMP_HANDSHAKE_SERVER_SEND_CHALLENGE:
-            if (ngx_rtmp_handshake_parse_challenge(s,
-                    &ngx_rtmp_client_partial_key,
-                    &ngx_rtmp_server_full_key) != NGX_OK)
-            {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "handshake: error parsing challenge");
-                ngx_rtmp_finalize_session(s);
-                return;
-            }
-            if (s->hs_old) {
-                ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                        "handshake: old-style challenge");
-                s->hs_buf->pos = s->hs_buf->start;
-                s->hs_buf->last = s->hs_buf->end;
-            } else if (ngx_rtmp_handshake_create_challenge(s,
-                        ngx_rtmp_server_version,
-                        &ngx_rtmp_server_partial_key) != NGX_OK)
-            {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "handshake: error creating challenge");
-                ngx_rtmp_finalize_session(s);
-                return;
-            }
-            ngx_rtmp_handshake_send(c->write);
-            break;
+    case NGX_RTMP_HANDSHAKE_SERVER_SEND_CHALLENGE:
+        if (ngx_rtmp_handshake_parse_challenge(s, &ngx_rtmp_client_partial_key,
+                                               &ngx_rtmp_server_full_key) !=
+            NGX_OK) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "handshake: error parsing challenge");
+            ngx_rtmp_finalize_session(s);
+            return;
+        }
+        if (s->hs_old) {
+            ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                           "handshake: old-style challenge");
+            s->hs_buf->pos  = s->hs_buf->start;
+            s->hs_buf->last = s->hs_buf->end;
+        } else if (ngx_rtmp_handshake_create_challenge(
+                       s, ngx_rtmp_server_version,
+                       &ngx_rtmp_server_partial_key) != NGX_OK) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "handshake: error creating challenge");
+            ngx_rtmp_finalize_session(s);
+            return;
+        }
+        ngx_rtmp_handshake_send(c->write);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_SERVER_DONE:
-            ngx_rtmp_handshake_done(s);
-            break;
+    case NGX_RTMP_HANDSHAKE_SERVER_DONE:
+        ngx_rtmp_handshake_done(s);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_CLIENT_RECV_RESPONSE:
-            if (ngx_rtmp_handshake_parse_challenge(s,
-                    &ngx_rtmp_server_partial_key,
-                    &ngx_rtmp_client_full_key) != NGX_OK)
-            {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "handshake: error parsing challenge");
-                ngx_rtmp_finalize_session(s);
-                return;
-            }
-            s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start + 1;
-            ngx_rtmp_handshake_recv(c->read);
-            break;
+    case NGX_RTMP_HANDSHAKE_CLIENT_RECV_RESPONSE:
+        if (ngx_rtmp_handshake_parse_challenge(s, &ngx_rtmp_server_partial_key,
+                                               &ngx_rtmp_client_full_key) !=
+            NGX_OK) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "handshake: error parsing challenge");
+            ngx_rtmp_finalize_session(s);
+            return;
+        }
+        s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start + 1;
+        ngx_rtmp_handshake_recv(c->read);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_CLIENT_SEND_RESPONSE:
-            if (ngx_rtmp_handshake_create_response(s) != NGX_OK) {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "handshake: response error");
-                ngx_rtmp_finalize_session(s);
-                return;
-            }
-            ngx_rtmp_handshake_send(c->write);
-            break;
+    case NGX_RTMP_HANDSHAKE_CLIENT_SEND_RESPONSE:
+        if (ngx_rtmp_handshake_create_response(s) != NGX_OK) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0, "handshake: response error");
+            ngx_rtmp_finalize_session(s);
+            return;
+        }
+        ngx_rtmp_handshake_send(c->write);
+        break;
     }
 }
 
-
-static void
-ngx_rtmp_handshake_send(ngx_event_t *wev)
+static void ngx_rtmp_handshake_send(ngx_event_t *wev)
 {
-    ngx_int_t                   n;
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
-    ngx_buf_t                  *b;
+    ngx_int_t n;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
+    ngx_buf_t *b;
 
     c = wev->data;
     s = c->data;
@@ -497,7 +444,7 @@ ngx_rtmp_handshake_send(ngx_event_t *wev)
 
     if (wev->timedout) {
         ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT,
-                "handshake: send: client timed out");
+                      "handshake: send: client timed out");
         c->timedout = 1;
         ngx_rtmp_finalize_session(s);
         return;
@@ -509,7 +456,7 @@ ngx_rtmp_handshake_send(ngx_event_t *wev)
 
     b = s->hs_buf;
 
-    while(b->pos != b->last) {
+    while (b->pos != b->last) {
         n = c->send(c, b->pos, b->last - b->pos);
 
         if (n == NGX_ERROR) {
@@ -534,79 +481,73 @@ ngx_rtmp_handshake_send(ngx_event_t *wev)
 
     ++s->hs_stage;
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: stage %ui", s->hs_stage);
+                   "handshake: stage %ui", s->hs_stage);
 
     switch (s->hs_stage) {
-        case NGX_RTMP_HANDSHAKE_SERVER_SEND_RESPONSE:
-            if (s->hs_old) {
-                ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                        "handshake: old-style response");
-                s->hs_buf->pos = s->hs_buf->start + 1;
-                s->hs_buf->last = s->hs_buf->end;
-            } else if (ngx_rtmp_handshake_create_response(s) != NGX_OK) {
-                ngx_log_error(NGX_LOG_INFO, c->log, 0,
-                        "handshake: response error");
-                ngx_rtmp_finalize_session(s);
-                return;
-            }
-            ngx_rtmp_handshake_send(wev);
-            break;
+    case NGX_RTMP_HANDSHAKE_SERVER_SEND_RESPONSE:
+        if (s->hs_old) {
+            ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                           "handshake: old-style response");
+            s->hs_buf->pos  = s->hs_buf->start + 1;
+            s->hs_buf->last = s->hs_buf->end;
+        } else if (ngx_rtmp_handshake_create_response(s) != NGX_OK) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0, "handshake: response error");
+            ngx_rtmp_finalize_session(s);
+            return;
+        }
+        ngx_rtmp_handshake_send(wev);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_SERVER_RECV_RESPONSE:
-            s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start + 1;
-            ngx_rtmp_handshake_recv(c->read);
-            break;
+    case NGX_RTMP_HANDSHAKE_SERVER_RECV_RESPONSE:
+        s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start + 1;
+        ngx_rtmp_handshake_recv(c->read);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_CLIENT_RECV_CHALLENGE:
-            s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start;
-            ngx_rtmp_handshake_recv(c->read);
-            break;
+    case NGX_RTMP_HANDSHAKE_CLIENT_RECV_CHALLENGE:
+        s->hs_buf->pos = s->hs_buf->last = s->hs_buf->start;
+        ngx_rtmp_handshake_recv(c->read);
+        break;
 
-        case NGX_RTMP_HANDSHAKE_CLIENT_DONE:
-            ngx_rtmp_handshake_done(s);
-            break;
+    case NGX_RTMP_HANDSHAKE_CLIENT_DONE:
+        ngx_rtmp_handshake_done(s);
+        break;
     }
 }
 
-
-void
-ngx_rtmp_handshake(ngx_rtmp_session_t *s)
+void ngx_rtmp_handshake(ngx_rtmp_session_t *s)
 {
-    ngx_connection_t           *c;
+    ngx_connection_t *c;
 
-    c = s->connection;
-    c->read->handler =  ngx_rtmp_handshake_recv;
+    c                 = s->connection;
+    c->read->handler  = ngx_rtmp_handshake_recv;
     c->write->handler = ngx_rtmp_handshake_send;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: start server handshake");
+                   "handshake: start server handshake");
 
-    s->hs_buf = ngx_rtmp_alloc_handshake_buffer(s);
+    s->hs_buf   = ngx_rtmp_alloc_handshake_buffer(s);
     s->hs_stage = NGX_RTMP_HANDSHAKE_SERVER_RECV_CHALLENGE;
 
     ngx_rtmp_handshake_recv(c->read);
 }
 
-
-void
-ngx_rtmp_client_handshake(ngx_rtmp_session_t *s, unsigned async)
+void ngx_rtmp_client_handshake(ngx_rtmp_session_t *s, unsigned async)
 {
-    ngx_connection_t           *c;
+    ngx_connection_t *c;
 
-    c = s->connection;
-    c->read->handler =  ngx_rtmp_handshake_recv;
+    c                 = s->connection;
+    c->read->handler  = ngx_rtmp_handshake_recv;
     c->write->handler = ngx_rtmp_handshake_send;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "handshake: start client handshake");
+                   "handshake: start client handshake");
 
-    s->hs_buf = ngx_rtmp_alloc_handshake_buffer(s);
+    s->hs_buf   = ngx_rtmp_alloc_handshake_buffer(s);
     s->hs_stage = NGX_RTMP_HANDSHAKE_CLIENT_SEND_CHALLENGE;
 
-    if (ngx_rtmp_handshake_create_challenge(s,
-                ngx_rtmp_client_version,
-                &ngx_rtmp_client_partial_key) != NGX_OK)
-    {
+    if (ngx_rtmp_handshake_create_challenge(s, ngx_rtmp_client_version,
+                                            &ngx_rtmp_client_partial_key) !=
+        NGX_OK) {
         ngx_rtmp_finalize_session(s);
         return;
     }
@@ -621,4 +562,3 @@ ngx_rtmp_client_handshake(ngx_rtmp_session_t *s, unsigned async)
 
     ngx_rtmp_handshake_send(c->write);
 }
-

--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -3,31 +3,27 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_proxy_protocol.h"
-
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 static void ngx_rtmp_close_connection(ngx_connection_t *c);
-static u_char * ngx_rtmp_log_error(ngx_log_t *log, u_char *buf, size_t len);
+static u_char *ngx_rtmp_log_error(ngx_log_t *log, u_char *buf, size_t len);
 
-
-void
-ngx_rtmp_init_connection(ngx_connection_t *c)
+void ngx_rtmp_init_connection(ngx_connection_t *c)
 {
-    ngx_uint_t             i;
-    ngx_rtmp_port_t       *port;
-    struct sockaddr       *sa;
-    struct sockaddr_in    *sin;
-    ngx_rtmp_in_addr_t    *addr;
-    ngx_rtmp_session_t    *s;
-    ngx_rtmp_addr_conf_t  *addr_conf;
-    ngx_int_t              unix_socket;
+    ngx_uint_t i;
+    ngx_rtmp_port_t *port;
+    struct sockaddr *sa;
+    struct sockaddr_in *sin;
+    ngx_rtmp_in_addr_t *addr;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_addr_conf_t *addr_conf;
+    ngx_int_t unix_socket;
 #if (NGX_HAVE_INET6)
-    struct sockaddr_in6   *sin6;
-    ngx_rtmp_in6_addr_t   *addr6;
+    struct sockaddr_in6 *sin6;
+    ngx_rtmp_in6_addr_t *addr6;
 #endif
 
     ++ngx_rtmp_naccepted;
@@ -36,11 +32,10 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
     /* AF_INET only */
 
-    port = c->listening->servers;
+    port        = c->listening->servers;
     unix_socket = 0;
 
     if (port->naddrs > 1) {
-
         /*
          * There are several addresses on this port and one of them
          * is the "*:port" wildcard so getsockname() is needed to determine
@@ -57,10 +52,9 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
         sa = c->local_sockaddr;
 
         switch (sa->sa_family) {
-
 #if (NGX_HAVE_INET6)
         case AF_INET6:
-            sin6 = (struct sockaddr_in6 *) sa;
+            sin6 = (struct sockaddr_in6 *)sa;
 
             addr6 = port->addrs;
 
@@ -81,7 +75,7 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
             unix_socket = 1;
 
         default: /* AF_INET */
-            sin = (struct sockaddr_in *) sa;
+            sin = (struct sockaddr_in *)sa;
 
             addr = port->addrs;
 
@@ -100,10 +94,9 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
     } else {
         switch (c->local_sockaddr->sa_family) {
-
 #if (NGX_HAVE_INET6)
         case AF_INET6:
-            addr6 = port->addrs;
+            addr6     = port->addrs;
             addr_conf = &addr6[0].conf;
             break;
 #endif
@@ -112,7 +105,7 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
             unix_socket = 1;
 
         default: /* AF_INET */
-            addr = port->addrs;
+            addr      = port->addrs;
             addr_conf = &addr[0].conf;
             break;
         }
@@ -139,29 +132,30 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
     }
 }
 
-
-ngx_rtmp_session_t *
-ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
+ngx_rtmp_session_t *ngx_rtmp_init_session(ngx_connection_t *c,
+                                          ngx_rtmp_addr_conf_t *addr_conf)
 {
-    ngx_rtmp_session_t             *s;
-    ngx_rtmp_core_srv_conf_t       *cscf;
-    ngx_rtmp_error_log_ctx_t       *ctx;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_rtmp_error_log_ctx_t *ctx;
 
-    s = ngx_pcalloc(c->pool, sizeof(ngx_rtmp_session_t) +
-            sizeof(ngx_chain_t *) * ((ngx_rtmp_core_srv_conf_t *)
-                addr_conf->ctx-> srv_conf[ngx_rtmp_core_module
-                    .ctx_index])->out_queue);
+    s = ngx_pcalloc(c->pool,
+                    sizeof(ngx_rtmp_session_t) +
+                        sizeof(ngx_chain_t *) *
+                            ((ngx_rtmp_core_srv_conf_t *)addr_conf->ctx
+                                 ->srv_conf[ngx_rtmp_core_module.ctx_index])
+                                ->out_queue);
     if (s == NULL) {
         ngx_rtmp_close_connection(c);
         return NULL;
     }
 
     s->main_conf = addr_conf->ctx->main_conf;
-    s->srv_conf = addr_conf->ctx->srv_conf;
+    s->srv_conf  = addr_conf->ctx->srv_conf;
 
     s->addr_text = &addr_conf->addr_text;
 
-    c->data = s;
+    c->data       = s;
     s->connection = c;
 
     ctx = ngx_palloc(c->pool, sizeof(ngx_rtmp_error_log_ctx_t));
@@ -170,13 +164,13 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
         return NULL;
     }
 
-    ctx->client = &c->addr_text;
+    ctx->client  = &c->addr_text;
     ctx->session = s;
 
     c->log->connection = c->number;
-    c->log->handler = ngx_rtmp_log_error;
-    c->log->data = ctx;
-    c->log->action = NULL;
+    c->log->handler    = ngx_rtmp_log_error;
+    c->log->data       = ctx;
+    c->log->action     = NULL;
 
     c->log_error = NGX_ERROR_INFO;
 
@@ -189,9 +183,9 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     s->out_queue = cscf->out_queue;
-    s->out_cork = cscf->out_cork;
-    s->in_streams = ngx_pcalloc(c->pool, sizeof(ngx_rtmp_stream_t)
-            * cscf->max_streams);
+    s->out_cork  = cscf->out_cork;
+    s->in_streams =
+        ngx_pcalloc(c->pool, sizeof(ngx_rtmp_stream_t) * cscf->max_streams);
     if (s->in_streams == NULL) {
         ngx_rtmp_close_connection(c);
         return NULL;
@@ -201,11 +195,10 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
     ngx_queue_init(&s->posted_dry_events);
 #endif
 
-    s->epoch = ngx_current_msec;
+    s->epoch   = ngx_current_msec;
     s->timeout = cscf->timeout;
-    s->buflen = cscf->buflen;
+    s->buflen  = cscf->buflen;
     ngx_rtmp_set_chunk_size(s, NGX_RTMP_DEFAULT_CHUNK_SIZE);
-
 
     if (ngx_rtmp_fire_event(s, NGX_RTMP_CONNECT, NULL, NULL) != NGX_OK) {
         ngx_rtmp_finalize_session(s);
@@ -215,13 +208,11 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
     return s;
 }
 
-
-static u_char *
-ngx_rtmp_log_error(ngx_log_t *log, u_char *buf, size_t len)
+static u_char *ngx_rtmp_log_error(ngx_log_t *log, u_char *buf, size_t len)
 {
-    u_char                     *p;
-    ngx_rtmp_session_t         *s;
-    ngx_rtmp_error_log_ctx_t   *ctx;
+    u_char *p;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_error_log_ctx_t *ctx;
 
     if (log->action) {
         p = ngx_snprintf(buf, len, " while %s", log->action);
@@ -248,16 +239,14 @@ ngx_rtmp_log_error(ngx_log_t *log, u_char *buf, size_t len)
     return p;
 }
 
-
-static void
-ngx_rtmp_close_connection(ngx_connection_t *c)
+static void ngx_rtmp_close_connection(ngx_connection_t *c)
 {
-    ngx_pool_t                         *pool;
+    ngx_pool_t *pool;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, c->log, 0, "close connection");
 
 #if (NGX_STAT_STUB)
-    (void) ngx_atomic_fetch_add(ngx_stat_active, -1);
+    (void)ngx_atomic_fetch_add(ngx_stat_active, -1);
 #endif
 
     pool = c->pool;
@@ -265,13 +254,11 @@ ngx_rtmp_close_connection(ngx_connection_t *c)
     ngx_destroy_pool(pool);
 }
 
-
-static void
-ngx_rtmp_close_session_handler(ngx_event_t *e)
+static void ngx_rtmp_close_session_handler(ngx_event_t *e)
 {
-    ngx_rtmp_session_t                 *s;
-    ngx_connection_t                   *c;
-    ngx_rtmp_core_srv_conf_t           *cscf;
+    ngx_rtmp_session_t *s;
+    ngx_connection_t *c;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     s = e->data;
     c = s->connection;
@@ -304,12 +291,10 @@ ngx_rtmp_close_session_handler(ngx_event_t *e)
     ngx_rtmp_close_connection(c);
 }
 
-
-void
-ngx_rtmp_finalize_session(ngx_rtmp_session_t *s)
+void ngx_rtmp_finalize_session(ngx_rtmp_session_t *s)
 {
-    ngx_event_t        *e;
-    ngx_connection_t   *c;
+    ngx_event_t *e;
+    ngx_connection_t *c;
 
     c = s->connection;
     if (c->destroyed) {
@@ -319,11 +304,10 @@ ngx_rtmp_finalize_session(ngx_rtmp_session_t *s)
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, c->log, 0, "finalize session");
 
     c->destroyed = 1;
-    e = &s->close;
-    e->data = s;
-    e->handler = ngx_rtmp_close_session_handler;
-    e->log = c->log;
+    e            = &s->close;
+    e->data      = s;
+    e->handler   = ngx_rtmp_close_session_handler;
+    e->log       = c->log;
 
     ngx_post_event(e, &ngx_posted_events);
 }
-

--- a/ngx_rtmp_limit_module.c
+++ b/ngx_rtmp_limit_module.c
@@ -3,70 +3,57 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-
 
 typedef struct {
-    ngx_int_t       max_conn;
+    ngx_int_t max_conn;
     ngx_shm_zone_t *shm_zone;
 } ngx_rtmp_limit_main_conf_t;
 
-
-static ngx_str_t    shm_name = ngx_string("rtmp_limit");
-
+static ngx_str_t shm_name = ngx_string("rtmp_limit");
 
 static ngx_int_t ngx_rtmp_limit_postconfiguration(ngx_conf_t *cf);
 static void *ngx_rtmp_limit_create_main_conf(ngx_conf_t *cf);
 
+static ngx_command_t ngx_rtmp_limit_commands[] = {
 
-static ngx_command_t  ngx_rtmp_limit_commands[] = {
+    {ngx_string("max_connections"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                        NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_num_slot, NGX_RTMP_MAIN_CONF_OFFSET,
+     offsetof(ngx_rtmp_limit_main_conf_t, max_conn), NULL},
 
-    { ngx_string("max_connections"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_num_slot,
-      NGX_RTMP_MAIN_CONF_OFFSET,
-      offsetof(ngx_rtmp_limit_main_conf_t, max_conn),
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_limit_module_ctx = {
+    NULL,                             /* preconfiguration */
+    ngx_rtmp_limit_postconfiguration, /* postconfiguration */
+    ngx_rtmp_limit_create_main_conf,  /* create main configuration */
+    NULL,                             /* init main configuration */
+    NULL,                             /* create server configuration */
+    NULL,                             /* merge server configuration */
+    NULL,                             /* create app configuration */
+    NULL                              /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_limit_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_limit_postconfiguration,       /* postconfiguration */
-    ngx_rtmp_limit_create_main_conf,        /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    NULL,                                   /* create app configuration */
-    NULL                                    /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_limit_module = {
+ngx_module_t ngx_rtmp_limit_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_limit_module_ctx,             /* module context */
-    ngx_rtmp_limit_commands,                /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_limit_module_ctx, /* module context */
+    ngx_rtmp_limit_commands,    /* module directives */
+    NGX_RTMP_MODULE,            /* module type */
+    NULL,                       /* init master */
+    NULL,                       /* init module */
+    NULL,                       /* init process */
+    NULL,                       /* init thread */
+    NULL,                       /* exit thread */
+    NULL,                       /* exit process */
+    NULL,                       /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void *
-ngx_rtmp_limit_create_main_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_limit_create_main_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_limit_main_conf_t      *lmcf;
+    ngx_rtmp_limit_main_conf_t *lmcf;
 
     lmcf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_limit_main_conf_t));
     if (lmcf == NULL) {
@@ -78,16 +65,14 @@ ngx_rtmp_limit_create_main_conf(ngx_conf_t *cf)
     return lmcf;
 }
 
-
-static ngx_int_t
-ngx_rtmp_limit_connect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-    ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_limit_connect(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
     ngx_rtmp_limit_main_conf_t *lmcf;
-    ngx_slab_pool_t            *shpool;
-    ngx_shm_zone_t             *shm_zone;
-    uint32_t                   *nconn, n;
-    ngx_int_t                   rc;
+    ngx_slab_pool_t *shpool;
+    ngx_shm_zone_t *shm_zone;
+    uint32_t *nconn, n;
+    ngx_int_t rc;
 
     lmcf = ngx_rtmp_get_module_main_conf(s, ngx_rtmp_limit_module);
     if (lmcf->max_conn == NGX_CONF_UNSET) {
@@ -95,36 +80,35 @@ ngx_rtmp_limit_connect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     }
 
     shm_zone = lmcf->shm_zone;
-    shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
-    nconn = shm_zone->data;
+    shpool   = (ngx_slab_pool_t *)shm_zone->shm.addr;
+    nconn    = shm_zone->data;
 
     ngx_shmtx_lock(&shpool->mutex);
     n = ++*nconn;
     ngx_shmtx_unlock(&shpool->mutex);
 
-    rc = n > (ngx_uint_t) lmcf->max_conn ? NGX_ERROR : NGX_OK;
+    rc = n > (ngx_uint_t)lmcf->max_conn ? NGX_ERROR : NGX_OK;
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "limit: inc conection counter: %uD", n);
 
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                      "limit: too many connections: %uD > %i",
-                      n, lmcf->max_conn);
+                      "limit: too many connections: %uD > %i", n,
+                      lmcf->max_conn);
     }
 
     return rc;
 }
 
-
-static ngx_int_t
-ngx_rtmp_limit_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-    ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_limit_disconnect(ngx_rtmp_session_t *s,
+                                           ngx_rtmp_header_t *h,
+                                           ngx_chain_t *in)
 {
     ngx_rtmp_limit_main_conf_t *lmcf;
-    ngx_slab_pool_t            *shpool;
-    ngx_shm_zone_t             *shm_zone;
-    uint32_t                   *nconn, n;
+    ngx_slab_pool_t *shpool;
+    ngx_shm_zone_t *shm_zone;
+    uint32_t *nconn, n;
 
     lmcf = ngx_rtmp_get_module_main_conf(s, ngx_rtmp_limit_module);
     if (lmcf->max_conn == NGX_CONF_UNSET) {
@@ -132,33 +116,31 @@ ngx_rtmp_limit_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     }
 
     shm_zone = lmcf->shm_zone;
-    shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
-    nconn = shm_zone->data;
+    shpool   = (ngx_slab_pool_t *)shm_zone->shm.addr;
+    nconn    = shm_zone->data;
 
     ngx_shmtx_lock(&shpool->mutex);
     n = --*nconn;
     ngx_shmtx_unlock(&shpool->mutex);
 
-    (void) n;
+    (void)n;
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "limit: dec conection counter: %uD", n);
 
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_limit_shm_init(ngx_shm_zone_t *shm_zone, void *data)
+static ngx_int_t ngx_rtmp_limit_shm_init(ngx_shm_zone_t *shm_zone, void *data)
 {
-    ngx_slab_pool_t    *shpool;
-    uint32_t           *nconn;
+    ngx_slab_pool_t *shpool;
+    uint32_t *nconn;
 
     if (data) {
         shm_zone->data = data;
         return NGX_OK;
     }
 
-    shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+    shpool = (ngx_slab_pool_t *)shm_zone->shm.addr;
 
     nconn = ngx_slab_alloc(shpool, 4);
     if (nconn == NULL) {
@@ -172,20 +154,18 @@ ngx_rtmp_limit_shm_init(ngx_shm_zone_t *shm_zone, void *data)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_limit_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_limit_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_core_main_conf_t  *cmcf;
+    ngx_rtmp_core_main_conf_t *cmcf;
     ngx_rtmp_limit_main_conf_t *lmcf;
-    ngx_rtmp_handler_pt        *h;
+    ngx_rtmp_handler_pt *h;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_CONNECT]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_CONNECT]);
     *h = ngx_rtmp_limit_connect;
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
     *h = ngx_rtmp_limit_disconnect;
 
     lmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_limit_module);

--- a/ngx_rtmp_live_module.h
+++ b/ngx_rtmp_live_module.h
@@ -3,82 +3,73 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_LIVE_H_INCLUDED_
 #define _NGX_RTMP_LIVE_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
+#include "ngx_rtmp_bandwidth.h"
+#include "ngx_rtmp_cmd_module.h"
+#include "ngx_rtmp_streams.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-#include "ngx_rtmp_cmd_module.h"
-#include "ngx_rtmp_bandwidth.h"
-#include "ngx_rtmp_streams.h"
-
 
 typedef struct ngx_rtmp_live_ctx_s ngx_rtmp_live_ctx_t;
 typedef struct ngx_rtmp_live_stream_s ngx_rtmp_live_stream_t;
 
-
 typedef struct {
-    unsigned                            active:1;
-    uint32_t                            timestamp;
-    uint32_t                            csid;
-    uint32_t                            dropped;
+    unsigned active : 1;
+    uint32_t timestamp;
+    uint32_t csid;
+    uint32_t dropped;
 } ngx_rtmp_live_chunk_stream_t;
 
-
 struct ngx_rtmp_live_ctx_s {
-    ngx_rtmp_session_t                 *session;
-    ngx_rtmp_live_stream_t             *stream;
-    ngx_rtmp_live_ctx_t                *next;
-    ngx_uint_t                          ndropped;
-    ngx_rtmp_live_chunk_stream_t        cs[3];
-    ngx_uint_t                          meta_version;
-    ngx_event_t                         idle_evt;
-    unsigned                            active:1;
-    unsigned                            publishing:1;
-    unsigned                            silent:1;
-    unsigned                            paused:1;
+    ngx_rtmp_session_t *session;
+    ngx_rtmp_live_stream_t *stream;
+    ngx_rtmp_live_ctx_t *next;
+    ngx_uint_t ndropped;
+    ngx_rtmp_live_chunk_stream_t cs[3];
+    ngx_uint_t meta_version;
+    ngx_event_t idle_evt;
+    unsigned active : 1;
+    unsigned publishing : 1;
+    unsigned silent : 1;
+    unsigned paused : 1;
 };
-
 
 struct ngx_rtmp_live_stream_s {
-    u_char                              name[NGX_RTMP_MAX_NAME];
-    ngx_rtmp_live_stream_t             *next;
-    ngx_rtmp_live_ctx_t                *ctx;
-    ngx_rtmp_bandwidth_t                bw_in;
-    ngx_rtmp_bandwidth_t                bw_in_audio;
-    ngx_rtmp_bandwidth_t                bw_in_video;
-    ngx_rtmp_bandwidth_t                bw_in_data;
-    ngx_rtmp_bandwidth_t                bw_out;
-    ngx_msec_t                          epoch;
-    unsigned                            active:1;
-    unsigned                            publishing:1;
+    u_char name[NGX_RTMP_MAX_NAME];
+    ngx_rtmp_live_stream_t *next;
+    ngx_rtmp_live_ctx_t *ctx;
+    ngx_rtmp_bandwidth_t bw_in;
+    ngx_rtmp_bandwidth_t bw_in_audio;
+    ngx_rtmp_bandwidth_t bw_in_video;
+    ngx_rtmp_bandwidth_t bw_in_data;
+    ngx_rtmp_bandwidth_t bw_out;
+    ngx_msec_t epoch;
+    unsigned active : 1;
+    unsigned publishing : 1;
 };
 
-
 typedef struct {
-    ngx_int_t                           nbuckets;
-    ngx_rtmp_live_stream_t            **streams;
-    ngx_flag_t                          live;
-    ngx_flag_t                          meta;
-    ngx_msec_t                          sync;
-    ngx_msec_t                          idle_timeout;
-    ngx_flag_t                          atc;
-    ngx_flag_t                          interleave;
-    ngx_flag_t                          wait_key;
-    ngx_flag_t                          wait_video;
-    ngx_flag_t                          publish_notify;
-    ngx_flag_t                          play_restart;
-    ngx_flag_t                          idle_streams;
-    ngx_msec_t                          buflen;
-    ngx_pool_t                         *pool;
-    ngx_rtmp_live_stream_t             *free_streams;
+    ngx_int_t nbuckets;
+    ngx_rtmp_live_stream_t **streams;
+    ngx_flag_t live;
+    ngx_flag_t meta;
+    ngx_msec_t sync;
+    ngx_msec_t idle_timeout;
+    ngx_flag_t atc;
+    ngx_flag_t interleave;
+    ngx_flag_t wait_key;
+    ngx_flag_t wait_video;
+    ngx_flag_t publish_notify;
+    ngx_flag_t play_restart;
+    ngx_flag_t idle_streams;
+    ngx_msec_t buflen;
+    ngx_pool_t *pool;
+    ngx_rtmp_live_stream_t *free_streams;
 } ngx_rtmp_live_app_conf_t;
 
-
-extern ngx_module_t  ngx_rtmp_live_module;
-
+extern ngx_module_t ngx_rtmp_live_module;
 
 #endif /* _NGX_RTMP_LIVE_H_INCLUDED_ */

--- a/ngx_rtmp_netcall_module.c
+++ b/ngx_rtmp_netcall_module.c
@@ -3,16 +3,14 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp_netcall_module.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp_netcall_module.h"
-
 
 static ngx_int_t ngx_rtmp_netcall_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_netcall_create_srv_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_netcall_merge_srv_conf(ngx_conf_t *cf,
-       void *parent, void *child);
+static void *ngx_rtmp_netcall_create_srv_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_netcall_merge_srv_conf(ngx_conf_t *cf, void *parent,
+                                             void *child);
 
 static void ngx_rtmp_netcall_close(ngx_connection_t *cc);
 static void ngx_rtmp_netcall_detach(ngx_connection_t *cc);
@@ -20,89 +18,75 @@ static void ngx_rtmp_netcall_detach(ngx_connection_t *cc);
 static void ngx_rtmp_netcall_recv(ngx_event_t *rev);
 static void ngx_rtmp_netcall_send(ngx_event_t *wev);
 
-
 typedef struct {
-    ngx_msec_t                                  timeout;
-    size_t                                      bufsize;
-    ngx_log_t                                  *log;
+    ngx_msec_t timeout;
+    size_t bufsize;
+    ngx_log_t *log;
 } ngx_rtmp_netcall_srv_conf_t;
 
-
 typedef struct ngx_rtmp_netcall_session_s {
-    ngx_rtmp_session_t                         *session;
-    ngx_peer_connection_t                      *pc;
-    ngx_url_t                                  *url;
-    struct ngx_rtmp_netcall_session_s          *next;
-    void                                       *arg;
-    ngx_rtmp_netcall_handle_pt                  handle;
-    ngx_rtmp_netcall_filter_pt                  filter;
-    ngx_rtmp_netcall_sink_pt                    sink;
-    ngx_chain_t                                *in;
-    ngx_chain_t                                *inlast;
-    ngx_chain_t                                *out;
-    ngx_msec_t                                  timeout;
-    unsigned                                    detached:1;
-    size_t                                      bufsize;
+    ngx_rtmp_session_t *session;
+    ngx_peer_connection_t *pc;
+    ngx_url_t *url;
+    struct ngx_rtmp_netcall_session_s *next;
+    void *arg;
+    ngx_rtmp_netcall_handle_pt handle;
+    ngx_rtmp_netcall_filter_pt filter;
+    ngx_rtmp_netcall_sink_pt sink;
+    ngx_chain_t *in;
+    ngx_chain_t *inlast;
+    ngx_chain_t *out;
+    ngx_msec_t timeout;
+    unsigned detached : 1;
+    size_t bufsize;
 } ngx_rtmp_netcall_session_t;
 
-
 typedef struct {
-    ngx_rtmp_netcall_session_t                 *cs;
+    ngx_rtmp_netcall_session_t *cs;
 } ngx_rtmp_netcall_ctx_t;
 
+static ngx_command_t ngx_rtmp_netcall_commands[] = {
 
-static ngx_command_t  ngx_rtmp_netcall_commands[] = {
+    {ngx_string("netcall_timeout"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_SRV_CONF_OFFSET,
+     offsetof(ngx_rtmp_netcall_srv_conf_t, timeout), NULL},
 
-    { ngx_string("netcall_timeout"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_SRV_CONF_OFFSET,
-      offsetof(ngx_rtmp_netcall_srv_conf_t, timeout),
-      NULL },
+    {ngx_string("netcall_buffer"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_size_slot, NGX_RTMP_SRV_CONF_OFFSET,
+     offsetof(ngx_rtmp_netcall_srv_conf_t, bufsize), NULL},
 
-    { ngx_string("netcall_buffer"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_size_slot,
-      NGX_RTMP_SRV_CONF_OFFSET,
-      offsetof(ngx_rtmp_netcall_srv_conf_t, bufsize),
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_netcall_module_ctx = {
+    NULL,                               /* preconfiguration */
+    ngx_rtmp_netcall_postconfiguration, /* postconfiguration */
+    NULL,                               /* create main configuration */
+    NULL,                               /* init main configuration */
+    ngx_rtmp_netcall_create_srv_conf,   /* create server configuration */
+    ngx_rtmp_netcall_merge_srv_conf,    /* merge server configuration */
+    NULL,                               /* create app configuration */
+    NULL                                /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_netcall_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_netcall_postconfiguration,     /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    ngx_rtmp_netcall_create_srv_conf,       /* create server configuration */
-    ngx_rtmp_netcall_merge_srv_conf,        /* merge server configuration */
-    NULL,                                   /* create app configuration */
-    NULL                                    /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_netcall_module = {
+ngx_module_t ngx_rtmp_netcall_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_netcall_module_ctx,           /* module context */
-    ngx_rtmp_netcall_commands,              /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_netcall_module_ctx, /* module context */
+    ngx_rtmp_netcall_commands,    /* module directives */
+    NGX_RTMP_MODULE,              /* module type */
+    NULL,                         /* init master */
+    NULL,                         /* init module */
+    NULL,                         /* init process */
+    NULL,                         /* init thread */
+    NULL,                         /* exit thread */
+    NULL,                         /* exit process */
+    NULL,                         /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void *
-ngx_rtmp_netcall_create_srv_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_netcall_create_srv_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_netcall_srv_conf_t     *nscf;
+    ngx_rtmp_netcall_srv_conf_t *nscf;
 
     nscf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_netcall_srv_conf_t));
     if (nscf == NULL) {
@@ -117,9 +101,8 @@ ngx_rtmp_netcall_create_srv_conf(ngx_conf_t *cf)
     return nscf;
 }
 
-
-static char *
-ngx_rtmp_netcall_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_netcall_merge_srv_conf(ngx_conf_t *cf, void *parent,
+                                             void *child)
 {
     ngx_rtmp_netcall_srv_conf_t *prev = parent;
     ngx_rtmp_netcall_srv_conf_t *conf = child;
@@ -130,13 +113,12 @@ ngx_rtmp_netcall_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_netcall_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_netcall_disconnect(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_header_t *h,
+                                             ngx_chain_t *in)
 {
-    ngx_rtmp_netcall_ctx_t         *ctx;
-    ngx_rtmp_netcall_session_t     *cs;
+    ngx_rtmp_netcall_ctx_t *ctx;
+    ngx_rtmp_netcall_session_t *cs;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_netcall_module);
 
@@ -149,40 +131,36 @@ ngx_rtmp_netcall_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_netcall_get_peer(ngx_peer_connection_t *pc, void *data)
+static ngx_int_t ngx_rtmp_netcall_get_peer(ngx_peer_connection_t *pc,
+                                           void *data)
 {
-    ngx_rtmp_netcall_session_t   *cs = data;
+    ngx_rtmp_netcall_session_t *cs = data;
 
-    pc->sockaddr =(struct sockaddr *)&cs->url->sockaddr;
-    pc->socklen = cs->url->socklen;
-    pc->name = &cs->url->host;
+    pc->sockaddr = (struct sockaddr *)&cs->url->sockaddr;
+    pc->socklen  = cs->url->socklen;
+    pc->name     = &cs->url->host;
 
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_netcall_free_peer(ngx_peer_connection_t *pc, void *data,
-            ngx_uint_t state)
+static void ngx_rtmp_netcall_free_peer(ngx_peer_connection_t *pc, void *data,
+                                       ngx_uint_t state)
 {
 }
 
-
-ngx_int_t
-ngx_rtmp_netcall_create(ngx_rtmp_session_t *s, ngx_rtmp_netcall_init_t *ci)
+ngx_int_t ngx_rtmp_netcall_create(ngx_rtmp_session_t *s,
+                                  ngx_rtmp_netcall_init_t *ci)
 {
-    ngx_rtmp_netcall_ctx_t         *ctx;
-    ngx_peer_connection_t          *pc;
-    ngx_rtmp_netcall_session_t     *cs;
-    ngx_rtmp_netcall_srv_conf_t    *nscf;
-    ngx_connection_t               *c, *cc;
-    ngx_pool_t                     *pool;
-    ngx_int_t                       rc;
+    ngx_rtmp_netcall_ctx_t *ctx;
+    ngx_peer_connection_t *pc;
+    ngx_rtmp_netcall_session_t *cs;
+    ngx_rtmp_netcall_srv_conf_t *nscf;
+    ngx_connection_t *c, *cc;
+    ngx_pool_t *pool;
+    ngx_int_t rc;
 
     pool = NULL;
-    c = s->connection;
+    c    = s->connection;
 
     nscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_netcall_module);
     if (nscf == NULL) {
@@ -192,8 +170,7 @@ ngx_rtmp_netcall_create(ngx_rtmp_session_t *s, ngx_rtmp_netcall_init_t *ci)
     /* get module context */
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_netcall_module);
     if (ctx == NULL) {
-        ctx = ngx_pcalloc(c->pool,
-                sizeof(ngx_rtmp_netcall_ctx_t));
+        ctx = ngx_pcalloc(c->pool, sizeof(ngx_rtmp_netcall_ctx_t));
         if (ctx == NULL) {
             return NGX_ERROR;
         }
@@ -230,47 +207,47 @@ ngx_rtmp_netcall_create(ngx_rtmp_session_t *s, ngx_rtmp_netcall_init_t *ci)
 
     cs->timeout = nscf->timeout;
     cs->bufsize = nscf->bufsize;
-    cs->url = ci->url;
+    cs->url     = ci->url;
     cs->session = s;
-    cs->filter = ci->filter;
-    cs->sink = ci->sink;
-    cs->handle = ci->handle;
+    cs->filter  = ci->filter;
+    cs->sink    = ci->sink;
+    cs->handle  = ci->handle;
     if (cs->handle == NULL) {
         cs->detached = 1;
     }
 
-    pc->log = nscf->log;
-    pc->get = ngx_rtmp_netcall_get_peer;
+    pc->log  = nscf->log;
+    pc->get  = ngx_rtmp_netcall_get_peer;
     pc->free = ngx_rtmp_netcall_free_peer;
     pc->data = cs;
 
     /* connect */
     rc = ngx_event_connect_peer(pc);
-    if (rc != NGX_OK && rc != NGX_AGAIN ) {
+    if (rc != NGX_OK && rc != NGX_AGAIN) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "netcall: connection failed");
+                       "netcall: connection failed");
         goto error;
     }
 
-    cc = pc->connection;
+    cc       = pc->connection;
     cc->data = cs;
     cc->pool = pool;
-    cs->pc = pc;
+    cs->pc   = pc;
 
     cs->out = ci->create(s, ci->arg, pool);
     if (cs->out == NULL) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "netcall: creation failed");
+                       "netcall: creation failed");
         ngx_close_connection(pc->connection);
         goto error;
     }
 
     cc->write->handler = ngx_rtmp_netcall_send;
-    cc->read->handler = ngx_rtmp_netcall_recv;
+    cc->read->handler  = ngx_rtmp_netcall_recv;
 
     if (!cs->detached) {
         cs->next = ctx->cs;
-        ctx->cs = cs;
+        ctx->cs  = cs;
     }
 
     ngx_rtmp_netcall_send(cc->write);
@@ -285,15 +262,13 @@ error:
     return NGX_ERROR;
 }
 
-
-static void
-ngx_rtmp_netcall_close(ngx_connection_t *cc)
+static void ngx_rtmp_netcall_close(ngx_connection_t *cc)
 {
-    ngx_rtmp_netcall_session_t         *cs, **css;
-    ngx_pool_t                         *pool;
-    ngx_rtmp_session_t                 *s;
-    ngx_rtmp_netcall_ctx_t             *ctx;
-    ngx_buf_t                          *b;
+    ngx_rtmp_netcall_session_t *cs, **css;
+    ngx_pool_t *pool;
+    ngx_rtmp_session_t *s;
+    ngx_rtmp_netcall_ctx_t *ctx;
+    ngx_buf_t *b;
 
     cs = cc->data;
 
@@ -304,18 +279,17 @@ ngx_rtmp_netcall_close(ngx_connection_t *cc)
     cc->destroyed = 1;
 
     if (!cs->detached) {
-        s = cs->session;
+        s   = cs->session;
         ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_netcall_module);
 
         if (cs->in && cs->sink) {
             cs->sink(cs->session, cs->in);
 
-            b = cs->in->buf;
+            b      = cs->in->buf;
             b->pos = b->last = b->start;
-
         }
 
-        for(css = &ctx->cs; *css; css = &((*css)->next)) {
+        for (css = &ctx->cs; *css; css = &((*css)->next)) {
             if (*css == cs) {
                 *css = cs->next;
                 break;
@@ -332,25 +306,21 @@ ngx_rtmp_netcall_close(ngx_connection_t *cc)
     ngx_destroy_pool(pool);
 }
 
-
-static void
-ngx_rtmp_netcall_detach(ngx_connection_t *cc)
+static void ngx_rtmp_netcall_detach(ngx_connection_t *cc)
 {
-    ngx_rtmp_netcall_session_t         *cs;
+    ngx_rtmp_netcall_session_t *cs;
 
-    cs = cc->data;
+    cs           = cc->data;
     cs->detached = 1;
 }
 
-
-static void
-ngx_rtmp_netcall_recv(ngx_event_t *rev)
+static void ngx_rtmp_netcall_recv(ngx_event_t *rev)
 {
-    ngx_rtmp_netcall_session_t         *cs;
-    ngx_connection_t                   *cc;
-    ngx_chain_t                        *cl;
-    ngx_int_t                           n;
-    ngx_buf_t                          *b;
+    ngx_rtmp_netcall_session_t *cs;
+    ngx_connection_t *cc;
+    ngx_chain_t *cl;
+    ngx_int_t n;
+    ngx_buf_t *b;
 
     cc = rev->data;
     cs = cc->data;
@@ -369,11 +339,9 @@ ngx_rtmp_netcall_recv(ngx_event_t *rev)
         ngx_del_timer(rev);
     }
 
-    for ( ;; ) {
-
+    for (;;) {
         if (cs->inlast == NULL ||
-            cs->inlast->buf->last == cs->inlast->buf->end)
-        {
+            cs->inlast->buf->last == cs->inlast->buf->end) {
             if (cs->in && cs->sink) {
                 if (!cs->detached) {
                     if (cs->sink(cs->session, cs->in) != NGX_OK) {
@@ -382,7 +350,7 @@ ngx_rtmp_netcall_recv(ngx_event_t *rev)
                     }
                 }
 
-                b = cs->in->buf;
+                b      = cs->in->buf;
                 b->pos = b->last = b->start;
 
             } else {
@@ -420,9 +388,7 @@ ngx_rtmp_netcall_recv(ngx_event_t *rev)
         }
 
         if (n == NGX_AGAIN) {
-            if (cs->filter && cs->in
-                && cs->filter(cs->in) != NGX_AGAIN)
-            {
+            if (cs->filter && cs->in && cs->filter(cs->in) != NGX_AGAIN) {
                 ngx_rtmp_netcall_close(cc);
                 return;
             }
@@ -438,13 +404,11 @@ ngx_rtmp_netcall_recv(ngx_event_t *rev)
     }
 }
 
-
-static void
-ngx_rtmp_netcall_send(ngx_event_t *wev)
+static void ngx_rtmp_netcall_send(ngx_event_t *wev)
 {
-    ngx_rtmp_netcall_session_t         *cs;
-    ngx_connection_t                   *cc;
-    ngx_chain_t                        *cl;
+    ngx_rtmp_netcall_session_t *cs;
+    ngx_connection_t *cc;
+    ngx_chain_t *cl;
 
     cc = wev->data;
     cs = cc->data;
@@ -455,7 +419,7 @@ ngx_rtmp_netcall_send(ngx_event_t *wev)
 
     if (wev->timedout) {
         ngx_log_error(NGX_LOG_INFO, cc->log, NGX_ETIMEDOUT,
-                "netcall: client send timed out");
+                      "netcall: client send timed out");
         cc->timedout = 1;
         ngx_rtmp_netcall_close(cc);
         return;
@@ -490,23 +454,20 @@ ngx_rtmp_netcall_send(ngx_event_t *wev)
     ngx_rtmp_netcall_recv(cc->read);
 }
 
-
-ngx_chain_t *
-ngx_rtmp_netcall_http_format_request(ngx_int_t method, ngx_str_t *host,
-                                     ngx_str_t *uri, ngx_chain_t *args,
-                                     ngx_chain_t *body, ngx_pool_t *pool,
-                                     ngx_str_t *content_type)
+ngx_chain_t *ngx_rtmp_netcall_http_format_request(
+    ngx_int_t method, ngx_str_t *host, ngx_str_t *uri, ngx_chain_t *args,
+    ngx_chain_t *body, ngx_pool_t *pool, ngx_str_t *content_type)
 {
-    ngx_chain_t                    *al, *bl, *ret;
-    ngx_buf_t                      *b;
-    size_t                          content_length;
-    static const char              *methods[2] = { "GET", "POST" };
-    static const char               rq_tmpl[] = " HTTP/1.0\r\n"
-                                                "Host: %V\r\n"
-                                                "Content-Type: %V\r\n"
-                                                "Connection: Close\r\n"
-                                                "Content-Length: %uz\r\n"
-                                                "\r\n";
+    ngx_chain_t *al, *bl, *ret;
+    ngx_buf_t *b;
+    size_t content_length;
+    static const char *methods[2] = {"GET", "POST"};
+    static const char rq_tmpl[]   = " HTTP/1.0\r\n"
+                                  "Host: %V\r\n"
+                                  "Content-Type: %V\r\n"
+                                  "Connection: Close\r\n"
+                                  "Content-Length: %uz\r\n"
+                                  "\r\n";
 
     content_length = 0;
     for (al = body; al; al = al->next) {
@@ -522,13 +483,13 @@ ngx_rtmp_netcall_http_format_request(ngx_int_t method, ngx_str_t *host,
     }
 
     b = ngx_create_temp_buf(pool, sizeof("POST") + /* longest method + 1 */
-                                  uri->len);
+                                      uri->len);
     if (b == NULL) {
         return NULL;
     }
 
-    b->last = ngx_snprintf(b->last, b->end - b->last, "%s %V",
-                           methods[method], uri);
+    b->last =
+        ngx_snprintf(b->last, b->end - b->last, "%s %V", methods[method], uri);
 
     al->buf = b;
 
@@ -536,8 +497,9 @@ ngx_rtmp_netcall_http_format_request(ngx_int_t method, ngx_str_t *host,
 
     if (args) {
         *b->last++ = '?';
-        al->next = args;
-        for (al = args; al->next; al = al->next);
+        al->next   = args;
+        for (al = args; al->next; al = al->next)
+            ;
     }
 
     /* create second buffer */
@@ -548,15 +510,15 @@ ngx_rtmp_netcall_http_format_request(ngx_int_t method, ngx_str_t *host,
     }
 
     b = ngx_create_temp_buf(pool, sizeof(rq_tmpl) + host->len +
-                            content_type->len + NGX_SIZE_T_LEN);
+                                      content_type->len + NGX_SIZE_T_LEN);
     if (b == NULL) {
         return NULL;
     }
 
     bl->buf = b;
 
-    b->last = ngx_snprintf(b->last, b->end - b->last, rq_tmpl,
-                           host, content_type, content_length);
+    b->last = ngx_snprintf(b->last, b->end - b->last, rq_tmpl, host,
+                           content_type, content_length);
 
     al->next = bl;
     bl->next = body;
@@ -564,14 +526,13 @@ ngx_rtmp_netcall_http_format_request(ngx_int_t method, ngx_str_t *host,
     return ret;
 }
 
-
-ngx_chain_t *
-ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
+ngx_chain_t *ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s,
+                                                  ngx_pool_t *pool)
 {
-    ngx_chain_t                    *cl;
-    ngx_buf_t                      *b;
-    ngx_str_t                      *addr_text;
-    size_t                          bsize;
+    ngx_chain_t *cl;
+    ngx_buf_t *b;
+    ngx_str_t *addr_text;
+    size_t bsize;
 
     addr_text = &s->connection->addr_text;
 
@@ -586,8 +547,8 @@ ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
      * So not override them with empty values
      */
 
-    bsize = sizeof("&addr=") - 1 + addr_text->len * 3 +
-            sizeof("&clientid=") - 1 + NGX_INT_T_LEN;
+    bsize = sizeof("&addr=") - 1 + addr_text->len * 3 + sizeof("&clientid=") -
+            1 + NGX_INT_T_LEN;
 
     if (s->app.len) {
         bsize += sizeof("app=") - 1 + s->app.len * 3;
@@ -610,62 +571,56 @@ ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
         return NULL;
     }
 
-    cl->buf = b;
+    cl->buf  = b;
     cl->next = NULL;
 
     if (s->app.len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "app=", sizeof("app=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, s->app.data, s->app.len,
+        b->last = ngx_cpymem(b->last, (u_char *)"app=", sizeof("app=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, s->app.data, s->app.len,
                                            NGX_ESCAPE_ARGS);
     }
     if (s->flashver.len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&flashver=",
+        b->last = ngx_cpymem(b->last, (u_char *)"&flashver=",
                              sizeof("&flashver=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, s->flashver.data,
+        b->last = (u_char *)ngx_escape_uri(b->last, s->flashver.data,
                                            s->flashver.len, NGX_ESCAPE_ARGS);
     }
     if (s->swf_url.len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&swfurl=",
-                             sizeof("&swfurl=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, s->swf_url.data,
+        b->last =
+            ngx_cpymem(b->last, (u_char *)"&swfurl=", sizeof("&swfurl=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, s->swf_url.data,
                                            s->swf_url.len, NGX_ESCAPE_ARGS);
     }
     if (s->tc_url.len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&tcurl=",
-                             sizeof("&tcurl=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, s->tc_url.data,
+        b->last =
+            ngx_cpymem(b->last, (u_char *)"&tcurl=", sizeof("&tcurl=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, s->tc_url.data,
                                            s->tc_url.len, NGX_ESCAPE_ARGS);
     }
     if (s->page_url.len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&pageurl=",
-                             sizeof("&pageurl=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, s->page_url.data,
+        b->last =
+            ngx_cpymem(b->last, (u_char *)"&pageurl=", sizeof("&pageurl=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, s->page_url.data,
                                            s->page_url.len, NGX_ESCAPE_ARGS);
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&addr=", sizeof("&addr=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, addr_text->data,
-                                       addr_text->len, NGX_ESCAPE_ARGS);
+    b->last = ngx_cpymem(b->last, (u_char *)"&addr=", sizeof("&addr=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, addr_text->data, addr_text->len,
+                                       NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&clientid=",
-                         sizeof("&clientid=") - 1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->connection->number);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&clientid=", sizeof("&clientid=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->connection->number);
 
     return cl;
 }
 
-
-ngx_chain_t *
-ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in)
+ngx_chain_t *ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in)
 {
-    ngx_buf_t       *b;
+    ngx_buf_t *b;
 
     /* find \n[\r]\n */
-    enum {
-        normal,
-        lf,
-        lfcr
-    } state = normal;
+    enum { normal, lf, lfcr } state = normal;
 
     if (in == NULL) {
         return NULL;
@@ -673,8 +628,7 @@ ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in)
 
     b = in->buf;
 
-    for ( ;; ) {
-
+    for (;;) {
         while (b->pos == b->last) {
             in = in->next;
             if (in == NULL) {
@@ -684,30 +638,30 @@ ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in)
         }
 
         switch (*b->pos++) {
-            case '\r':
-                state = (state == lf) ? lfcr : normal;
-                break;
+        case '\r':
+            state = (state == lf) ? lfcr : normal;
+            break;
 
-            case '\n':
-                if (state != normal) {
-                    return in;
-                }
-                state = lf;
-                break;
+        case '\n':
+            if (state != normal) {
+                return in;
+            }
+            state = lf;
+            break;
 
-           default:
-                state = normal;
+        default:
+            state = normal;
         }
     }
 }
 
-
-ngx_chain_t *
-ngx_rtmp_netcall_memcache_set(ngx_rtmp_session_t *s, ngx_pool_t *pool,
-        ngx_str_t *key, ngx_str_t *value, ngx_uint_t flags, ngx_uint_t sec)
+ngx_chain_t *ngx_rtmp_netcall_memcache_set(ngx_rtmp_session_t *s,
+                                           ngx_pool_t *pool, ngx_str_t *key,
+                                           ngx_str_t *value, ngx_uint_t flags,
+                                           ngx_uint_t sec)
 {
-    ngx_chain_t                    *cl;
-    ngx_buf_t                      *b;
+    ngx_chain_t *cl;
+    ngx_buf_t *b;
 
     cl = ngx_alloc_chain_link(pool);
     if (cl == NULL) {
@@ -715,34 +669,31 @@ ngx_rtmp_netcall_memcache_set(ngx_rtmp_session_t *s, ngx_pool_t *pool,
     }
 
     b = ngx_create_temp_buf(pool, sizeof("set ") - 1 + key->len +
-                            (1 + NGX_INT_T_LEN) * 3 +
-                            (sizeof("\r\n") - 1) * 2 + value->len);
+                                      (1 + NGX_INT_T_LEN) * 3 +
+                                      (sizeof("\r\n") - 1) * 2 + value->len);
 
     if (b == NULL) {
         return NULL;
     }
 
     cl->next = NULL;
-    cl->buf = b;
+    cl->buf  = b;
 
-    b->last = ngx_sprintf(b->pos, "set %V %ui %ui %ui\r\n%V\r\n",
-                          key, flags, sec, (ngx_uint_t) value->len, value);
+    b->last = ngx_sprintf(b->pos, "set %V %ui %ui %ui\r\n%V\r\n", key, flags,
+                          sec, (ngx_uint_t)value->len, value);
 
     return cl;
 }
 
-
-static ngx_int_t
-ngx_rtmp_netcall_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_netcall_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_core_main_conf_t          *cmcf;
-    ngx_rtmp_handler_pt                *h;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_rtmp_handler_pt *h;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_DISCONNECT]);
     *h = ngx_rtmp_netcall_disconnect;
 
     return NGX_OK;
 }
-

--- a/ngx_rtmp_netcall_module.h
+++ b/ngx_rtmp_netcall_module.h
@@ -3,27 +3,23 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_NETCALL_H_INCLUDED_
 #define _NGX_RTMP_NETCALL_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
 
-
-typedef ngx_chain_t * (*ngx_rtmp_netcall_create_pt)(ngx_rtmp_session_t *s,
-        void *arg, ngx_pool_t *pool);
+typedef ngx_chain_t *(*ngx_rtmp_netcall_create_pt)(ngx_rtmp_session_t *s,
+                                                   void *arg, ngx_pool_t *pool);
 typedef ngx_int_t (*ngx_rtmp_netcall_filter_pt)(ngx_chain_t *in);
 typedef ngx_int_t (*ngx_rtmp_netcall_sink_pt)(ngx_rtmp_session_t *s,
-        ngx_chain_t *in);
+                                              ngx_chain_t *in);
 typedef ngx_int_t (*ngx_rtmp_netcall_handle_pt)(ngx_rtmp_session_t *s,
-        void *arg, ngx_chain_t *in);
+                                                void *arg, ngx_chain_t *in);
 
-#define NGX_RTMP_NETCALL_HTTP_GET   0
-#define NGX_RTMP_NETCALL_HTTP_POST  1
-
+#define NGX_RTMP_NETCALL_HTTP_GET 0
+#define NGX_RTMP_NETCALL_HTTP_POST 1
 
 /* If handle is NULL then netcall is created detached
  * which means it's completely independent of RTMP
@@ -35,33 +31,30 @@ typedef ngx_int_t (*ngx_rtmp_netcall_handle_pt)(ngx_rtmp_session_t *s,
  * BEFORE your handler. It leads to a crash
  * after netcall connection is closed */
 typedef struct {
-    ngx_url_t                      *url;
-    ngx_rtmp_netcall_create_pt      create;
-    ngx_rtmp_netcall_filter_pt      filter;
-    ngx_rtmp_netcall_sink_pt        sink;
-    ngx_rtmp_netcall_handle_pt      handle;
-    void                           *arg;
-    size_t                          argsize;
+    ngx_url_t *url;
+    ngx_rtmp_netcall_create_pt create;
+    ngx_rtmp_netcall_filter_pt filter;
+    ngx_rtmp_netcall_sink_pt sink;
+    ngx_rtmp_netcall_handle_pt handle;
+    void *arg;
+    size_t argsize;
 } ngx_rtmp_netcall_init_t;
 
-
 ngx_int_t ngx_rtmp_netcall_create(ngx_rtmp_session_t *s,
-        ngx_rtmp_netcall_init_t *ci);
-
+                                  ngx_rtmp_netcall_init_t *ci);
 
 /* HTTP handling */
-ngx_chain_t * ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s,
-        ngx_pool_t *pool);
-ngx_chain_t * ngx_rtmp_netcall_http_format_request(ngx_int_t method,
-        ngx_str_t *host, ngx_str_t *uri, ngx_chain_t *args, ngx_chain_t *body,
-        ngx_pool_t *pool, ngx_str_t *content_type);
-ngx_chain_t * ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in);
-
+ngx_chain_t *ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s,
+                                                  ngx_pool_t *pool);
+ngx_chain_t *ngx_rtmp_netcall_http_format_request(
+    ngx_int_t method, ngx_str_t *host, ngx_str_t *uri, ngx_chain_t *args,
+    ngx_chain_t *body, ngx_pool_t *pool, ngx_str_t *content_type);
+ngx_chain_t *ngx_rtmp_netcall_http_skip_header(ngx_chain_t *in);
 
 /* Memcache handling */
-ngx_chain_t * ngx_rtmp_netcall_memcache_set(ngx_rtmp_session_t *s,
-        ngx_pool_t *pool, ngx_str_t *key, ngx_str_t *value,
-        ngx_uint_t flags, ngx_uint_t sec);
-
+ngx_chain_t *ngx_rtmp_netcall_memcache_set(ngx_rtmp_session_t *s,
+                                           ngx_pool_t *pool, ngx_str_t *key,
+                                           ngx_str_t *value, ngx_uint_t flags,
+                                           ngx_uint_t sec);
 
 #endif /* _NGX_RTMP_NETCALL_H_INCLUDED_ */

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -3,52 +3,46 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
-#include <ngx_md5.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_cmd_module.h"
 #include "ngx_rtmp_netcall_module.h"
 #include "ngx_rtmp_record_module.h"
 #include "ngx_rtmp_relay_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_md5.h>
 
-
-static ngx_rtmp_connect_pt                      next_connect;
-static ngx_rtmp_disconnect_pt                   next_disconnect;
-static ngx_rtmp_publish_pt                      next_publish;
-static ngx_rtmp_play_pt                         next_play;
-static ngx_rtmp_close_stream_pt                 next_close_stream;
-static ngx_rtmp_record_done_pt                  next_record_done;
-static ngx_rtmp_playlist_pt                     next_playlist;
-
+static ngx_rtmp_connect_pt next_connect;
+static ngx_rtmp_disconnect_pt next_disconnect;
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_play_pt next_play;
+static ngx_rtmp_close_stream_pt next_close_stream;
+static ngx_rtmp_record_done_pt next_record_done;
+static ngx_rtmp_playlist_pt next_playlist;
 
 static char *ngx_rtmp_notify_on_srv_event(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+                                          void *conf);
 static char *ngx_rtmp_notify_on_app_event(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+                                          void *conf);
 static char *ngx_rtmp_notify_method(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+                                    void *conf);
 static char *ngx_rtmp_notify_send_redirect(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+                                           void *conf);
 static ngx_int_t ngx_rtmp_notify_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_notify_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_notify_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
+static void *ngx_rtmp_notify_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_notify_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                            void *child);
 static void *ngx_rtmp_notify_create_srv_conf(ngx_conf_t *cf);
 static char *ngx_rtmp_notify_merge_srv_conf(ngx_conf_t *cf, void *parent,
-       void *child);
+                                            void *child);
 static ngx_int_t ngx_rtmp_notify_done(ngx_rtmp_session_t *s, char *cbname,
-       ngx_uint_t url_idx);
+                                      ngx_uint_t url_idx);
 
+ngx_str_t ngx_rtmp_notify_urlencoded =
+    ngx_string("application/x-www-form-urlencoded");
 
-ngx_str_t   ngx_rtmp_notify_urlencoded =
-            ngx_string("application/x-www-form-urlencoded");
-
-
-#define NGX_RTMP_NOTIFY_PUBLISHING              0x01
-#define NGX_RTMP_NOTIFY_PLAYING                 0x02
-
+#define NGX_RTMP_NOTIFY_PUBLISHING 0x01
+#define NGX_RTMP_NOTIFY_PLAYING 0x02
 
 enum {
     NGX_RTMP_NOTIFY_PLAY,
@@ -62,192 +56,142 @@ enum {
     NGX_RTMP_NOTIFY_APP_MAX
 };
 
-
 enum {
     NGX_RTMP_NOTIFY_CONNECT,
     NGX_RTMP_NOTIFY_DISCONNECT,
     NGX_RTMP_NOTIFY_SRV_MAX
 };
 
-
 typedef struct {
-    ngx_url_t                                  *url[NGX_RTMP_NOTIFY_APP_MAX];
-    ngx_flag_t                                  active;
-    ngx_uint_t                                  method;
-    ngx_flag_t                                  send_redirect;
-    ngx_msec_t                                  update_timeout;
-    ngx_flag_t                                  update_strict;
-    ngx_flag_t                                  relay_redirect;
+    ngx_url_t *url[NGX_RTMP_NOTIFY_APP_MAX];
+    ngx_flag_t active;
+    ngx_uint_t method;
+    ngx_flag_t send_redirect;
+    ngx_msec_t update_timeout;
+    ngx_flag_t update_strict;
+    ngx_flag_t relay_redirect;
 } ngx_rtmp_notify_app_conf_t;
 
-
 typedef struct {
-    ngx_url_t                                  *url[NGX_RTMP_NOTIFY_SRV_MAX];
-    ngx_uint_t                                  method;
-    ngx_flag_t                                  send_redirect;
+    ngx_url_t *url[NGX_RTMP_NOTIFY_SRV_MAX];
+    ngx_uint_t method;
+    ngx_flag_t send_redirect;
 } ngx_rtmp_notify_srv_conf_t;
 
-
 typedef struct {
-    ngx_uint_t                                  flags;
-    u_char                                      name[NGX_RTMP_MAX_NAME];
-    u_char                                      args[NGX_RTMP_MAX_ARGS];
-    ngx_event_t                                 update_evt;
-    time_t                                      start;
+    ngx_uint_t flags;
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
+    ngx_event_t update_evt;
+    time_t start;
 } ngx_rtmp_notify_ctx_t;
 
-
 typedef struct {
-    u_char                                     *cbname;
-    ngx_uint_t                                  url_idx;
+    u_char *cbname;
+    ngx_uint_t url_idx;
 } ngx_rtmp_notify_done_t;
 
+static ngx_command_t ngx_rtmp_notify_commands[] = {
 
-static ngx_command_t  ngx_rtmp_notify_commands[] = {
+    {ngx_string("on_connect"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_srv_event, NGX_RTMP_SRV_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_connect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_srv_event,
-      NGX_RTMP_SRV_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_disconnect"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_srv_event, NGX_RTMP_SRV_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_disconnect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_srv_event,
-      NGX_RTMP_SRV_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_publish"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                   NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_publish"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_play"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_play"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_publish_done"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                        NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_publish_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_play_done"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                     NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_play_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_done"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_record_done"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_RTMP_REC_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_record_done"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_RTMP_REC_CONF|
-                         NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_update"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                  NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_update"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("on_playlist"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                    NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_on_app_event, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("on_playlist"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_on_app_event,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("notify_method"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                      NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_rtmp_notify_method, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("notify_method"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_method,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("notify_update_timeout"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_notify_app_conf_t, update_timeout), NULL},
 
-    { ngx_string("notify_update_timeout"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_notify_app_conf_t, update_timeout),
-      NULL },
+    {ngx_string("notify_update_strict"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_notify_app_conf_t, update_strict), NULL},
 
-    { ngx_string("notify_update_strict"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_notify_app_conf_t, update_strict),
-      NULL },
+    {ngx_string("notify_relay_redirect"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_notify_app_conf_t, relay_redirect), NULL},
 
-    { ngx_string("notify_relay_redirect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_notify_app_conf_t, relay_redirect),
-      NULL },
+    {ngx_string("notify_send_redirect"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_RTMP_APP_CONF |
+         NGX_CONF_TAKE1,
+     ngx_rtmp_notify_send_redirect, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("notify_send_redirect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_rtmp_notify_send_redirect,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    ngx_null_command};
 
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_notify_module_ctx = {
+    NULL,                              /* preconfiguration */
+    ngx_rtmp_notify_postconfiguration, /* postconfiguration */
+    NULL,                              /* create main configuration */
+    NULL,                              /* init main configuration */
+    ngx_rtmp_notify_create_srv_conf,   /* create server configuration */
+    ngx_rtmp_notify_merge_srv_conf,    /* merge server configuration */
+    ngx_rtmp_notify_create_app_conf,   /* create app configuration */
+    ngx_rtmp_notify_merge_app_conf     /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_notify_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_notify_postconfiguration,      /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    ngx_rtmp_notify_create_srv_conf,        /* create server configuration */
-    ngx_rtmp_notify_merge_srv_conf,         /* merge server configuration */
-    ngx_rtmp_notify_create_app_conf,        /* create app configuration */
-    ngx_rtmp_notify_merge_app_conf          /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_notify_module = {
+ngx_module_t ngx_rtmp_notify_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_notify_module_ctx,            /* module context */
-    ngx_rtmp_notify_commands,               /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    NULL,                                   /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_notify_module_ctx, /* module context */
+    ngx_rtmp_notify_commands,    /* module directives */
+    NGX_RTMP_MODULE,             /* module type */
+    NULL,                        /* init master */
+    NULL,                        /* init module */
+    NULL,                        /* init process */
+    NULL,                        /* init thread */
+    NULL,                        /* exit thread */
+    NULL,                        /* exit process */
+    NULL,                        /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void *
-ngx_rtmp_notify_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_notify_create_app_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_notify_app_conf_t     *nacf;
-    ngx_uint_t                      n;
+    ngx_rtmp_notify_app_conf_t *nacf;
+    ngx_uint_t n;
 
     nacf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_notify_app_conf_t));
     if (nacf == NULL) {
@@ -258,22 +202,21 @@ ngx_rtmp_notify_create_app_conf(ngx_conf_t *cf)
         nacf->url[n] = NGX_CONF_UNSET_PTR;
     }
 
-    nacf->method = NGX_CONF_UNSET_UINT;
-    nacf->send_redirect = NGX_CONF_UNSET;
+    nacf->method         = NGX_CONF_UNSET_UINT;
+    nacf->send_redirect  = NGX_CONF_UNSET;
     nacf->update_timeout = NGX_CONF_UNSET_MSEC;
-    nacf->update_strict = NGX_CONF_UNSET;
+    nacf->update_strict  = NGX_CONF_UNSET;
     nacf->relay_redirect = NGX_CONF_UNSET;
 
     return nacf;
 }
 
-
-static char *
-ngx_rtmp_notify_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_notify_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                            void *child)
 {
     ngx_rtmp_notify_app_conf_t *prev = parent;
     ngx_rtmp_notify_app_conf_t *conf = child;
-    ngx_uint_t                  n;
+    ngx_uint_t n;
 
     for (n = 0; n < NGX_RTMP_NOTIFY_APP_MAX; ++n) {
         ngx_conf_merge_ptr_value(conf->url[n], prev->url[n], NULL);
@@ -297,12 +240,10 @@ ngx_rtmp_notify_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static void *
-ngx_rtmp_notify_create_srv_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_notify_create_srv_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_notify_srv_conf_t     *nscf;
-    ngx_uint_t                      n;
+    ngx_rtmp_notify_srv_conf_t *nscf;
+    ngx_uint_t n;
 
     nscf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_notify_srv_conf_t));
     if (nscf == NULL) {
@@ -313,19 +254,18 @@ ngx_rtmp_notify_create_srv_conf(ngx_conf_t *cf)
         nscf->url[n] = NGX_CONF_UNSET_PTR;
     }
 
-    nscf->method = NGX_CONF_UNSET_UINT;
+    nscf->method        = NGX_CONF_UNSET_UINT;
     nscf->send_redirect = NGX_CONF_UNSET;
 
     return nscf;
 }
 
-
-static char *
-ngx_rtmp_notify_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_notify_merge_srv_conf(ngx_conf_t *cf, void *parent,
+                                            void *child)
 {
     ngx_rtmp_notify_srv_conf_t *prev = parent;
     ngx_rtmp_notify_srv_conf_t *conf = child;
-    ngx_uint_t                  n;
+    ngx_uint_t n;
 
     for (n = 0; n < NGX_RTMP_NOTIFY_SRV_MAX; ++n) {
         ngx_conf_merge_ptr_value(conf->url[n], prev->url[n], NULL);
@@ -338,24 +278,24 @@ ngx_rtmp_notify_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_create_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
-                                   ngx_uint_t url_idx, ngx_chain_t *args)
+static ngx_chain_t *ngx_rtmp_notify_create_request(ngx_rtmp_session_t *s,
+                                                   ngx_pool_t *pool,
+                                                   ngx_uint_t url_idx,
+                                                   ngx_chain_t *args)
 {
     ngx_rtmp_notify_app_conf_t *nacf;
-    ngx_chain_t                *al, *bl, *cl;
-    ngx_url_t                  *url;
+    ngx_chain_t *al, *bl, *cl;
+    ngx_url_t *url;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create request: begin");
+                   "notify: create request: begin");
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
 
     url = nacf->url[url_idx];
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create request: netcall format session");
+                   "notify: create request: netcall format session");
 
     al = ngx_rtmp_netcall_http_format_session(s, pool);
     if (al == NULL) {
@@ -369,11 +309,11 @@ ngx_rtmp_notify_create_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
     // In args first symbol IS NOT '&', but LAST ONE
     if (args) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "notify: create request: swap formated args");
+                       "notify: create request: swap formated args");
 
-        cl = args;
+        cl   = args;
         args = al;
-        al = cl;
+        al   = cl;
     }
 
     al->next = args;
@@ -387,31 +327,31 @@ ngx_rtmp_notify_create_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create request: netcall format request");
+                   "notify: create request: netcall format request");
 
     return ngx_rtmp_netcall_http_format_request(nacf->method, &url->host,
                                                 &url->uri, al, bl, pool,
                                                 &ngx_rtmp_notify_urlencoded);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_create_srv_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
-                                   ngx_uint_t url_idx, ngx_chain_t *args)
+static ngx_chain_t *ngx_rtmp_notify_create_srv_request(ngx_rtmp_session_t *s,
+                                                       ngx_pool_t *pool,
+                                                       ngx_uint_t url_idx,
+                                                       ngx_chain_t *args)
 {
     ngx_rtmp_notify_srv_conf_t *nscf;
-    ngx_chain_t                *al, *bl, *cl;
-    ngx_url_t                  *url;
+    ngx_chain_t *al, *bl, *cl;
+    ngx_url_t *url;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create srv request: begin");
+                   "notify: create srv request: begin");
 
     nscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_notify_module);
 
     url = nscf->url[url_idx];
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create srv request: netcall format session");
+                   "notify: create srv request: netcall format session");
 
     al = ngx_rtmp_netcall_http_format_session(s, pool);
     if (al == NULL) {
@@ -425,11 +365,11 @@ ngx_rtmp_notify_create_srv_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
     // In args first symbol IS NOT '&', but LAST ONE
     if (args) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "notify: create srv request: swap formated args");
+                       "notify: create srv request: swap formated args");
 
-        cl = args;
+        cl   = args;
         args = al;
-        al = cl;
+        al   = cl;
     }
 
     al->next = args;
@@ -443,24 +383,22 @@ ngx_rtmp_notify_create_srv_request(ngx_rtmp_session_t *s, ngx_pool_t *pool,
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: create srv request: netcall format request");
+                   "notify: create srv request: netcall format request");
 
     return ngx_rtmp_netcall_http_format_request(nscf->method, &url->host,
                                                 &url->uri, al, bl, pool,
                                                 &ngx_rtmp_notify_urlencoded);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s,
+                                                   void *arg, ngx_pool_t *pool)
 {
-    ngx_rtmp_connect_t             *v = arg;
+    ngx_rtmp_connect_t *v = arg;
 
-    ngx_chain_t                    *al;
-    ngx_buf_t                      *b;
-    size_t                          app_len, args_len, flashver_len,
-                                    swf_url_len, tc_url_len, page_url_len;
+    ngx_chain_t *al;
+    ngx_buf_t *b;
+    size_t app_len, args_len, flashver_len, swf_url_len, tc_url_len,
+        page_url_len;
 
     al = ngx_alloc_chain_link(pool);
     if (al == NULL) {
@@ -468,132 +406,127 @@ ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s, void *arg,
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "notify: connect: begin");
+                   "notify: connect: begin");
 
     /* these values are still missing in session
      * so we have to construct the request from
      * connection struct */
 
-    app_len = ngx_strlen(v->app);
-    args_len = ngx_strlen(v->args);
+    app_len      = ngx_strlen(v->app);
+    args_len     = ngx_strlen(v->args);
     flashver_len = ngx_strlen(v->flashver);
-    swf_url_len = ngx_strlen(v->swf_url);
-    tc_url_len = ngx_strlen(v->tc_url);
+    swf_url_len  = ngx_strlen(v->swf_url);
+    tc_url_len   = ngx_strlen(v->tc_url);
     page_url_len = ngx_strlen(v->page_url);
 
-    b = ngx_create_temp_buf(pool,
-            sizeof("call=connect") +
-            sizeof("&app=") - 1 + app_len * 3 +
-            sizeof("&flashver=") - 1 + flashver_len * 3 +
-            sizeof("&swfurl=") - 1 + swf_url_len * 3 +
-            sizeof("&tcurl=") - 1 + tc_url_len * 3 +
-            sizeof("&pageurl=") - 1 + page_url_len * 3 +
-            sizeof("&epoch=") - 1 + NGX_INT32_LEN +
-            1 + args_len + 1
-        );
+    b = ngx_create_temp_buf(pool, sizeof("call=connect") + sizeof("&app=") - 1 +
+                                      app_len * 3 + sizeof("&flashver=") - 1 +
+                                      flashver_len * 3 + sizeof("&swfurl=") -
+                                      1 + swf_url_len * 3 + sizeof("&tcurl=") -
+                                      1 + tc_url_len * 3 + sizeof("&pageurl=") -
+                                      1 + page_url_len * 3 + sizeof("&epoch=") -
+                                      1 + NGX_INT32_LEN + 1 + args_len + 1);
 
     if (b == NULL) {
         return NULL;
     }
 
-    al->buf = b;
+    al->buf  = b;
     al->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, v->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, v->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=connect",
+    b->last = ngx_cpymem(b->last, (u_char *)"call=connect",
                          sizeof("call=connect") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&app=", sizeof("&app=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->app, app_len,
+    b->last = ngx_cpymem(b->last, (u_char *)"&app=", sizeof("&app=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, v->app, app_len, NGX_ESCAPE_ARGS);
+
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&flashver=", sizeof("&flashver=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->flashver, flashver_len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&flashver=",
-                         sizeof("&flashver=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->flashver, flashver_len,
+    b->last = ngx_cpymem(b->last, (u_char *)"&swfurl=", sizeof("&swfurl=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->swf_url, swf_url_len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&swfurl=",
-                         sizeof("&swfurl=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->swf_url, swf_url_len,
+    b->last = ngx_cpymem(b->last, (u_char *)"&tcurl=", sizeof("&tcurl=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->tc_url, tc_url_len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&tcurl=",
-                         sizeof("&tcurl=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->tc_url, tc_url_len,
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&pageurl=", sizeof("&pageurl=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->page_url, page_url_len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&pageurl=",
-                         sizeof("&pageurl=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->page_url, page_url_len,
-                                       NGX_ESCAPE_ARGS);
-
-    b->last = ngx_cpymem(b->last, (u_char*) "&epoch=", sizeof("&epoch=") -1);
-    b->last = ngx_sprintf(b->last, "%uD", (uint32_t) s->epoch);
+    b->last = ngx_cpymem(b->last, (u_char *)"&epoch=", sizeof("&epoch=") - 1);
+    b->last = ngx_sprintf(b->last, "%uD", (uint32_t)s->epoch);
 
     *b->last++ = '&';
 
-    return ngx_rtmp_notify_create_srv_request(s, pool, NGX_RTMP_NOTIFY_CONNECT, al);
+    return ngx_rtmp_notify_create_srv_request(s, pool, NGX_RTMP_NOTIFY_CONNECT,
+                                              al);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_disconnect_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_disconnect_create(ngx_rtmp_session_t *s,
+                                                      void *arg,
+                                                      ngx_pool_t *pool)
 {
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
 
     pl = ngx_alloc_chain_link(pool);
     if (pl == NULL) {
         return NULL;
     }
 
-    b = ngx_create_temp_buf(pool,
-            sizeof("call=disconnect") +
-            sizeof("&bytes_in=") - 1 + NGX_INT32_LEN +
-            sizeof("&bytes_out=") - 1 + NGX_INT32_LEN +
-            1 + s->args.len + 1);
+    b = ngx_create_temp_buf(pool, sizeof("call=disconnect") +
+                                      sizeof("&bytes_in=") - 1 + NGX_INT32_LEN +
+                                      sizeof("&bytes_out=") - 1 +
+                                      NGX_INT32_LEN + 1 + s->args.len + 1);
 
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (s->args.len) {
-        b->last = (u_char *) ngx_cpymem(b->last, s->args.data, s->args.len);
+        b->last    = (u_char *)ngx_cpymem(b->last, s->args.data, s->args.len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=disconnect",
+    b->last = ngx_cpymem(b->last, (u_char *)"call=disconnect",
                          sizeof("call=disconnect") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_in=", sizeof("&bytes_in=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->in_bytes);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_in=", sizeof("&bytes_in=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->in_bytes);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_out=", sizeof("&bytes_out=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->out_bytes);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_out=", sizeof("&bytes_out=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->out_bytes);
 
     *b->last++ = '&';
 
-    return ngx_rtmp_notify_create_srv_request(s, pool, NGX_RTMP_NOTIFY_DISCONNECT, pl);
+    return ngx_rtmp_notify_create_srv_request(s, pool,
+                                              NGX_RTMP_NOTIFY_DISCONNECT, pl);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_publish_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_publish_create(ngx_rtmp_session_t *s,
+                                                   void *arg, ngx_pool_t *pool)
 {
-    ngx_rtmp_publish_t             *v = arg;
+    ngx_rtmp_publish_t *v = arg;
 
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          name_len, type_len, args_len;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t name_len, type_len, args_len;
 
     pl = ngx_alloc_chain_link(pool);
     if (pl == NULL) {
@@ -604,49 +537,45 @@ ngx_rtmp_notify_publish_create(ngx_rtmp_session_t *s, void *arg,
     type_len = ngx_strlen(v->type);
     args_len = ngx_strlen(v->args);
 
-    b = ngx_create_temp_buf(pool,
-                            sizeof("call=publish") +
-                            sizeof("&name=") + name_len * 3 +
-                            sizeof("&type=") + type_len * 3 +
-                            1 + args_len + 1);
+    b = ngx_create_temp_buf(pool, sizeof("call=publish") + sizeof("&name=") +
+                                      name_len * 3 + sizeof("&type=") +
+                                      type_len * 3 + 1 + args_len + 1);
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, v->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, v->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=publish",
+    b->last = ngx_cpymem(b->last, (u_char *)"call=publish",
                          sizeof("call=publish") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->name, name_len,
-                                       NGX_ESCAPE_ARGS);
+    b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, v->name, name_len, NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&type=", sizeof("&type=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->type, type_len,
-                                       NGX_ESCAPE_ARGS);
+    b->last = ngx_cpymem(b->last, (u_char *)"&type=", sizeof("&type=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, v->type, type_len, NGX_ESCAPE_ARGS);
 
     *b->last++ = '&';
 
     return ngx_rtmp_notify_create_request(s, pool, NGX_RTMP_NOTIFY_PUBLISH, pl);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_play_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_play_create(ngx_rtmp_session_t *s,
+                                                void *arg, ngx_pool_t *pool)
 {
-    ngx_rtmp_play_t                *v = arg;
+    ngx_rtmp_play_t *v = arg;
 
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          name_len, args_len;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t name_len, args_len;
 
     pl = ngx_alloc_chain_link(pool);
     if (pl == NULL) {
@@ -656,51 +585,47 @@ ngx_rtmp_notify_play_create(ngx_rtmp_session_t *s, void *arg,
     name_len = ngx_strlen(v->name);
     args_len = ngx_strlen(v->args);
 
-    b = ngx_create_temp_buf(pool,
-                            sizeof("call=play") +
-                            sizeof("&name=") + name_len * 3 +
-                            sizeof("&start=&duration=&reset=") +
-                            NGX_INT32_LEN * 3 + 1 + args_len + 1);
+    b = ngx_create_temp_buf(pool, sizeof("call=play") + sizeof("&name=") +
+                                      name_len * 3 +
+                                      sizeof("&start=&duration=&reset=") +
+                                      NGX_INT32_LEN * 3 + 1 + args_len + 1);
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, v->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, v->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=play",
-                         sizeof("call=play") - 1);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"call=play", sizeof("call=play") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->name, name_len,
-                                       NGX_ESCAPE_ARGS);
+    b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, v->name, name_len, NGX_ESCAPE_ARGS);
 
-    b->last = ngx_snprintf(b->last, b->end - b->last,
-                           "&start=%uD&duration=%uD&reset=%d",
-                           (uint32_t) v->start, (uint32_t) v->duration,
-                           v->reset & 1);
+    b->last = ngx_snprintf(
+        b->last, b->end - b->last, "&start=%uD&duration=%uD&reset=%d",
+        (uint32_t)v->start, (uint32_t)v->duration, v->reset & 1);
 
     *b->last++ = '&';
 
     return ngx_rtmp_notify_create_request(s, pool, NGX_RTMP_NOTIFY_PLAY, pl);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_done_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_done_create(ngx_rtmp_session_t *s,
+                                                void *arg, ngx_pool_t *pool)
 {
-    ngx_rtmp_notify_done_t         *ds = arg;
+    ngx_rtmp_notify_done_t *ds = arg;
 
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          cbname_len, name_len, args_len;
-    ngx_rtmp_notify_ctx_t          *ctx;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t cbname_len, name_len, args_len;
+    ngx_rtmp_notify_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
@@ -710,58 +635,56 @@ ngx_rtmp_notify_done_create(ngx_rtmp_session_t *s, void *arg,
     }
 
     cbname_len = ngx_strlen(ds->cbname);
-    name_len = ctx ? ngx_strlen(ctx->name) : 0;
-    args_len = ctx ? ngx_strlen(ctx->args) : 0;
+    name_len   = ctx ? ngx_strlen(ctx->name) : 0;
+    args_len   = ctx ? ngx_strlen(ctx->args) : 0;
 
-    b = ngx_create_temp_buf(pool,
-            sizeof("call=") + cbname_len +
-            sizeof("&name=") + name_len * 3 +
-            sizeof("&bytes_in=") - 1 + NGX_INT32_LEN +
-            sizeof("&bytes_out=") - 1 + NGX_INT32_LEN +
-            1 + args_len + 1);
+    b = ngx_create_temp_buf(
+        pool, sizeof("call=") + cbname_len + sizeof("&name=") + name_len * 3 +
+                  sizeof("&bytes_in=") - 1 + NGX_INT32_LEN +
+                  sizeof("&bytes_out=") - 1 + NGX_INT32_LEN + 1 + args_len + 1);
 
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, ctx->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, ctx->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=", sizeof("call=") - 1);
+    b->last = ngx_cpymem(b->last, (u_char *)"call=", sizeof("call=") - 1);
     b->last = ngx_cpymem(b->last, ds->cbname, cbname_len);
 
     if (name_len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, ctx->name, name_len,
+        b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, ctx->name, name_len,
                                            NGX_ESCAPE_ARGS);
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_in=", sizeof("&bytes_in=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->in_bytes);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_in=", sizeof("&bytes_in=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->in_bytes);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_out=", sizeof("&bytes_out=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->out_bytes);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_out=", sizeof("&bytes_out=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->out_bytes);
 
     *b->last++ = '&';
 
     return ngx_rtmp_notify_create_request(s, pool, ds->url_idx, pl);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_update_create(ngx_rtmp_session_t *s, void *arg,
-        ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_update_create(ngx_rtmp_session_t *s,
+                                                  void *arg, ngx_pool_t *pool)
 {
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          name_len, args_len;
-    ngx_rtmp_notify_ctx_t          *ctx;
-    ngx_str_t                       sfx;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t name_len, args_len;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_str_t sfx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
@@ -781,39 +704,36 @@ ngx_rtmp_notify_update_create(ngx_rtmp_session_t *s, void *arg,
     name_len = ctx ? ngx_strlen(ctx->name) : 0;
     args_len = ctx ? ngx_strlen(ctx->args) : 0;
 
-    b = ngx_create_temp_buf(pool,
-                            sizeof("call=update") + sfx.len +
-                            sizeof("&time=") + NGX_TIME_T_LEN +
-                            sizeof("&timestamp=") + NGX_INT32_LEN +
-                            sizeof("&name=") + name_len * 3 +
-                            1 + args_len + 1);
+    b = ngx_create_temp_buf(
+        pool, sizeof("call=update") + sfx.len + sizeof("&time=") +
+                  NGX_TIME_T_LEN + sizeof("&timestamp=") + NGX_INT32_LEN +
+                  sizeof("&name=") + name_len * 3 + 1 + args_len + 1);
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, ctx->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, ctx->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=update",
-                         sizeof("call=update") - 1);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"call=update", sizeof("call=update") - 1);
     b->last = ngx_cpymem(b->last, sfx.data, sfx.len);
 
-    b->last = ngx_cpymem(b->last, (u_char *) "&time=",
-                         sizeof("&time=") - 1);
+    b->last = ngx_cpymem(b->last, (u_char *)"&time=", sizeof("&time=") - 1);
     b->last = ngx_sprintf(b->last, "%T", ngx_cached_time->sec - ctx->start);
 
-    b->last = ngx_cpymem(b->last, (u_char *) "&timestamp=",
-                         sizeof("&timestamp=") - 1);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&timestamp=", sizeof("&timestamp=") - 1);
     b->last = ngx_sprintf(b->last, "%D", s->current_time);
 
     if (name_len) {
-        b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-        b->last = (u_char*) ngx_escape_uri(b->last, ctx->name, name_len,
+        b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+        b->last = (u_char *)ngx_escape_uri(b->last, ctx->name, name_len,
                                            NGX_ESCAPE_ARGS);
     }
 
@@ -822,17 +742,16 @@ ngx_rtmp_notify_update_create(ngx_rtmp_session_t *s, void *arg,
     return ngx_rtmp_notify_create_request(s, pool, NGX_RTMP_NOTIFY_UPDATE, pl);
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_notify_record_done_create(ngx_rtmp_session_t *s, void *arg,
-                                   ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_record_done_create(ngx_rtmp_session_t *s,
+                                                       void *arg,
+                                                       ngx_pool_t *pool)
 {
-    ngx_rtmp_record_done_t         *v = arg;
+    ngx_rtmp_record_done_t *v = arg;
 
-    ngx_rtmp_notify_ctx_t          *ctx;
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          name_len, args_len;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t name_len, args_len;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
@@ -841,51 +760,51 @@ ngx_rtmp_notify_record_done_create(ngx_rtmp_session_t *s, void *arg,
         return NULL;
     }
 
-    name_len  = ngx_strlen(ctx->name);
-    args_len  = ngx_strlen(ctx->args);
+    name_len = ngx_strlen(ctx->name);
+    args_len = ngx_strlen(ctx->args);
 
-    b = ngx_create_temp_buf(pool,
-            sizeof("call=record_done") +
-            sizeof("&recorder=") + v->recorder.len +
-            sizeof("&name=") + name_len * 3 +
-            sizeof("&path=") + v->path.len * 3 +
-            sizeof("&bytes_in=") - 1 + NGX_INT32_LEN +
-            sizeof("&bytes_out=") - 1 + NGX_INT32_LEN +
-            1 + args_len + 1);
+    b = ngx_create_temp_buf(
+        pool, sizeof("call=record_done") + sizeof("&recorder=") +
+                  v->recorder.len + sizeof("&name=") + name_len * 3 +
+                  sizeof("&path=") + v->path.len * 3 + sizeof("&bytes_in=") -
+                  1 + NGX_INT32_LEN + sizeof("&bytes_out=") - 1 +
+                  NGX_INT32_LEN + 1 + args_len + 1);
 
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
     if (args_len) {
-        b->last = (u_char *) ngx_cpymem(b->last, ctx->args, args_len);
+        b->last    = (u_char *)ngx_cpymem(b->last, ctx->args, args_len);
         *b->last++ = '&';
     }
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=record_done",
+    b->last = ngx_cpymem(b->last, (u_char *)"call=record_done",
                          sizeof("call=record_done") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char *) "&recorder=",
-                         sizeof("&recorder=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->recorder.data,
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&recorder=", sizeof("&recorder=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->recorder.data,
                                        v->recorder.len, NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, ctx->name, name_len,
+    b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, ctx->name, name_len, NGX_ESCAPE_ARGS);
+
+    b->last = ngx_cpymem(b->last, (u_char *)"&path=", sizeof("&path=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->path.data, v->path.len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&path=", sizeof("&path=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->path.data, v->path.len,
-                                       NGX_ESCAPE_ARGS);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_in=", sizeof("&bytes_in=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->in_bytes);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_in=", sizeof("&bytes_in=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->in_bytes);
-
-    b->last = ngx_cpymem(b->last, (u_char*) "&bytes_out=", sizeof("&bytes_out=") -1);
-    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->out_bytes);
+    b->last =
+        ngx_cpymem(b->last, (u_char *)"&bytes_out=", sizeof("&bytes_out=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t)s->out_bytes);
 
     *b->last++ = '&';
 
@@ -893,16 +812,15 @@ ngx_rtmp_notify_record_done_create(ngx_rtmp_session_t *s, void *arg,
                                           pl);
 }
 
-static ngx_chain_t *
-ngx_rtmp_notify_playlist_create(ngx_rtmp_session_t *s, void *arg,
-                                   ngx_pool_t *pool)
+static ngx_chain_t *ngx_rtmp_notify_playlist_create(ngx_rtmp_session_t *s,
+                                                    void *arg, ngx_pool_t *pool)
 {
-    ngx_rtmp_playlist_t            *v = arg;
+    ngx_rtmp_playlist_t *v = arg;
 
-    ngx_rtmp_notify_ctx_t          *ctx;
-    ngx_chain_t                    *pl;
-    ngx_buf_t                      *b;
-    size_t                          name_len;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_chain_t *pl;
+    ngx_buf_t *b;
+    size_t name_len;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
@@ -911,37 +829,34 @@ ngx_rtmp_notify_playlist_create(ngx_rtmp_session_t *s, void *arg,
         return NULL;
     }
 
-    name_len  = ngx_strlen(ctx->name);
+    name_len = ngx_strlen(ctx->name);
 
-    b = ngx_create_temp_buf(pool,
-            sizeof("call=playlist") +
-            sizeof("&module=") + v->module.len +
-            sizeof("&name=") + name_len * 3 +
-            sizeof("&path=") + v->playlist.len * 3 +
-            1 + 1);
+    b = ngx_create_temp_buf(pool, sizeof("call=playlist") + sizeof("&module=") +
+                                      v->module.len + sizeof("&name=") +
+                                      name_len * 3 + sizeof("&path=") +
+                                      v->playlist.len * 3 + 1 + 1);
 
     if (b == NULL) {
         return NULL;
     }
 
-    pl->buf = b;
+    pl->buf  = b;
     pl->next = NULL;
 
-    b->last = ngx_cpymem(b->last, (u_char*) "call=playlist",
+    b->last = ngx_cpymem(b->last, (u_char *)"call=playlist",
                          sizeof("call=playlist") - 1);
 
-    b->last = ngx_cpymem(b->last, (u_char *) "&module=",
-                         sizeof("&module=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->module.data,
-                                       v->module.len, NGX_ESCAPE_ARGS);
-
-    b->last = ngx_cpymem(b->last, (u_char*) "&name=", sizeof("&name=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, ctx->name, name_len,
+    b->last = ngx_cpymem(b->last, (u_char *)"&module=", sizeof("&module=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->module.data, v->module.len,
                                        NGX_ESCAPE_ARGS);
 
-    b->last = ngx_cpymem(b->last, (u_char*) "&path=", sizeof("&path=") - 1);
-    b->last = (u_char*) ngx_escape_uri(b->last, v->playlist.data, v->playlist.len,
-                                       NGX_ESCAPE_ARGS);
+    b->last = ngx_cpymem(b->last, (u_char *)"&name=", sizeof("&name=") - 1);
+    b->last =
+        (u_char *)ngx_escape_uri(b->last, ctx->name, name_len, NGX_ESCAPE_ARGS);
+
+    b->last = ngx_cpymem(b->last, (u_char *)"&path=", sizeof("&path=") - 1);
+    b->last = (u_char *)ngx_escape_uri(b->last, v->playlist.data,
+                                       v->playlist.len, NGX_ESCAPE_ARGS);
 
     *b->last++ = '&';
 
@@ -949,14 +864,12 @@ ngx_rtmp_notify_playlist_create(ngx_rtmp_session_t *s, void *arg,
                                           pl);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_parse_http_retcode(ngx_rtmp_session_t *s,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_notify_parse_http_retcode(ngx_rtmp_session_t *s,
+                                                    ngx_chain_t *in)
 {
-    ngx_buf_t      *b;
-    ngx_int_t       n;
-    u_char          c;
+    ngx_buf_t *b;
+    ngx_int_t n;
+    u_char c;
 
     /* find 10th character */
 
@@ -967,21 +880,21 @@ ngx_rtmp_notify_parse_http_retcode(ngx_rtmp_session_t *s,
             c = b->pos[n];
             if (c >= (u_char)'0' && c <= (u_char)'9') {
                 ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                    "notify: HTTP retcode: %dxx", (int)(c - '0'));
+                               "notify: HTTP retcode: %dxx", (int)(c - '0'));
                 switch (c) {
-                    case (u_char) '2':
-                        return NGX_OK;
-                    case (u_char) '3':
-                        return NGX_AGAIN;
-                    case (u_char) '4':
-                        return NGX_DECLINED;
-                    default:
-                        return NGX_ERROR;
+                case (u_char)'2':
+                    return NGX_OK;
+                case (u_char)'3':
+                    return NGX_AGAIN;
+                case (u_char)'4':
+                    return NGX_DECLINED;
+                default:
+                    return NGX_ERROR;
                 }
             }
 
             ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                    "notify: invalid HTTP retcode: %d..", (int)c);
+                          "notify: invalid HTTP retcode: %d..", (int)c);
 
             return NGX_ERROR;
         }
@@ -990,7 +903,7 @@ ngx_rtmp_notify_parse_http_retcode(ngx_rtmp_session_t *s,
     }
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: empty or broken HTTP response");
+                  "notify: empty or broken HTTP response");
 
     /*
      * not enough data;
@@ -1000,15 +913,15 @@ ngx_rtmp_notify_parse_http_retcode(ngx_rtmp_session_t *s,
     return NGX_ERROR;
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
-        ngx_chain_t *in, ngx_str_t *name, u_char *data, size_t len)
+static ngx_int_t ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
+                                                   ngx_chain_t *in,
+                                                   ngx_str_t *name,
+                                                   u_char *data, size_t len)
 {
-    ngx_buf_t      *b;
-    ngx_int_t       matched;
-    u_char         *p, c;
-    ngx_uint_t      n;
+    ngx_buf_t *b;
+    ngx_int_t matched;
+    u_char *p, c;
+    ngx_uint_t n;
 
     enum {
         parse_name,
@@ -1017,7 +930,7 @@ ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
         parse_value_newline
     } state = parse_name;
 
-    n = 0;
+    n       = 0;
     matched = 0;
 
     while (in) {
@@ -1031,61 +944,60 @@ ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
             }
 
             switch (state) {
-                case parse_value_newline:
-                    if (c == ' ' || c == '\t') {
-                        state = parse_space;
-                        break;
-                    }
+            case parse_value_newline:
+                if (c == ' ' || c == '\t') {
+                    state = parse_space;
+                    break;
+                }
 
-                    if (matched) {
-                        return n;
-                    }
+                if (matched) {
+                    return n;
+                }
 
-                    if (c == '\n') {
-                        return NGX_OK;
-                    }
+                if (c == '\n') {
+                    return NGX_OK;
+                }
 
+                n     = 0;
+                state = parse_name;
+
+            case parse_name:
+                switch (c) {
+                case ':':
+                    matched = (n == name->len);
+                    n       = 0;
+                    state   = parse_space;
+                    break;
+                case '\n':
                     n = 0;
-                    state = parse_name;
-
-                case parse_name:
-                    switch (c) {
-                        case ':':
-                            matched = (n == name->len);
-                            n = 0;
-                            state = parse_space;
-                            break;
-                        case '\n':
-                            n = 0;
-                            break;
-                        default:
-                            if (n < name->len &&
-                                ngx_tolower(c) == ngx_tolower(name->data[n]))
-                            {
-                                ++n;
-                                break;
-                            }
-                            n = name->len + 1;
-                    }
                     break;
-
-                case parse_space:
-                    if (c == ' ' || c == '\t') {
+                default:
+                    if (n < name->len &&
+                        ngx_tolower(c) == ngx_tolower(name->data[n])) {
+                        ++n;
                         break;
                     }
-                    state = parse_value;
+                    n = name->len + 1;
+                }
+                break;
 
-                case parse_value:
-                    if (c == '\n') {
-                        state = parse_value_newline;
-                        break;
-                    }
-
-                    if (matched && n + 1 < len) {
-                        data[n++] = c;
-                    }
-
+            case parse_space:
+                if (c == ' ' || c == '\t') {
                     break;
+                }
+                state = parse_value;
+
+            case parse_value:
+                if (c == '\n') {
+                    state = parse_value_newline;
+                    break;
+                }
+
+                if (matched && n + 1 < len) {
+                    data[n++] = c;
+                }
+
+                break;
             }
         }
 
@@ -1095,29 +1007,25 @@ ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_notify_clear_flag(ngx_rtmp_session_t *s, ngx_uint_t flag)
+static void ngx_rtmp_notify_clear_flag(ngx_rtmp_session_t *s, ngx_uint_t flag)
 {
-    ngx_rtmp_notify_ctx_t  *ctx;
+    ngx_rtmp_notify_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
     ctx->flags &= ~flag;
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
-        void *arg, ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
+                                                void *arg, ngx_chain_t *in)
 {
     ngx_rtmp_connect_t *v = arg;
-    ngx_int_t           rc, send;
-    ngx_str_t                   local_name;
+    ngx_int_t rc, send;
+    ngx_str_t local_name;
     ngx_rtmp_notify_srv_conf_t *nscf;
-    u_char              app[NGX_RTMP_MAX_NAME];
+    u_char app[NGX_RTMP_MAX_NAME];
 
-    static ngx_str_t    location = ngx_string("location");
+    static ngx_str_t location = ngx_string("location");
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
 
@@ -1130,17 +1038,18 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
     /* HTTP 4xx */
 
     if (rc == NGX_DECLINED) {
-
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: connection denyed by callback return code 4xx");
+                      "notify: connection denyed by callback return code 4xx");
 
         ngx_rtmp_send_status(s, "NetConnection.Connect.Rejected", "error",
-                             "Cennection denyed by notify event handler and callback return code");
+                             "Cennection denyed by notify event handler and "
+                             "callback return code");
 
         // Something by rtmpdump lib
         send = ngx_rtmp_send_close_method(s, "close");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: connect send(e) close method = '%ui'", send == NGX_OK);
+                      "notify: connect send(e) close method = '%ui'",
+                      send == NGX_OK);
 
         return NGX_ERROR;
     }
@@ -1152,7 +1061,7 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
     /* HTTP 3xx */
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                   "notify: connect redirect received");
+                  "notify: connect redirect received");
 
     rc = ngx_rtmp_notify_parse_http_header(s, in, &location, app,
                                            sizeof(app) - 1);
@@ -1161,11 +1070,11 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
     }
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                 "notify: parsed location '%*s'", rc, app);
+                  "notify: parsed location '%*s'", rc, app);
 
     /* switch app */
 
-    if (ngx_strncasecmp(app, (u_char *) "rtmp://", 7)) {
+    if (ngx_strncasecmp(app, (u_char *)"rtmp://", 7)) {
         *ngx_cpymem(v->app, app, rc) = 0;
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                       "notify: connect redirect to '%s'", v->app);
@@ -1180,29 +1089,35 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
         // Send 302 redirect and go next
 
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: connect send 302 redirect");
+                      "notify: connect send 302 redirect");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: -- for app '%s' to new location '%*s'", v->app, rc, app);
+                      "notify: -- for app '%s' to new location '%*s'", v->app,
+                      rc, app);
 
-        local_name.data = ngx_palloc(s->connection->pool, rc+1);
-        local_name.len = rc;
+        local_name.data = ngx_palloc(s->connection->pool, rc + 1);
+        local_name.len  = rc;
         *ngx_cpymem(local_name.data, app, rc) = 0;
 
         /* MAGICK HERE */
 
-        if (!ngx_strncasecmp(s->flashver.data, (u_char *) "FMLE/", 5)) {
+        if (!ngx_strncasecmp(s->flashver.data, (u_char *)"FMLE/", 5)) {
             // Official method, by FMS SDK
-            send = ngx_rtmp_send_redirect_status(s, "onStatus", "Connect here", local_name);
-            send &= ngx_rtmp_send_redirect_status(s, "netStatus", "Connect here", local_name);
+            send = ngx_rtmp_send_redirect_status(s, "onStatus", "Connect here",
+                                                 local_name);
+            send &= ngx_rtmp_send_redirect_status(s, "netStatus",
+                                                  "Connect here", local_name);
 
             ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                      "notify: connect send(o) status = '%ui'", send == NGX_OK);
+                          "notify: connect send(o) status = '%ui'",
+                          send == NGX_OK);
         } else {
             // Something by rtmpdump lib
-            send = ngx_rtmp_send_redirect_status(s, "_error", "Connect here", local_name);
+            send = ngx_rtmp_send_redirect_status(s, "_error", "Connect here",
+                                                 local_name);
 
             ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                      "notify: connect send(e) status = '%ui'", send == NGX_OK);
+                          "notify: connect send(e) status = '%ui'",
+                          send == NGX_OK);
         }
 
         ngx_pfree(s->connection->pool, local_name.data);
@@ -1210,7 +1125,8 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
         // Something by rtmpdump lib
         send = ngx_rtmp_send_close_method(s, "close");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: connect send(e) close method = '%ui'", send == NGX_OK);
+                      "notify: connect send(e) close method = '%ui'",
+                      send == NGX_OK);
 
         return send;
     }
@@ -1220,36 +1136,32 @@ next:
     return next_connect(s, v);
 }
 
-
-static void
-ngx_rtmp_notify_set_name(u_char *dst, size_t dst_len, u_char *src,
-    size_t src_len)
+static void ngx_rtmp_notify_set_name(u_char *dst, size_t dst_len, u_char *src,
+                                     size_t src_len)
 {
-    u_char     result[16], *p;
-    ngx_md5_t  md5;
+    u_char result[16], *p;
+    ngx_md5_t md5;
 
     ngx_md5_init(&md5);
     ngx_md5_update(&md5, src, src_len);
     ngx_md5_final(result, &md5);
 
-    p = ngx_hex_dump(dst, result, ngx_min((dst_len - 1) / 2, 16));
+    p  = ngx_hex_dump(dst, result, ngx_min((dst_len - 1) / 2, 16));
     *p = '\0';
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
-        void *arg, ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
+                                                void *arg, ngx_chain_t *in)
 {
-    ngx_rtmp_publish_t         *v = arg;
-    ngx_int_t                   rc, send;
-    ngx_str_t                   local_name;
-    ngx_rtmp_relay_target_t     target;
-    ngx_url_t                  *u;
+    ngx_rtmp_publish_t *v = arg;
+    ngx_int_t rc, send;
+    ngx_str_t local_name;
+    ngx_rtmp_relay_target_t target;
+    ngx_url_t *u;
     ngx_rtmp_notify_app_conf_t *nacf;
-    u_char                      name[NGX_RTMP_MAX_NAME];
+    u_char name[NGX_RTMP_MAX_NAME];
 
-    static ngx_str_t    location = ngx_string("location");
+    static ngx_str_t location = ngx_string("location");
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
 
@@ -1263,19 +1175,20 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
     /* HTTP 4xx */
 
     if (rc == NGX_DECLINED) {
-
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: publishing denyed by callback return code 4xx");
+                      "notify: publishing denyed by callback return code 4xx");
 
         ngx_rtmp_send_status(s, "NetConnection.Connect.Rejected", "error",
-                             "Publishing denyed by notify event handler and callback return code");
+                             "Publishing denyed by notify event handler and "
+                             "callback return code");
 
         ngx_rtmp_notify_clear_flag(s, NGX_RTMP_NOTIFY_PUBLISHING);
 
         // Something by rtmpdump lib
         send = ngx_rtmp_send_close_method(s, "close");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: connect send(e) close method = '%ui'", send == NGX_OK);
+                      "notify: connect send(e) close method = '%ui'",
+                      send == NGX_OK);
 
         return NGX_ERROR;
     }
@@ -1287,7 +1200,7 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
     /* HTTP 3xx */
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                   "notify: publish redirect received");
+                  "notify: publish redirect received");
 
     rc = ngx_rtmp_notify_parse_http_header(s, in, &location, name,
                                            sizeof(name) - 1);
@@ -1295,7 +1208,7 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
         goto next;
     }
 
-    if (ngx_strncasecmp(name, (u_char *) "rtmp://", 7)) {
+    if (ngx_strncasecmp(name, (u_char *)"rtmp://", 7)) {
         *ngx_cpymem(v->name, name, rc) = 0;
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                       "notify: publish redirect to '%s'", v->name);
@@ -1310,30 +1223,35 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
         // Send 302 redirect and go next
 
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: publish send 302 redirect");
+                      "notify: publish send 302 redirect");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: -- for stream '%s' to new location '%*s'", v->name, rc, name);
+                      "notify: -- for stream '%s' to new location '%*s'",
+                      v->name, rc, name);
 
-        local_name.data = ngx_palloc(s->connection->pool, rc+1);
-        local_name.len = rc;
+        local_name.data = ngx_palloc(s->connection->pool, rc + 1);
+        local_name.len  = rc;
         *ngx_cpymem(local_name.data, name, rc) = 0;
 
         /* MAGICK HERE */
 
-        if (!ngx_strncasecmp(s->flashver.data, (u_char *) "FMLE/", 5)) {
+        if (!ngx_strncasecmp(s->flashver.data, (u_char *)"FMLE/", 5)) {
             // Official method, by FMS SDK
-            send = ngx_rtmp_send_redirect_status(s, "onStatus", "Connect here", local_name);
-            send &= ngx_rtmp_send_redirect_status(s, "netStatus", "Connect here", local_name);
+            send = ngx_rtmp_send_redirect_status(s, "onStatus", "Connect here",
+                                                 local_name);
+            send &= ngx_rtmp_send_redirect_status(s, "netStatus",
+                                                  "Connect here", local_name);
 
             ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                      "notify: publish send(o) status = '%ui'", send == NGX_OK);
+                          "notify: publish send(o) status = '%ui'",
+                          send == NGX_OK);
         } else {
-
             // Something by rtmpdump lib
-            send = ngx_rtmp_send_redirect_status(s, "_error", "Connect here", local_name);
+            send = ngx_rtmp_send_redirect_status(s, "_error", "Connect here",
+                                                 local_name);
 
             ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                      "notify: publish send(e) status = '%ui'", send == NGX_OK);
+                          "notify: publish send(e) status = '%ui'",
+                          send == NGX_OK);
         }
 
         ngx_pfree(s->connection->pool, local_name.data);
@@ -1343,31 +1261,32 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
         // Something by rtmpdump lib
         send = ngx_rtmp_send_close_method(s, "close");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: publish send(e) close method = '%ui'", send == NGX_OK);
+                      "notify: publish send(e) close method = '%ui'",
+                      send == NGX_OK);
 
         return send;
 
     } else if (nacf->relay_redirect) {
         // Relay local streams, change name
 
-        ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t) rc);
+        ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t)rc);
     }
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                   "notify: push '%s' to '%*s'", v->name, rc, name);
 
     local_name.data = v->name;
-    local_name.len = ngx_strlen(v->name);
+    local_name.len  = ngx_strlen(v->name);
 
     ngx_memzero(&target, sizeof(target));
 
-    u = &target.url;
-    u->url = local_name;
-    u->url.data = name + 7;
-    u->url.len = rc - 7;
+    u               = &target.url;
+    u->url          = local_name;
+    u->url.data     = name + 7;
+    u->url.len      = rc - 7;
     u->default_port = 1935;
-    u->uri_part = 1;
-    u->no_resolve = 1; /* want ip here */
+    u->uri_part     = 1;
+    u->no_resolve   = 1; /* want ip here */
 
     if (ngx_parse_url(s->connection->pool, u) != NGX_OK) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
@@ -1382,23 +1301,21 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
-        void *arg, ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s, void *arg,
+                                             ngx_chain_t *in)
 {
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
-                  "notify: ngx_rtmp_notify_play_handle");
+                   "notify: ngx_rtmp_notify_play_handle");
 
-    ngx_rtmp_play_t            *v = arg;
-    ngx_int_t                   rc, send;
-    ngx_str_t                   local_name;
-    ngx_rtmp_relay_target_t     target;
-    ngx_url_t                  *u;
+    ngx_rtmp_play_t *v = arg;
+    ngx_int_t rc, send;
+    ngx_str_t local_name;
+    ngx_rtmp_relay_target_t target;
+    ngx_url_t *u;
     ngx_rtmp_notify_app_conf_t *nacf;
-    u_char                      name[NGX_RTMP_MAX_NAME];
+    u_char name[NGX_RTMP_MAX_NAME];
 
-    static ngx_str_t            location = ngx_string("location");
+    static ngx_str_t location = ngx_string("location");
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
 
@@ -1412,19 +1329,20 @@ ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
     /* HTTP 4xx */
 
     if (rc == NGX_DECLINED) {
-
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: playing denyed by callback return code 4xx");
+                      "notify: playing denyed by callback return code 4xx");
 
-        ngx_rtmp_send_status(s, "NetConnection.Connect.Rejected", "error",
-                             "Playing denyed by notify event handler and callback return code");
+        ngx_rtmp_send_status(
+            s, "NetConnection.Connect.Rejected", "error",
+            "Playing denyed by notify event handler and callback return code");
 
         ngx_rtmp_notify_clear_flag(s, NGX_RTMP_NOTIFY_PLAYING);
 
         // Something by rtmpdump lib
         send = ngx_rtmp_send_close_method(s, "close");
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "notify: connect send(e) close method = '%ui'", send == NGX_OK);
+                      "notify: connect send(e) close method = '%ui'",
+                      send == NGX_OK);
 
         return NGX_ERROR;
     }
@@ -1444,7 +1362,7 @@ ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
         goto next;
     }
 
-    if (ngx_strncasecmp(name, (u_char *) "rtmp://", 7)) {
+    if (ngx_strncasecmp(name, (u_char *)"rtmp://", 7)) {
         *ngx_cpymem(v->name, name, rc) = 0;
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                       "notify: play redirect to '%s'", v->name);
@@ -1455,24 +1373,24 @@ ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
     if (nacf->relay_redirect) {
-        ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t) rc);
+        ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t)rc);
     }
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                   "notify: pull '%s' from '%*s'", v->name, rc, name);
 
     local_name.data = v->name;
-    local_name.len = ngx_strlen(v->name);
+    local_name.len  = ngx_strlen(v->name);
 
     ngx_memzero(&target, sizeof(target));
 
-    u = &target.url;
-    u->url = local_name;
-    u->url.data = name + 7;
-    u->url.len = rc - 7;
+    u               = &target.url;
+    u->url          = local_name;
+    u->url.data     = name + 7;
+    u->url.len      = rc - 7;
     u->default_port = 1935;
-    u->uri_part = 1;
-    u->no_resolve = 1; /* want ip here */
+    u->uri_part     = 1;
+    u->no_resolve   = 1; /* want ip here */
 
     if (ngx_parse_url(s->connection->pool, u) != NGX_OK) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
@@ -1484,27 +1402,24 @@ ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
 
 next:
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
-              "notify: ngx_rtmp_notify_play_handle: next");
+                   "notify: ngx_rtmp_notify_play_handle: next");
 
     return next_play(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_update_handle(ngx_rtmp_session_t *s,
-        void *arg, ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_notify_update_handle(ngx_rtmp_session_t *s, void *arg,
+                                               ngx_chain_t *in)
 {
     ngx_rtmp_notify_app_conf_t *nacf;
-    ngx_rtmp_notify_ctx_t      *ctx;
-    ngx_int_t                   rc;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_int_t rc;
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
 
     if ((!nacf->update_strict && rc == NGX_ERROR) ||
-         (nacf->update_strict && rc != NGX_OK))
-    {
+        (nacf->update_strict && rc != NGX_OK)) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
                       "notify: update failed");
 
@@ -1514,23 +1429,20 @@ ngx_rtmp_notify_update_handle(ngx_rtmp_session_t *s,
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_notify_module);
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "notify: schedule update %Mms",
-                   nacf->update_timeout);
+                   "notify: schedule update %Mms", nacf->update_timeout);
 
     ngx_add_timer(&ctx->update_evt, nacf->update_timeout);
 
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_notify_update(ngx_event_t *e)
+static void ngx_rtmp_notify_update(ngx_event_t *e)
 {
-    ngx_connection_t           *c;
-    ngx_rtmp_session_t         *s;
+    ngx_connection_t *c;
+    ngx_rtmp_session_t *s;
     ngx_rtmp_notify_app_conf_t *nacf;
-    ngx_rtmp_netcall_init_t     ci;
-    ngx_url_t                  *url;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_url_t *url;
 
     c = e->data;
     s = c->data;
@@ -1539,12 +1451,12 @@ ngx_rtmp_notify_update(ngx_event_t *e)
 
     url = nacf->url[NGX_RTMP_NOTIFY_UPDATE];
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: update '%V'", &url->url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "notify: update '%V'",
+                  &url->url);
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
+    ci.url    = url;
     ci.create = ngx_rtmp_notify_update_create;
     ci.handle = ngx_rtmp_notify_update_handle;
 
@@ -1557,15 +1469,14 @@ ngx_rtmp_notify_update(ngx_event_t *e)
     ngx_rtmp_notify_update_handle(s, NULL, NULL);
 }
 
-
-static void
-ngx_rtmp_notify_init(ngx_rtmp_session_t *s,
-        u_char name[NGX_RTMP_MAX_NAME], u_char args[NGX_RTMP_MAX_ARGS],
-        ngx_uint_t flags)
+static void ngx_rtmp_notify_init(ngx_rtmp_session_t *s,
+                                 u_char name[NGX_RTMP_MAX_NAME],
+                                 u_char args[NGX_RTMP_MAX_ARGS],
+                                 ngx_uint_t flags)
 {
-    ngx_rtmp_notify_ctx_t          *ctx;
-    ngx_rtmp_notify_app_conf_t     *nacf;
-    ngx_event_t                    *e;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_rtmp_notify_app_conf_t *nacf;
+    ngx_event_t *e;
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
     if (!nacf->active) {
@@ -1589,8 +1500,7 @@ ngx_rtmp_notify_init(ngx_rtmp_session_t *s,
     ctx->flags |= flags;
 
     if (nacf->url[NGX_RTMP_NOTIFY_UPDATE] == NULL ||
-        nacf->update_timeout == 0)
-    {
+        nacf->update_timeout == 0) {
         return;
     }
 
@@ -1602,8 +1512,8 @@ ngx_rtmp_notify_init(ngx_rtmp_session_t *s,
 
     e = &ctx->update_evt;
 
-    e->data = s->connection;
-    e->log = s->connection->log;
+    e->data    = s->connection;
+    e->log     = s->connection->log;
     e->handler = ngx_rtmp_notify_update;
 
     ngx_add_timer(e, nacf->update_timeout);
@@ -1613,13 +1523,12 @@ ngx_rtmp_notify_init(ngx_rtmp_session_t *s,
                    nacf->update_timeout);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
+static ngx_int_t ngx_rtmp_notify_connect(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_connect_t *v)
 {
-    ngx_rtmp_notify_srv_conf_t     *nscf;
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_url_t                      *url;
+    ngx_rtmp_notify_srv_conf_t *nscf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_url_t *url;
 
     if (s->auto_pushed || s->relay) {
         goto next;
@@ -1632,15 +1541,15 @@ ngx_rtmp_notify_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
         goto next;
     }
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: connect '%V'", &url->url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "notify: connect '%V'",
+                  &url->url);
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
-    ci.create = ngx_rtmp_notify_connect_create;
-    ci.handle = ngx_rtmp_notify_connect_handle;
-    ci.arg = v;
+    ci.url     = url;
+    ci.create  = ngx_rtmp_notify_connect_create;
+    ci.handle  = ngx_rtmp_notify_connect_handle;
+    ci.arg     = v;
     ci.argsize = sizeof(*v);
 
     return ngx_rtmp_netcall_create(s, &ci);
@@ -1649,13 +1558,11 @@ next:
     return next_connect(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_disconnect(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_notify_disconnect(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_notify_srv_conf_t     *nscf;
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_url_t                      *url;
+    ngx_rtmp_notify_srv_conf_t *nscf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_url_t *url;
 
     if (s->auto_pushed || s->relay) {
         goto next;
@@ -1673,7 +1580,7 @@ ngx_rtmp_notify_disconnect(ngx_rtmp_session_t *s)
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
+    ci.url    = url;
     ci.create = ngx_rtmp_notify_disconnect_create;
 
     ngx_rtmp_netcall_create(s, &ci);
@@ -1682,13 +1589,12 @@ next:
     return next_disconnect(s);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_notify_publish(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_publish_t *v)
 {
-    ngx_rtmp_notify_app_conf_t     *nacf;
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_url_t                      *url;
+    ngx_rtmp_notify_app_conf_t *nacf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_url_t *url;
 
     if (s->auto_pushed) {
         goto next;
@@ -1707,15 +1613,15 @@ ngx_rtmp_notify_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: publish '%V'", &url->url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "notify: publish '%V'",
+                  &url->url);
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
-    ci.create = ngx_rtmp_notify_publish_create;
-    ci.handle = ngx_rtmp_notify_publish_handle;
-    ci.arg = v;
+    ci.url     = url;
+    ci.create  = ngx_rtmp_notify_publish_create;
+    ci.handle  = ngx_rtmp_notify_publish_handle;
+    ci.arg     = v;
     ci.argsize = sizeof(*v);
 
     return ngx_rtmp_netcall_create(s, &ci);
@@ -1724,16 +1630,14 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
+static ngx_int_t ngx_rtmp_notify_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
                   "notify: ngx_rtmp_notify_play");
 
-    ngx_rtmp_notify_app_conf_t     *nacf;
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_url_t                      *url;
+    ngx_rtmp_notify_app_conf_t *nacf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_url_t *url;
 
     if (s->auto_pushed) {
         goto next;
@@ -1752,33 +1656,31 @@ ngx_rtmp_notify_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         goto next;
     }
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: play '%V'", &url->url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "notify: play '%V'",
+                  &url->url);
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
-    ci.create = ngx_rtmp_notify_play_create;
-    ci.handle = ngx_rtmp_notify_play_handle;
-    ci.arg = v;
+    ci.url     = url;
+    ci.create  = ngx_rtmp_notify_play_create;
+    ci.handle  = ngx_rtmp_notify_play_handle;
+    ci.arg     = v;
     ci.argsize = sizeof(*v);
 
     return ngx_rtmp_netcall_create(s, &ci);
 
 next:
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
-              "notify: ngx_rtmp_notify_play: next");
+                  "notify: ngx_rtmp_notify_play: next");
 
     return next_play(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_close_stream(ngx_rtmp_session_t *s,
-                             ngx_rtmp_close_stream_t *v)
+static ngx_int_t ngx_rtmp_notify_close_stream(ngx_rtmp_session_t *s,
+                                              ngx_rtmp_close_stream_t *v)
 {
-    ngx_rtmp_notify_ctx_t          *ctx;
-    ngx_rtmp_notify_app_conf_t     *nacf;
+    ngx_rtmp_notify_ctx_t *ctx;
+    ngx_rtmp_notify_app_conf_t *nacf;
 
     if (s->auto_pushed) {
         goto next;
@@ -1818,12 +1720,11 @@ next:
     return next_close_stream(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_record_done(ngx_rtmp_session_t *s, ngx_rtmp_record_done_t *v)
+static ngx_int_t ngx_rtmp_notify_record_done(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_record_done_t *v)
 {
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_rtmp_notify_app_conf_t     *nacf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_rtmp_notify_app_conf_t *nacf;
 
     if (s->auto_pushed) {
         goto next;
@@ -1851,14 +1752,13 @@ next:
     return next_record_done(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_done(ngx_rtmp_session_t *s, char *cbname, ngx_uint_t url_idx)
+static ngx_int_t ngx_rtmp_notify_done(ngx_rtmp_session_t *s, char *cbname,
+                                      ngx_uint_t url_idx)
 {
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_rtmp_notify_done_t          ds;
-    ngx_rtmp_notify_app_conf_t     *nacf;
-    ngx_url_t                      *url;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_rtmp_notify_done_t ds;
+    ngx_rtmp_notify_app_conf_t *nacf;
+    ngx_url_t *url;
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
 
@@ -1867,27 +1767,25 @@ ngx_rtmp_notify_done(ngx_rtmp_session_t *s, char *cbname, ngx_uint_t url_idx)
         return NGX_OK;
     }
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                  "notify: %s '%V'", cbname, &url->url);
+    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "notify: %s '%V'",
+                  cbname, &url->url);
 
-    ds.cbname = (u_char *) cbname;
+    ds.cbname  = (u_char *)cbname;
     ds.url_idx = url_idx;
 
     ngx_memzero(&ci, sizeof(ci));
 
-    ci.url = url;
-    ci.arg = &ds;
+    ci.url    = url;
+    ci.arg    = &ds;
     ci.create = ngx_rtmp_notify_done_create;
 
     return ngx_rtmp_netcall_create(s, &ci);
 }
 
-
-static ngx_url_t *
-ngx_rtmp_notify_parse_url(ngx_conf_t *cf, ngx_str_t *url)
+static ngx_url_t *ngx_rtmp_notify_parse_url(ngx_conf_t *cf, ngx_str_t *url)
 {
-    ngx_url_t  *u;
-    size_t      add;
+    ngx_url_t *u;
+    size_t add;
 
     add = 0;
 
@@ -1896,19 +1794,19 @@ ngx_rtmp_notify_parse_url(ngx_conf_t *cf, ngx_str_t *url)
         return NULL;
     }
 
-    if (ngx_strncasecmp(url->data, (u_char *) "http://", 7) == 0) {
+    if (ngx_strncasecmp(url->data, (u_char *)"http://", 7) == 0) {
         add = 7;
     }
 
-    u->url.len = url->len - add;
-    u->url.data = url->data + add;
+    u->url.len      = url->len - add;
+    u->url.data     = url->data + add;
     u->default_port = 80;
-    u->uri_part = 1;
+    u->uri_part     = 1;
 
     if (ngx_parse_url(cf->pool, u) != NGX_OK) {
         if (u->err) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                    "%s in url \"%V\"", u->err, &u->url);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "%s in url \"%V\"", u->err,
+                               &u->url);
         }
         return NULL;
     }
@@ -1916,12 +1814,11 @@ ngx_rtmp_notify_parse_url(ngx_conf_t *cf, ngx_str_t *url)
     return u;
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_playlist(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v)
+static ngx_int_t ngx_rtmp_notify_playlist(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_playlist_t *v)
 {
-    ngx_rtmp_netcall_init_t         ci;
-    ngx_rtmp_notify_app_conf_t     *nacf;
+    ngx_rtmp_netcall_init_t ci;
+    ngx_rtmp_notify_app_conf_t *nacf;
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
     if (nacf == NULL || nacf->url[NGX_RTMP_NOTIFY_PLAYLIST] == NULL) {
@@ -1944,16 +1841,14 @@ next:
     return next_playlist(s, v);
 }
 
-
-
-static char *
-ngx_rtmp_notify_on_srv_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_notify_on_srv_event(ngx_conf_t *cf, ngx_command_t *cmd,
+                                          void *conf)
 {
-    ngx_rtmp_notify_srv_conf_t     *nscf = conf;
+    ngx_rtmp_notify_srv_conf_t *nscf = conf;
 
-    ngx_str_t                      *name, *value;
-    ngx_url_t                      *u;
-    ngx_uint_t                      n;
+    ngx_str_t *name, *value;
+    ngx_url_t *u;
+    ngx_uint_t n;
 
     value = cf->args->elts;
 
@@ -1967,13 +1862,13 @@ ngx_rtmp_notify_on_srv_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     n = 0;
 
     switch (name->len) {
-        case sizeof("on_connect") - 1:
-            n = NGX_RTMP_NOTIFY_CONNECT;
-            break;
+    case sizeof("on_connect") - 1:
+        n = NGX_RTMP_NOTIFY_CONNECT;
+        break;
 
-        case sizeof("on_disconnect") - 1:
-            n = NGX_RTMP_NOTIFY_DISCONNECT;
-            break;
+    case sizeof("on_disconnect") - 1:
+        n = NGX_RTMP_NOTIFY_DISCONNECT;
+        break;
     }
 
     nscf->url[n] = u;
@@ -1981,15 +1876,14 @@ ngx_rtmp_notify_on_srv_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-
-static char *
-ngx_rtmp_notify_on_app_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_notify_on_app_event(ngx_conf_t *cf, ngx_command_t *cmd,
+                                          void *conf)
 {
-    ngx_rtmp_notify_app_conf_t     *nacf = conf;
+    ngx_rtmp_notify_app_conf_t *nacf = conf;
 
-    ngx_str_t                      *name, *value;
-    ngx_url_t                      *u;
-    ngx_uint_t                      n;
+    ngx_str_t *name, *value;
+    ngx_url_t *u;
+    ngx_uint_t n;
 
     value = cf->args->elts;
 
@@ -2003,37 +1897,37 @@ ngx_rtmp_notify_on_app_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     n = 0;
 
     switch (name->len) {
-        case sizeof("on_done") - 1: /* and on_play */
-            if (name->data[3] == 'd') {
-                n = NGX_RTMP_NOTIFY_DONE;
-            } else {
-                n = NGX_RTMP_NOTIFY_PLAY;
-            }
-            break;
+    case sizeof("on_done") - 1: /* and on_play */
+        if (name->data[3] == 'd') {
+            n = NGX_RTMP_NOTIFY_DONE;
+        } else {
+            n = NGX_RTMP_NOTIFY_PLAY;
+        }
+        break;
 
-        case sizeof("on_update") - 1:
-            n = NGX_RTMP_NOTIFY_UPDATE;
-            break;
+    case sizeof("on_update") - 1:
+        n = NGX_RTMP_NOTIFY_UPDATE;
+        break;
 
-        case sizeof("on_playlist") - 1:
-            n = NGX_RTMP_NOTIFY_PLAYLIST;
-            break;
+    case sizeof("on_playlist") - 1:
+        n = NGX_RTMP_NOTIFY_PLAYLIST;
+        break;
 
-        case sizeof("on_publish") - 1:
-            n = NGX_RTMP_NOTIFY_PUBLISH;
-            break;
+    case sizeof("on_publish") - 1:
+        n = NGX_RTMP_NOTIFY_PUBLISH;
+        break;
 
-        case sizeof("on_play_done") - 1:
-            n = NGX_RTMP_NOTIFY_PLAY_DONE;
-            break;
+    case sizeof("on_play_done") - 1:
+        n = NGX_RTMP_NOTIFY_PLAY_DONE;
+        break;
 
-        case sizeof("on_record_done") - 1:
-            n = NGX_RTMP_NOTIFY_RECORD_DONE;
-            break;
+    case sizeof("on_record_done") - 1:
+        n = NGX_RTMP_NOTIFY_RECORD_DONE;
+        break;
 
-        case sizeof("on_publish_done") - 1:
-            n = NGX_RTMP_NOTIFY_PUBLISH_DONE;
-            break;
+    case sizeof("on_publish_done") - 1:
+        n = NGX_RTMP_NOTIFY_PUBLISH_DONE;
+        break;
     }
 
     nacf->url[n] = u;
@@ -2041,26 +1935,24 @@ ngx_rtmp_notify_on_app_event(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-
-static char *
-ngx_rtmp_notify_method(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_notify_method(ngx_conf_t *cf, ngx_command_t *cmd,
+                                    void *conf)
 {
-    ngx_rtmp_notify_app_conf_t     *nacf = conf;
+    ngx_rtmp_notify_app_conf_t *nacf = conf;
 
-    ngx_rtmp_notify_srv_conf_t     *nscf;
-    ngx_str_t                      *value;
+    ngx_rtmp_notify_srv_conf_t *nscf;
+    ngx_str_t *value;
 
     value = cf->args->elts;
     value++;
 
     if (value->len == sizeof("get") - 1 &&
-        ngx_strncasecmp(value->data, (u_char *) "get", value->len) == 0)
-    {
+        ngx_strncasecmp(value->data, (u_char *)"get", value->len) == 0) {
         nacf->method = NGX_RTMP_NETCALL_HTTP_GET;
 
     } else if (value->len == sizeof("post") - 1 &&
-               ngx_strncasecmp(value->data, (u_char *) "post", value->len) == 0)
-    {
+               ngx_strncasecmp(value->data, (u_char *)"post", value->len) ==
+                   0) {
         nacf->method = NGX_RTMP_NETCALL_HTTP_POST;
 
     } else {
@@ -2073,25 +1965,23 @@ ngx_rtmp_notify_method(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-static char *
-ngx_rtmp_notify_send_redirect(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_notify_send_redirect(ngx_conf_t *cf, ngx_command_t *cmd,
+                                           void *conf)
 {
-    ngx_rtmp_notify_app_conf_t     *nacf = conf;
+    ngx_rtmp_notify_app_conf_t *nacf = conf;
 
-    ngx_rtmp_notify_srv_conf_t     *nscf;
-    ngx_str_t                      *value;
+    ngx_rtmp_notify_srv_conf_t *nscf;
+    ngx_str_t *value;
 
     value = cf->args->elts;
     value++;
 
     if (value->len == sizeof("on") - 1 &&
-        ngx_strncasecmp(value->data, (u_char *) "on", value->len) == 0)
-    {
+        ngx_strncasecmp(value->data, (u_char *)"on", value->len) == 0) {
         nacf->send_redirect = 1;
 
     } else if (value->len == sizeof("off") - 1 &&
-               ngx_strncasecmp(value->data, (u_char *) "off", value->len) == 0)
-    {
+               ngx_strncasecmp(value->data, (u_char *)"off", value->len) == 0) {
         nacf->send_redirect = 0;
 
     } else {
@@ -2104,29 +1994,27 @@ ngx_rtmp_notify_send_redirect(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_notify_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_notify_postconfiguration(ngx_conf_t *cf)
 {
-    next_connect = ngx_rtmp_connect;
+    next_connect     = ngx_rtmp_connect;
     ngx_rtmp_connect = ngx_rtmp_notify_connect;
 
-    next_disconnect = ngx_rtmp_disconnect;
+    next_disconnect     = ngx_rtmp_disconnect;
     ngx_rtmp_disconnect = ngx_rtmp_notify_disconnect;
 
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_notify_publish;
 
-    next_play = ngx_rtmp_play;
+    next_play     = ngx_rtmp_play;
     ngx_rtmp_play = ngx_rtmp_notify_play;
 
-    next_close_stream = ngx_rtmp_close_stream;
+    next_close_stream     = ngx_rtmp_close_stream;
     ngx_rtmp_close_stream = ngx_rtmp_notify_close_stream;
 
-    next_record_done = ngx_rtmp_record_done;
+    next_record_done     = ngx_rtmp_record_done;
     ngx_rtmp_record_done = ngx_rtmp_notify_record_done;
 
-    next_playlist = ngx_rtmp_playlist;
+    next_playlist     = ngx_rtmp_playlist;
     ngx_rtmp_playlist = ngx_rtmp_notify_playlist;
 
     return NGX_OK;

--- a/ngx_rtmp_play_module.h
+++ b/ngx_rtmp_play_module.h
@@ -3,91 +3,80 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_PLAY_H_INCLUDED_
 #define _NGX_RTMP_PLAY_H_INCLUDED_
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_cmd_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
-
-typedef ngx_int_t (*ngx_rtmp_play_init_pt)  (ngx_rtmp_session_t *s,
-        ngx_file_t *f, ngx_int_t aindex, ngx_int_t vindex);
-typedef ngx_int_t (*ngx_rtmp_play_done_pt)  (ngx_rtmp_session_t *s,
-        ngx_file_t *f);
-typedef ngx_int_t (*ngx_rtmp_play_start_pt) (ngx_rtmp_session_t *s,
-        ngx_file_t *f);
-typedef ngx_int_t (*ngx_rtmp_play_seek_pt)  (ngx_rtmp_session_t *s,
-        ngx_file_t *f, ngx_uint_t offs);
-typedef ngx_int_t (*ngx_rtmp_play_stop_pt)  (ngx_rtmp_session_t *s,
-        ngx_file_t *f);
-typedef ngx_int_t (*ngx_rtmp_play_send_pt)  (ngx_rtmp_session_t *s,
-        ngx_file_t *f, ngx_uint_t *ts);
-
+typedef ngx_int_t (*ngx_rtmp_play_init_pt)(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                           ngx_int_t aindex, ngx_int_t vindex);
+typedef ngx_int_t (*ngx_rtmp_play_done_pt)(ngx_rtmp_session_t *s,
+                                           ngx_file_t *f);
+typedef ngx_int_t (*ngx_rtmp_play_start_pt)(ngx_rtmp_session_t *s,
+                                            ngx_file_t *f);
+typedef ngx_int_t (*ngx_rtmp_play_seek_pt)(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                           ngx_uint_t offs);
+typedef ngx_int_t (*ngx_rtmp_play_stop_pt)(ngx_rtmp_session_t *s,
+                                           ngx_file_t *f);
+typedef ngx_int_t (*ngx_rtmp_play_send_pt)(ngx_rtmp_session_t *s, ngx_file_t *f,
+                                           ngx_uint_t *ts);
 
 typedef struct {
-    ngx_str_t               name;
-    ngx_str_t               pfx;
-    ngx_str_t               sfx;
+    ngx_str_t name;
+    ngx_str_t pfx;
+    ngx_str_t sfx;
 
-    ngx_rtmp_play_init_pt   init;
-    ngx_rtmp_play_done_pt   done;
-    ngx_rtmp_play_start_pt  start;
-    ngx_rtmp_play_seek_pt   seek;
-    ngx_rtmp_play_stop_pt   stop;
-    ngx_rtmp_play_send_pt   send;
+    ngx_rtmp_play_init_pt init;
+    ngx_rtmp_play_done_pt done;
+    ngx_rtmp_play_start_pt start;
+    ngx_rtmp_play_seek_pt seek;
+    ngx_rtmp_play_stop_pt stop;
+    ngx_rtmp_play_send_pt send;
 } ngx_rtmp_play_fmt_t;
-
 
 typedef struct ngx_rtmp_play_ctx_s ngx_rtmp_play_ctx_t;
 
-
 struct ngx_rtmp_play_ctx_s {
-    ngx_rtmp_session_t     *session;
-    ngx_file_t              file;
-    ngx_rtmp_play_fmt_t    *fmt;
-    ngx_event_t             send_evt;
-    unsigned                playing:1;
-    unsigned                opened:1;
-    unsigned                joined:1;
-    ngx_uint_t              ncrs;
-    ngx_uint_t              nheader;
-    ngx_uint_t              nbody;
-    size_t                  pfx_size;
-    ngx_str_t               sfx;
-    ngx_uint_t              file_id;
-    ngx_int_t               aindex, vindex;
-    ngx_uint_t              nentry;
-    ngx_uint_t              post_seek;
-    u_char                  name[NGX_RTMP_MAX_NAME];
-    ngx_rtmp_play_ctx_t    *next;
+    ngx_rtmp_session_t *session;
+    ngx_file_t file;
+    ngx_rtmp_play_fmt_t *fmt;
+    ngx_event_t send_evt;
+    unsigned playing : 1;
+    unsigned opened : 1;
+    unsigned joined : 1;
+    ngx_uint_t ncrs;
+    ngx_uint_t nheader;
+    ngx_uint_t nbody;
+    size_t pfx_size;
+    ngx_str_t sfx;
+    ngx_uint_t file_id;
+    ngx_int_t aindex, vindex;
+    ngx_uint_t nentry;
+    ngx_uint_t post_seek;
+    u_char name[NGX_RTMP_MAX_NAME];
+    ngx_rtmp_play_ctx_t *next;
 };
 
-
 typedef struct {
-    ngx_str_t              *root;
-    ngx_url_t              *url;
+    ngx_str_t *root;
+    ngx_url_t *url;
 } ngx_rtmp_play_entry_t;
 
-
 typedef struct {
-    ngx_str_t               temp_path;
-    ngx_str_t               local_path;
-    ngx_array_t             entries; /* ngx_rtmp_play_entry_t * */
-    ngx_uint_t              nbuckets;
-    ngx_rtmp_play_ctx_t   **ctx;
+    ngx_str_t temp_path;
+    ngx_str_t local_path;
+    ngx_array_t entries; /* ngx_rtmp_play_entry_t * */
+    ngx_uint_t nbuckets;
+    ngx_rtmp_play_ctx_t **ctx;
 } ngx_rtmp_play_app_conf_t;
 
-
 typedef struct {
-    ngx_array_t             fmts; /* ngx_rtmp_play_fmt_t * */
+    ngx_array_t fmts; /* ngx_rtmp_play_fmt_t * */
 } ngx_rtmp_play_main_conf_t;
 
-
-extern ngx_module_t         ngx_rtmp_play_module;
-
+extern ngx_module_t ngx_rtmp_play_module;
 
 #endif /* _NGX_RTMP_PLAY_H_INCLUDED_ */

--- a/ngx_rtmp_proxy_protocol.h
+++ b/ngx_rtmp_proxy_protocol.h
@@ -3,17 +3,13 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_PROXY_PROTOCOL_H_INCLUDED_
 #define _NGX_RTMP_PROXY_PROTOCOL_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-
 
 void ngx_rtmp_proxy_protocol(ngx_rtmp_session_t *c);
-
 
 #endif /* _NGX_RTMP_PROXY_PROTOCOL_H_INCLUDED_ */

--- a/ngx_rtmp_receive.c
+++ b/ngx_rtmp_receive.c
@@ -3,94 +3,89 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_amf.h"
 #include "ngx_rtmp_cmd_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <string.h>
 
-
-ngx_int_t
-ngx_rtmp_protocol_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in)
+ngx_int_t ngx_rtmp_protocol_message_handler(ngx_rtmp_session_t *s,
+                                            ngx_rtmp_header_t *h,
+                                            ngx_chain_t *in)
 {
-    ngx_buf_t              *b;
-    u_char                 *p;
-    uint32_t                val;
-    uint8_t                 limit;
+    ngx_buf_t *b;
+    u_char *p;
+    uint32_t val;
+    uint8_t limit;
 
     b = in->buf;
 
     if (b->last - b->pos < 4) {
         ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "too small buffer for %d message: %d",
-                (int)h->type, b->last - b->pos);
+                       "too small buffer for %d message: %d", (int)h->type,
+                       b->last - b->pos);
         return NGX_OK;
     }
 
-    p = (u_char*)&val;
+    p    = (u_char *)&val;
     p[0] = b->pos[3];
     p[1] = b->pos[2];
     p[2] = b->pos[1];
     p[3] = b->pos[0];
 
-    switch(h->type) {
-        case NGX_RTMP_MSG_CHUNK_SIZE:
-            /* set chunk size =val */
-            ngx_rtmp_set_chunk_size(s, val);
-            break;
+    switch (h->type) {
+    case NGX_RTMP_MSG_CHUNK_SIZE:
+        /* set chunk size =val */
+        ngx_rtmp_set_chunk_size(s, val);
+        break;
 
-        case NGX_RTMP_MSG_ABORT:
-            /* abort chunk stream =val */
-            break;
+    case NGX_RTMP_MSG_ABORT:
+        /* abort chunk stream =val */
+        break;
 
-        case NGX_RTMP_MSG_ACK:
-            /* receive ack with sequence number =val */
-            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "receive ack seq=%uD", val);
-            break;
+    case NGX_RTMP_MSG_ACK:
+        /* receive ack with sequence number =val */
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive ack seq=%uD", val);
+        break;
 
-        case NGX_RTMP_MSG_ACK_SIZE:
-            /* receive window size =val */
-            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "receive ack_size=%uD", val);
-            s->ack_size = val;
-            break;
+    case NGX_RTMP_MSG_ACK_SIZE:
+        /* receive window size =val */
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive ack_size=%uD", val);
+        s->ack_size = val;
+        break;
 
-        case NGX_RTMP_MSG_BANDWIDTH:
-            if (b->last - b->pos >= 5) {
-                limit = *(uint8_t*)&b->pos[4];
+    case NGX_RTMP_MSG_BANDWIDTH:
+        if (b->last - b->pos >= 5) {
+            limit = *(uint8_t *)&b->pos[4];
 
-                (void)val;
-                (void)limit;
+            (void)val;
+            (void)limit;
 
-                ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                    "receive bandwidth=%uD limit=%d",
-                    val, (int)limit);
+            ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                           "receive bandwidth=%uD limit=%d", val, (int)limit);
 
-                /* receive window size =val
-                 * && limit */
-            }
-            break;
+            /* receive window size =val
+             * && limit */
+        }
+        break;
 
-        default:
-            return NGX_ERROR;
+    default:
+        return NGX_ERROR;
     }
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_user_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                              ngx_chain_t *in)
+ngx_int_t ngx_rtmp_user_message_handler(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_buf_t              *b;
-    u_char                 *p;
-    uint16_t                evt;
-    uint32_t                val;
+    ngx_buf_t *b;
+    u_char *p;
+    uint16_t evt;
+    uint32_t val;
 
     b = in->buf;
 
@@ -101,120 +96,113 @@ ngx_rtmp_user_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         return NGX_OK;
     }
 
-    p = (u_char*)&evt;
+    p = (u_char *)&evt;
 
     p[0] = b->pos[1];
     p[1] = b->pos[0];
 
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "RTMP recv user evt %s (%i)",
-                   ngx_rtmp_user_message_type(evt), (ngx_int_t) evt);
+                   ngx_rtmp_user_message_type(evt), (ngx_int_t)evt);
 
-    p = (u_char *) &val;
+    p = (u_char *)&val;
 
     p[0] = b->pos[5];
     p[1] = b->pos[4];
     p[2] = b->pos[3];
     p[3] = b->pos[2];
 
-    switch(evt) {
-        case NGX_RTMP_USER_STREAM_BEGIN:
-            {
-                ngx_rtmp_stream_begin_t     v;
+    switch (evt) {
+    case NGX_RTMP_USER_STREAM_BEGIN: {
+        ngx_rtmp_stream_begin_t v;
 
-                v.msid = val;
+        v.msid = val;
 
-                ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "receive: stream_begin msid=%uD", v.msid);
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive: stream_begin msid=%uD", v.msid);
 
-                return ngx_rtmp_stream_begin(s, &v);
-            }
+        return ngx_rtmp_stream_begin(s, &v);
+    }
 
-        case NGX_RTMP_USER_STREAM_EOF:
-            {
-                ngx_rtmp_stream_eof_t       v;
+    case NGX_RTMP_USER_STREAM_EOF: {
+        ngx_rtmp_stream_eof_t v;
 
-                v.msid = val;
+        v.msid = val;
 
-                ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "receive: stream_eof msid=%uD", v.msid);
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive: stream_eof msid=%uD", v.msid);
 
-                return ngx_rtmp_stream_eof(s, &v);
-            }
+        return ngx_rtmp_stream_eof(s, &v);
+    }
 
-        case NGX_RTMP_USER_STREAM_DRY:
-            {
-                ngx_rtmp_stream_dry_t       v;
+    case NGX_RTMP_USER_STREAM_DRY: {
+        ngx_rtmp_stream_dry_t v;
 
-                v.msid = val;
+        v.msid = val;
 
-                ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "receive: stream_dry msid=%uD", v.msid);
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive: stream_dry msid=%uD", v.msid);
 
-                return ngx_rtmp_stream_dry(s, &v);
-            }
+        return ngx_rtmp_stream_dry(s, &v);
+    }
 
-        case NGX_RTMP_USER_SET_BUFLEN:
-            {
-                ngx_rtmp_set_buflen_t       v;
+    case NGX_RTMP_USER_SET_BUFLEN: {
+        ngx_rtmp_set_buflen_t v;
 
-                v.msid = val;
+        v.msid = val;
 
-                if (b->last - b->pos < 10) {
-                    return NGX_OK;
-                }
-
-                p = (u_char *) &v.buflen;
-
-                p[0] = b->pos[9];
-                p[1] = b->pos[8];
-                p[2] = b->pos[7];
-                p[3] = b->pos[6];
-
-                ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "receive: set_buflen msid=%uD buflen=%uD",
-                               v.msid, v.buflen);
-
-                /*TODO: move this to play module */
-                s->buflen = v.buflen;
-
-                return ngx_rtmp_set_buflen(s, &v);
-            }
-
-        case NGX_RTMP_USER_RECORDED:
-            {
-                ngx_rtmp_recorded_t       v;
-
-                v.msid = val;
-
-                ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "receive: recorded msid=%uD", v.msid);
-
-                return ngx_rtmp_recorded(s, &v);
-            }
-
-        case NGX_RTMP_USER_PING_REQUEST:
-            return ngx_rtmp_send_ping_response(s, val);
-
-        case NGX_RTMP_USER_PING_RESPONSE:
-
-            /* val = incoming timestamp */
-
-            ngx_rtmp_reset_ping(s);
-
+        if (b->last - b->pos < 10) {
             return NGX_OK;
+        }
 
-        default:
-            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                           "unexpected user event: %i", (ngx_int_t) evt);
+        p = (u_char *)&v.buflen;
 
-            return NGX_OK;
+        p[0] = b->pos[9];
+        p[1] = b->pos[8];
+        p[2] = b->pos[7];
+        p[3] = b->pos[6];
+
+        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive: set_buflen msid=%uD buflen=%uD", v.msid,
+                       v.buflen);
+
+        /*TODO: move this to play module */
+        s->buflen = v.buflen;
+
+        return ngx_rtmp_set_buflen(s, &v);
+    }
+
+    case NGX_RTMP_USER_RECORDED: {
+        ngx_rtmp_recorded_t v;
+
+        v.msid = val;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "receive: recorded msid=%uD", v.msid);
+
+        return ngx_rtmp_recorded(s, &v);
+    }
+
+    case NGX_RTMP_USER_PING_REQUEST:
+        return ngx_rtmp_send_ping_response(s, val);
+
+    case NGX_RTMP_USER_PING_RESPONSE:
+
+        /* val = incoming timestamp */
+
+        ngx_rtmp_reset_ping(s);
+
+        return NGX_OK;
+
+    default:
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                       "unexpected user event: %i", (ngx_int_t)evt);
+
+        return NGX_OK;
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_fetch(ngx_chain_t **in, u_char *ret)
+static ngx_int_t ngx_rtmp_fetch(ngx_chain_t **in, u_char *ret)
 {
     while (*in && (*in)->buf->pos >= (*in)->buf->last) {
         *in = (*in)->next;
@@ -229,19 +217,16 @@ ngx_rtmp_fetch(ngx_chain_t **in, u_char *ret)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_fetch_uint8(ngx_chain_t **in, uint8_t *ret)
+static ngx_int_t ngx_rtmp_fetch_uint8(ngx_chain_t **in, uint8_t *ret)
 {
-    return ngx_rtmp_fetch(in, (u_char *) ret);
+    return ngx_rtmp_fetch(in, (u_char *)ret);
 }
 
-
-static ngx_int_t
-ngx_rtmp_fetch_uint32(ngx_chain_t **in, uint32_t *ret, ngx_int_t n)
+static ngx_int_t ngx_rtmp_fetch_uint32(ngx_chain_t **in, uint32_t *ret,
+                                       ngx_int_t n)
 {
-    u_char     *r = (u_char *) ret;
-    ngx_int_t   rc;
+    u_char *r = (u_char *)ret;
+    ngx_int_t rc;
 
     *ret = 0;
 
@@ -255,23 +240,22 @@ ngx_rtmp_fetch_uint32(ngx_chain_t **in, uint32_t *ret, ngx_int_t n)
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                                   ngx_chain_t *in)
+ngx_int_t ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_header_t *h,
+                                             ngx_chain_t *in)
 {
-    uint32_t            base_time, timestamp, prev_size;
-    size_t              len;
-    ngx_int_t           first;
-    u_char             *last;
-    ngx_int_t           rc;
-    ngx_buf_t          *b;
-    ngx_chain_t        *cl, *next;
-    ngx_rtmp_header_t   ch;
+    uint32_t base_time, timestamp, prev_size;
+    size_t len;
+    ngx_int_t first;
+    u_char *last;
+    ngx_int_t rc;
+    ngx_buf_t *b;
+    ngx_chain_t *cl, *next;
+    ngx_rtmp_header_t ch;
 
     ch = *h;
 
-    first = 1;
+    first     = 1;
     base_time = 0;
 
     while (in) {
@@ -287,31 +271,28 @@ ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
             return NGX_ERROR;
         }
 
-        if (ngx_rtmp_fetch_uint8(&in, (uint8_t *) &timestamp + 3) != NGX_OK)
-        {
+        if (ngx_rtmp_fetch_uint8(&in, (uint8_t *)&timestamp + 3) != NGX_OK) {
             return NGX_ERROR;
         }
 
-        if (ngx_rtmp_fetch_uint32(&in, &ch.msid, 3) != NGX_OK)
-        {
+        if (ngx_rtmp_fetch_uint32(&in, &ch.msid, 3) != NGX_OK) {
             return NGX_ERROR;
         }
 
         if (first) {
             base_time = timestamp;
-            first = 0;
+            first     = 0;
         }
 
         ngx_log_debug6(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                        "RTMP aggregate %s (%d) len=%uD time=%uD (+%D) msid=%uD",
-                       ngx_rtmp_message_type(ch.type),
-                       (ngx_int_t) ch.type, ch.mlen, ch.timestamp,
-                       timestamp - base_time, ch.msid);
+                       ngx_rtmp_message_type(ch.type), (ngx_int_t)ch.type,
+                       ch.mlen, ch.timestamp, timestamp - base_time, ch.msid);
 
         /* limit chain */
 
         len = 0;
-        cl = in;
+        cl  = in;
         while (cl) {
             b = cl->buf;
             len += (b->last - b->pos);
@@ -327,10 +308,10 @@ ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
             return NGX_ERROR;
         }
 
-        next = cl->next;
+        next     = cl->next;
         cl->next = NULL;
-        b = cl->buf;
-        last = b->last;
+        b        = cl->buf;
+        last     = b->last;
         b->last -= (len - ch.mlen);
 
         /* handle aggregated message */
@@ -341,10 +322,10 @@ ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
         /* restore chain before checking the result */
 
-        in = cl;
+        in       = cl;
         in->next = next;
-        b->pos = b->last;
-        b->last = last;
+        b->pos   = b->last;
+        b->last  = last;
 
         if (rc != NGX_OK) {
             return rc;
@@ -363,31 +344,26 @@ ngx_rtmp_aggregate_message_handler(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
-        ngx_rtmp_header_t *h, ngx_chain_t *in)
+ngx_int_t ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
+                                       ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_amf_ctx_t          act;
-    ngx_rtmp_core_main_conf_t  *cmcf;
-    ngx_array_t                *ch;
-    ngx_rtmp_handler_pt        *ph;
-    size_t                      len, n;
+    ngx_rtmp_amf_ctx_t act;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_array_t *ch;
+    ngx_rtmp_handler_pt *ph;
+    size_t len, n;
 
-    static u_char               func[128];
+    static u_char func[128];
 
-    static ngx_rtmp_amf_elt_t   elts[] = {
+    static ngx_rtmp_amf_elt_t elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          func,   sizeof(func) },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, func, sizeof(func)},
     };
 
     /* AMF command names come with string type, but shared object names
      * come without type */
     if (h->type == NGX_RTMP_MSG_AMF_SHARED ||
-        h->type == NGX_RTMP_MSG_AMF3_SHARED)
-    {
+        h->type == NGX_RTMP_MSG_AMF3_SHARED) {
         elts[0].type |= NGX_RTMP_AMF_TYPELESS;
     } else {
         elts[0].type &= ~NGX_RTMP_AMF_TYPELESS;
@@ -395,11 +371,10 @@ ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
 
     if ((h->type == NGX_RTMP_MSG_AMF3_SHARED ||
          h->type == NGX_RTMP_MSG_AMF3_META ||
-         h->type == NGX_RTMP_MSG_AMF3_CMD)
-         && in->buf->last > in->buf->pos)
-    {
+         h->type == NGX_RTMP_MSG_AMF3_CMD) &&
+        in->buf->last > in->buf->pos) {
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "AMF3 prefix: %ui", (ngx_int_t)*in->buf->pos);
+                       "AMF3 prefix: %ui", (ngx_int_t)*in->buf->pos);
         ++in->buf->pos;
     }
 
@@ -408,14 +383,13 @@ ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
     /* read AMF func name & transaction id */
     ngx_memzero(&act, sizeof(act));
     act.link = in;
-    act.log = s->connection->log;
+    act.log  = s->connection->log;
     memset(func, 0, sizeof(func));
 
-    if (ngx_rtmp_amf_read(&act, elts,
-                sizeof(elts) / sizeof(elts[0])) != NGX_OK)
-    {
+    if (ngx_rtmp_amf_read(&act, elts, sizeof(elts) / sizeof(elts[0])) !=
+        NGX_OK) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "AMF cmd failed");
+                       "AMF cmd failed");
         return NGX_ERROR;
     }
 
@@ -425,40 +399,38 @@ ngx_rtmp_amf_message_handler(ngx_rtmp_session_t *s,
 
     len = ngx_strlen(func);
 
-    ch = ngx_hash_find(&cmcf->amf_hash,
-            ngx_hash_strlow(func, func, len), func, len);
+    ch = ngx_hash_find(&cmcf->amf_hash, ngx_hash_strlow(func, func, len), func,
+                       len);
 
     if (ch && ch->nelts) {
         ph = ch->elts;
         for (n = 0; n < ch->nelts; ++n, ++ph) {
             ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "AMF func '%s' passed to handler %d/%d",
-                func, n, ch->nelts);
+                           "AMF func '%s' passed to handler %d/%d", func, n,
+                           ch->nelts);
             switch ((*ph)(s, h, in)) {
-                case NGX_ERROR:
-                    return NGX_ERROR;
-                case NGX_DONE:
-                    return NGX_OK;
+            case NGX_ERROR:
+                return NGX_ERROR;
+            case NGX_DONE:
+                return NGX_OK;
             }
         }
     } else {
         ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "AMF cmd '%s' no handler", func);
+                       "AMF cmd '%s' no handler", func);
     }
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_receive_amf(ngx_rtmp_session_t *s, ngx_chain_t *in,
-        ngx_rtmp_amf_elt_t *elts, size_t nelts)
+ngx_int_t ngx_rtmp_receive_amf(ngx_rtmp_session_t *s, ngx_chain_t *in,
+                               ngx_rtmp_amf_elt_t *elts, size_t nelts)
 {
-    ngx_rtmp_amf_ctx_t     act;
+    ngx_rtmp_amf_ctx_t act;
 
     ngx_memzero(&act, sizeof(act));
     act.link = in;
-    act.log = s->connection->log;
+    act.log  = s->connection->log;
 
     return ngx_rtmp_amf_read(&act, elts, nelts);
 }

--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -3,95 +3,83 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_RECORD_H_INCLUDED_
 #define _NGX_RTMP_RECORD_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
 
-
-#define NGX_RTMP_RECORD_OFF             0x01
-#define NGX_RTMP_RECORD_AUDIO           0x02
-#define NGX_RTMP_RECORD_VIDEO           0x04
-#define NGX_RTMP_RECORD_DATA            0x08
-#define NGX_RTMP_RECORD_KEYFRAMES       0x10
-#define NGX_RTMP_RECORD_MANUAL          0x20
+#define NGX_RTMP_RECORD_OFF 0x01
+#define NGX_RTMP_RECORD_AUDIO 0x02
+#define NGX_RTMP_RECORD_VIDEO 0x04
+#define NGX_RTMP_RECORD_DATA 0x08
+#define NGX_RTMP_RECORD_KEYFRAMES 0x10
+#define NGX_RTMP_RECORD_MANUAL 0x20
 
 typedef struct {
-    ngx_str_t                           id;
-    ngx_uint_t                          flags;
-    ngx_str_t                           path;
-    size_t                              max_size;
-    size_t                              interval_size;
-    size_t                              max_frames;
-    ngx_msec_t                          interval;
-    ngx_str_t                           suffix;
-    ngx_flag_t                          unique;
-    ngx_flag_t                          append;
-    ngx_flag_t                          lock_file;
-    ngx_flag_t                          notify;
-    ngx_url_t                          *url;
+    ngx_str_t id;
+    ngx_uint_t flags;
+    ngx_str_t path;
+    size_t max_size;
+    size_t interval_size;
+    size_t max_frames;
+    ngx_msec_t interval;
+    ngx_str_t suffix;
+    ngx_flag_t unique;
+    ngx_flag_t append;
+    ngx_flag_t lock_file;
+    ngx_flag_t notify;
+    ngx_url_t *url;
 
-    void                              **rec_conf;
-    ngx_array_t                         rec; /* ngx_rtmp_record_app_conf_t * */
+    void **rec_conf;
+    ngx_array_t rec; /* ngx_rtmp_record_app_conf_t * */
 } ngx_rtmp_record_app_conf_t;
 
-
 typedef struct {
-    ngx_rtmp_record_app_conf_t         *conf;
-    ngx_file_t                          file;
-    ngx_uint_t                          nframes;
-    uint32_t                            epoch, time_shift;
-    ngx_time_t                          last;
-    time_t                              timestamp;
-    unsigned                            failed:1;
-    unsigned                            initialized:1;
-    unsigned                            aac_header_sent:1;
-    unsigned                            avc_header_sent:1;
-    unsigned                            video_key_sent:1;
-    unsigned                            audio:1;
-    unsigned                            video:1;
+    ngx_rtmp_record_app_conf_t *conf;
+    ngx_file_t file;
+    ngx_uint_t nframes;
+    uint32_t epoch, time_shift;
+    ngx_time_t last;
+    time_t timestamp;
+    unsigned failed : 1;
+    unsigned initialized : 1;
+    unsigned aac_header_sent : 1;
+    unsigned avc_header_sent : 1;
+    unsigned video_key_sent : 1;
+    unsigned audio : 1;
+    unsigned video : 1;
 } ngx_rtmp_record_rec_ctx_t;
 
-
 typedef struct {
-    ngx_array_t                         rec; /* ngx_rtmp_record_rec_ctx_t */
-    u_char                              name[NGX_RTMP_MAX_NAME];
-    u_char                              args[NGX_RTMP_MAX_ARGS];
+    ngx_array_t rec; /* ngx_rtmp_record_rec_ctx_t */
+    u_char name[NGX_RTMP_MAX_NAME];
+    u_char args[NGX_RTMP_MAX_ARGS];
 } ngx_rtmp_record_ctx_t;
 
-
 ngx_uint_t ngx_rtmp_record_find(ngx_rtmp_record_app_conf_t *racf,
-           ngx_str_t *id);
-
+                                ngx_str_t *id);
 
 /* Manual recording control,
  * 'n' is record node index in config array.
  * Note: these functions allocate path in static buffer */
 
 ngx_int_t ngx_rtmp_record_open(ngx_rtmp_session_t *s, ngx_uint_t n,
-          ngx_str_t *path);
+                               ngx_str_t *path);
 ngx_int_t ngx_rtmp_record_close(ngx_rtmp_session_t *s, ngx_uint_t n,
-          ngx_str_t *path);
-
+                                ngx_str_t *path);
 
 typedef struct {
-    ngx_str_t                           recorder;
-    ngx_str_t                           path;
+    ngx_str_t recorder;
+    ngx_str_t path;
 } ngx_rtmp_record_done_t;
 
-
 typedef ngx_int_t (*ngx_rtmp_record_done_pt)(ngx_rtmp_session_t *s,
-        ngx_rtmp_record_done_t *v);
+                                             ngx_rtmp_record_done_t *v);
 
+extern ngx_rtmp_record_done_pt ngx_rtmp_record_done;
 
-extern ngx_rtmp_record_done_pt          ngx_rtmp_record_done;
-
-
-extern ngx_module_t                     ngx_rtmp_record_module;
-
+extern ngx_module_t ngx_rtmp_record_module;
 
 #endif /* _NGX_RTMP_RECORD_H_INCLUDED_ */

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -3,33 +3,29 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp_relay_module.h"
 #include "ngx_rtmp_cmd_module.h"
 #include "ngx_rtmp_codec_module.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
-
-static ngx_rtmp_publish_pt          next_publish;
-static ngx_rtmp_play_pt             next_play;
-static ngx_rtmp_delete_stream_pt    next_delete_stream;
-static ngx_rtmp_close_stream_pt     next_close_stream;
-
+static ngx_rtmp_publish_pt next_publish;
+static ngx_rtmp_play_pt next_play;
+static ngx_rtmp_delete_stream_pt next_delete_stream;
+static ngx_rtmp_close_stream_pt next_close_stream;
 
 static ngx_int_t ngx_rtmp_relay_init_process(ngx_cycle_t *cycle);
 static ngx_int_t ngx_rtmp_relay_postconfiguration(ngx_conf_t *cf);
-static void * ngx_rtmp_relay_create_app_conf(ngx_conf_t *cf);
-static char * ngx_rtmp_relay_merge_app_conf(ngx_conf_t *cf,
-       void *parent, void *child);
-static char * ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd,
-       void *conf);
+static void *ngx_rtmp_relay_create_app_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_relay_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                           void *child);
+static char *ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd,
+                                      void *conf);
 static ngx_int_t ngx_rtmp_relay_publish(ngx_rtmp_session_t *s,
-       ngx_rtmp_publish_t *v);
-static ngx_rtmp_relay_ctx_t * ngx_rtmp_relay_create_connection(
-       ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
-       ngx_rtmp_relay_target_t *target);
-
+                                        ngx_rtmp_publish_t *v);
+static ngx_rtmp_relay_ctx_t *
+ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t *name,
+                                 ngx_rtmp_relay_target_t *target);
 
 /*                _____
  * =push=        |     |---publish--->
@@ -44,122 +40,93 @@ static ngx_rtmp_relay_ctx_t * ngx_rtmp_relay_create_connection(
  *     (next)     -----
  */
 
-
 typedef struct {
-    ngx_array_t                 pulls;         /* ngx_rtmp_relay_target_t * */
-    ngx_array_t                 pushes;        /* ngx_rtmp_relay_target_t * */
-    ngx_array_t                 static_pulls;  /* ngx_rtmp_relay_target_t * */
-    ngx_array_t                 static_events; /* ngx_event_t * */
-    ngx_log_t                  *log;
-    ngx_uint_t                  nbuckets;
-    ngx_msec_t                  buflen;
-    ngx_flag_t                  session_relay;
-    ngx_msec_t                  push_reconnect;
-    ngx_msec_t                  pull_reconnect;
-    ngx_rtmp_relay_ctx_t        **ctx;
+    ngx_array_t pulls;         /* ngx_rtmp_relay_target_t * */
+    ngx_array_t pushes;        /* ngx_rtmp_relay_target_t * */
+    ngx_array_t static_pulls;  /* ngx_rtmp_relay_target_t * */
+    ngx_array_t static_events; /* ngx_event_t * */
+    ngx_log_t *log;
+    ngx_uint_t nbuckets;
+    ngx_msec_t buflen;
+    ngx_flag_t session_relay;
+    ngx_msec_t push_reconnect;
+    ngx_msec_t pull_reconnect;
+    ngx_rtmp_relay_ctx_t **ctx;
 } ngx_rtmp_relay_app_conf_t;
 
-
 typedef struct {
-    ngx_rtmp_conf_ctx_t         cctx;
-    ngx_rtmp_relay_target_t    *target;
+    ngx_rtmp_conf_ctx_t cctx;
+    ngx_rtmp_relay_target_t *target;
 } ngx_rtmp_relay_static_t;
 
+#define NGX_RTMP_RELAY_CONNECT_TRANS 1
+#define NGX_RTMP_RELAY_CREATE_STREAM_TRANS 2
 
-#define NGX_RTMP_RELAY_CONNECT_TRANS            1
-#define NGX_RTMP_RELAY_CREATE_STREAM_TRANS      2
-
-
-#define NGX_RTMP_RELAY_CSID_AMF_INI             3
-#define NGX_RTMP_RELAY_CSID_AMF                 5
-#define NGX_RTMP_RELAY_MSID                     1
-
+#define NGX_RTMP_RELAY_CSID_AMF_INI 3
+#define NGX_RTMP_RELAY_CSID_AMF 5
+#define NGX_RTMP_RELAY_MSID 1
 
 /* default flashVer */
-#define NGX_RTMP_RELAY_FLASHVER                 "LNX.11,1,102,55"
+#define NGX_RTMP_RELAY_FLASHVER "LNX.11,1,102,55"
 
+static ngx_command_t ngx_rtmp_relay_commands[] = {
 
-static ngx_command_t  ngx_rtmp_relay_commands[] = {
+    {ngx_string("push"), NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_relay_push_pull, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("push"),
-      NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_relay_push_pull,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("pull"), NGX_RTMP_APP_CONF | NGX_CONF_1MORE,
+     ngx_rtmp_relay_push_pull, NGX_RTMP_APP_CONF_OFFSET, 0, NULL},
 
-    { ngx_string("pull"),
-      NGX_RTMP_APP_CONF|NGX_CONF_1MORE,
-      ngx_rtmp_relay_push_pull,
-      NGX_RTMP_APP_CONF_OFFSET,
-      0,
-      NULL },
+    {ngx_string("relay_buffer"),
+     NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_relay_app_conf_t, buflen), NULL},
 
-    { ngx_string("relay_buffer"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_relay_app_conf_t, buflen),
-      NULL },
+    {ngx_string("push_reconnect"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                       NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_relay_app_conf_t, push_reconnect), NULL},
 
-    { ngx_string("push_reconnect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_relay_app_conf_t, push_reconnect),
-      NULL },
+    {ngx_string("pull_reconnect"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                       NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_msec_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_relay_app_conf_t, pull_reconnect), NULL},
 
-    { ngx_string("pull_reconnect"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_relay_app_conf_t, pull_reconnect),
-      NULL },
+    {ngx_string("session_relay"), NGX_RTMP_MAIN_CONF | NGX_RTMP_SRV_CONF |
+                                      NGX_RTMP_APP_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_RTMP_APP_CONF_OFFSET,
+     offsetof(ngx_rtmp_relay_app_conf_t, session_relay), NULL},
 
-    { ngx_string("session_relay"),
-      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
-      NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_relay_app_conf_t, session_relay),
-      NULL },
+    ngx_null_command};
 
-
-      ngx_null_command
+static ngx_rtmp_module_t ngx_rtmp_relay_module_ctx = {
+    NULL,                             /* preconfiguration */
+    ngx_rtmp_relay_postconfiguration, /* postconfiguration */
+    NULL,                             /* create main configuration */
+    NULL,                             /* init main configuration */
+    NULL,                             /* create server configuration */
+    NULL,                             /* merge server configuration */
+    ngx_rtmp_relay_create_app_conf,   /* create app configuration */
+    ngx_rtmp_relay_merge_app_conf     /* merge app configuration */
 };
 
-
-static ngx_rtmp_module_t  ngx_rtmp_relay_module_ctx = {
-    NULL,                                   /* preconfiguration */
-    ngx_rtmp_relay_postconfiguration,       /* postconfiguration */
-    NULL,                                   /* create main configuration */
-    NULL,                                   /* init main configuration */
-    NULL,                                   /* create server configuration */
-    NULL,                                   /* merge server configuration */
-    ngx_rtmp_relay_create_app_conf,         /* create app configuration */
-    ngx_rtmp_relay_merge_app_conf           /* merge app configuration */
-};
-
-
-ngx_module_t  ngx_rtmp_relay_module = {
+ngx_module_t ngx_rtmp_relay_module = {
     NGX_MODULE_V1,
-    &ngx_rtmp_relay_module_ctx,             /* module context */
-    ngx_rtmp_relay_commands,                /* module directives */
-    NGX_RTMP_MODULE,                        /* module type */
-    NULL,                                   /* init master */
-    NULL,                                   /* init module */
-    ngx_rtmp_relay_init_process,            /* init process */
-    NULL,                                   /* init thread */
-    NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
-    NULL,                                   /* exit master */
-    NGX_MODULE_V1_PADDING
-};
+    &ngx_rtmp_relay_module_ctx,  /* module context */
+    ngx_rtmp_relay_commands,     /* module directives */
+    NGX_RTMP_MODULE,             /* module type */
+    NULL,                        /* init master */
+    NULL,                        /* init module */
+    ngx_rtmp_relay_init_process, /* init process */
+    NULL,                        /* init thread */
+    NULL,                        /* exit thread */
+    NULL,                        /* exit process */
+    NULL,                        /* exit master */
+    NGX_MODULE_V1_PADDING};
 
-
-static void *
-ngx_rtmp_relay_create_app_conf(ngx_conf_t *cf)
+static void *ngx_rtmp_relay_create_app_conf(ngx_conf_t *cf)
 {
-    ngx_rtmp_relay_app_conf_t     *racf;
+    ngx_rtmp_relay_app_conf_t *racf;
 
     racf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_relay_app_conf_t));
     if (racf == NULL) {
@@ -174,56 +141,49 @@ ngx_rtmp_relay_create_app_conf(ngx_conf_t *cf)
         return NULL;
     }
 
-    if (ngx_array_init(&racf->static_pulls, cf->pool, 1, sizeof(void *))
-        != NGX_OK)
-    {
+    if (ngx_array_init(&racf->static_pulls, cf->pool, 1, sizeof(void *)) !=
+        NGX_OK) {
         return NULL;
     }
 
-    if (ngx_array_init(&racf->static_events, cf->pool, 1, sizeof(void *))
-        != NGX_OK)
-    {
+    if (ngx_array_init(&racf->static_events, cf->pool, 1, sizeof(void *)) !=
+        NGX_OK) {
         return NULL;
     }
 
-    racf->nbuckets = 1024;
-    racf->log = &cf->cycle->new_log;
-    racf->buflen = NGX_CONF_UNSET_MSEC;
-    racf->session_relay = NGX_CONF_UNSET;
+    racf->nbuckets       = 1024;
+    racf->log            = &cf->cycle->new_log;
+    racf->buflen         = NGX_CONF_UNSET_MSEC;
+    racf->session_relay  = NGX_CONF_UNSET;
     racf->push_reconnect = NGX_CONF_UNSET_MSEC;
     racf->pull_reconnect = NGX_CONF_UNSET_MSEC;
 
     return racf;
 }
 
-
-static char *
-ngx_rtmp_relay_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
+static char *ngx_rtmp_relay_merge_app_conf(ngx_conf_t *cf, void *parent,
+                                           void *child)
 {
-    ngx_rtmp_relay_app_conf_t  *prev = parent;
-    ngx_rtmp_relay_app_conf_t  *conf = child;
+    ngx_rtmp_relay_app_conf_t *prev = parent;
+    ngx_rtmp_relay_app_conf_t *conf = child;
 
-    conf->ctx = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_relay_ctx_t *)
-            * conf->nbuckets);
+    conf->ctx =
+        ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_relay_ctx_t *) * conf->nbuckets);
 
     ngx_conf_merge_value(conf->session_relay, prev->session_relay, 0);
     ngx_conf_merge_msec_value(conf->buflen, prev->buflen, 5000);
-    ngx_conf_merge_msec_value(conf->push_reconnect, prev->push_reconnect,
-            3000);
-    ngx_conf_merge_msec_value(conf->pull_reconnect, prev->pull_reconnect,
-            3000);
+    ngx_conf_merge_msec_value(conf->push_reconnect, prev->push_reconnect, 3000);
+    ngx_conf_merge_msec_value(conf->pull_reconnect, prev->pull_reconnect, 3000);
 
     return NGX_CONF_OK;
 }
 
-
-static void
-ngx_rtmp_relay_static_pull_reconnect(ngx_event_t *ev)
+static void ngx_rtmp_relay_static_pull_reconnect(ngx_event_t *ev)
 {
-    ngx_rtmp_relay_static_t    *rs = ev->data;
+    ngx_rtmp_relay_static_t *rs = ev->data;
 
-    ngx_rtmp_relay_ctx_t       *ctx;
-    ngx_rtmp_relay_app_conf_t  *racf;
+    ngx_rtmp_relay_ctx_t *ctx;
+    ngx_rtmp_relay_app_conf_t *racf;
 
     racf = ngx_rtmp_get_module_app_conf(&rs->cctx, ngx_rtmp_relay_module);
 
@@ -234,26 +194,24 @@ ngx_rtmp_relay_static_pull_reconnect(ngx_event_t *ev)
                                            rs->target);
     if (ctx) {
         ctx->session->static_relay = 1;
-        ctx->static_evt = ev;
+        ctx->static_evt            = ev;
         return;
     }
 
     ngx_add_timer(ev, racf->pull_reconnect);
 }
 
-
-static void
-ngx_rtmp_relay_push_reconnect(ngx_event_t *ev)
+static void ngx_rtmp_relay_push_reconnect(ngx_event_t *ev)
 {
-    ngx_rtmp_session_t             *s = ev->data;
+    ngx_rtmp_session_t *s = ev->data;
 
-    ngx_rtmp_relay_app_conf_t      *racf;
-    ngx_rtmp_relay_ctx_t           *ctx, *pctx;
-    ngx_uint_t                      n;
-    ngx_rtmp_relay_target_t        *target, **t;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_ctx_t *ctx, *pctx;
+    ngx_uint_t n;
+    ngx_rtmp_relay_target_t *target, **t;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "relay: push reconnect");
+                   "relay: push reconnect");
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_relay_module);
 
@@ -266,16 +224,14 @@ ngx_rtmp_relay_push_reconnect(ngx_event_t *ev)
     for (n = 0; n < racf->pushes.nelts; ++n, ++t) {
         target = *t;
 
-        if (target->name.len && (ctx->name.len != target->name.len ||
-            ngx_memcmp(ctx->name.data, target->name.data, ctx->name.len)))
-        {
+        if (target->name.len &&
+            (ctx->name.len != target->name.len ||
+             ngx_memcmp(ctx->name.data, target->name.data, ctx->name.len))) {
             continue;
         }
 
         for (pctx = ctx->play; pctx; pctx = pctx->next) {
-            if (pctx->tag == &ngx_rtmp_relay_module &&
-                pctx->data == target)
-            {
+            if (pctx->tag == &ngx_rtmp_relay_module && pctx->data == target) {
                 break;
             }
         }
@@ -289,10 +245,10 @@ ngx_rtmp_relay_push_reconnect(ngx_event_t *ev)
         }
 
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                "relay: push reconnect failed name='%V' app='%V' "
-                "playpath='%V' url='%V'",
-                &ctx->name, &target->app, &target->play_path,
-                &target->url.url);
+                      "relay: push reconnect failed name='%V' app='%V' "
+                      "playpath='%V' url='%V'",
+                      &ctx->name, &target->app, &target->play_path,
+                      &target->url.url);
 
         if (!ctx->push_evt.timer_set) {
             ngx_add_timer(&ctx->push_evt, racf->push_reconnect);
@@ -300,32 +256,26 @@ ngx_rtmp_relay_push_reconnect(ngx_event_t *ev)
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_get_peer(ngx_peer_connection_t *pc, void *data)
+static ngx_int_t ngx_rtmp_relay_get_peer(ngx_peer_connection_t *pc, void *data)
 {
     return NGX_OK;
 }
 
-
-static void
-ngx_rtmp_relay_free_peer(ngx_peer_connection_t *pc, void *data,
-            ngx_uint_t state)
+static void ngx_rtmp_relay_free_peer(ngx_peer_connection_t *pc, void *data,
+                                     ngx_uint_t state)
 {
 }
 
+typedef ngx_rtmp_relay_ctx_t *(*ngx_rtmp_relay_create_ctx_pt)(
+    ngx_rtmp_session_t *s, ngx_str_t *name, ngx_rtmp_relay_target_t *target);
 
-typedef ngx_rtmp_relay_ctx_t * (* ngx_rtmp_relay_create_ctx_pt)
-    (ngx_rtmp_session_t *s, ngx_str_t *name, ngx_rtmp_relay_target_t *target);
-
-
-static ngx_int_t
-ngx_rtmp_relay_copy_str(ngx_pool_t *pool, ngx_str_t *dst, ngx_str_t *src)
+static ngx_int_t ngx_rtmp_relay_copy_str(ngx_pool_t *pool, ngx_str_t *dst,
+                                         ngx_str_t *src)
 {
     if (src->len == 0) {
         return NGX_OK;
     }
-    dst->len = src->len;
+    dst->len  = src->len;
     dst->data = ngx_palloc(pool, src->len);
     if (dst->data == NULL) {
         return NGX_ERROR;
@@ -334,23 +284,22 @@ ngx_rtmp_relay_copy_str(ngx_pool_t *pool, ngx_str_t *dst, ngx_str_t *src)
     return NGX_OK;
 }
 
-
 static ngx_rtmp_relay_ctx_t *
-ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
-        ngx_rtmp_relay_target_t *target)
+ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t *name,
+                                 ngx_rtmp_relay_target_t *target)
 {
-    ngx_rtmp_relay_app_conf_t      *racf;
-    ngx_rtmp_relay_ctx_t           *rctx;
-    ngx_rtmp_addr_conf_t           *addr_conf;
-    ngx_rtmp_conf_ctx_t            *addr_ctx;
-    ngx_rtmp_session_t             *rs;
-    ngx_peer_connection_t          *pc;
-    ngx_connection_t               *c;
-    ngx_addr_t                     *addr;
-    ngx_pool_t                     *pool;
-    ngx_int_t                       rc;
-    ngx_str_t                       v, *uri;
-    u_char                         *first, *last, *p;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_ctx_t *rctx;
+    ngx_rtmp_addr_conf_t *addr_conf;
+    ngx_rtmp_conf_ctx_t *addr_ctx;
+    ngx_rtmp_session_t *rs;
+    ngx_peer_connection_t *pc;
+    ngx_connection_t *c;
+    ngx_addr_t *addr;
+    ngx_pool_t *pool;
+    ngx_int_t rc;
+    ngx_str_t v, *uri;
+    u_char *first, *last, *p;
 
     racf = ngx_rtmp_get_module_app_conf(cctx, ngx_rtmp_relay_module);
 
@@ -376,20 +325,20 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
         goto clear;
     }
 
-    rctx->tag = target->tag;
+    rctx->tag  = target->tag;
     rctx->data = target->data;
 
-#define NGX_RTMP_RELAY_STR_COPY(to, from)                                     \
-    if (ngx_rtmp_relay_copy_str(pool, &rctx->to, &target->from) != NGX_OK) {  \
-        goto clear;                                                           \
+#define NGX_RTMP_RELAY_STR_COPY(to, from)                                      \
+    if (ngx_rtmp_relay_copy_str(pool, &rctx->to, &target->from) != NGX_OK) {   \
+        goto clear;                                                            \
     }
 
-    NGX_RTMP_RELAY_STR_COPY(app,        app);
-    NGX_RTMP_RELAY_STR_COPY(tc_url,     tc_url);
-    NGX_RTMP_RELAY_STR_COPY(page_url,   page_url);
-    NGX_RTMP_RELAY_STR_COPY(swf_url,    swf_url);
-    NGX_RTMP_RELAY_STR_COPY(flash_ver,  flash_ver);
-    NGX_RTMP_RELAY_STR_COPY(play_path,  play_path);
+    NGX_RTMP_RELAY_STR_COPY(app, app);
+    NGX_RTMP_RELAY_STR_COPY(tc_url, tc_url);
+    NGX_RTMP_RELAY_STR_COPY(page_url, page_url);
+    NGX_RTMP_RELAY_STR_COPY(swf_url, swf_url);
+    NGX_RTMP_RELAY_STR_COPY(flash_ver, flash_ver);
+    NGX_RTMP_RELAY_STR_COPY(play_path, play_path);
 
     rctx->live  = target->live;
     rctx->start = target->start;
@@ -399,7 +348,7 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
 
     if (rctx->app.len == 0 || rctx->play_path.len == 0) {
         /* parse uri */
-        uri = &target->url.uri;
+        uri   = &target->url.uri;
         first = uri->data;
         last  = uri->data + uri->len;
         if (first != last && *first == '/') {
@@ -407,7 +356,6 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
         }
 
         if (first != last) {
-
             /* deduce app */
             p = ngx_strlchr(first, last, '/');
             if (p == NULL) {
@@ -416,7 +364,7 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
 
             if (rctx->app.len == 0 && first != p) {
                 v.data = first;
-                v.len = p - first;
+                v.len  = p - first;
                 if (ngx_rtmp_relay_copy_str(pool, &rctx->app, &v) != NGX_OK) {
                     goto clear;
                 }
@@ -429,10 +377,9 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
 
             if (rctx->play_path.len == 0 && p != last) {
                 v.data = p;
-                v.len = last - p;
-                if (ngx_rtmp_relay_copy_str(pool, &rctx->play_path, &v)
-                        != NGX_OK)
-                {
+                v.len  = last - p;
+                if (ngx_rtmp_relay_copy_str(pool, &rctx->play_path, &v) !=
+                    NGX_OK) {
                     goto clear;
                 }
             }
@@ -445,8 +392,7 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
     }
 
     if (target->url.naddrs == 0) {
-        ngx_log_error(NGX_LOG_ERR, racf->log, 0,
-                      "relay: no address");
+        ngx_log_error(NGX_LOG_ERR, racf->log, 0, "relay: no address");
         goto clear;
     }
 
@@ -455,12 +401,12 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
     target->counter++;
 
     /* copy log to keep shared log unchanged */
-    rctx->log = *racf->log;
-    pc->log = &rctx->log;
-    pc->get = ngx_rtmp_relay_get_peer;
-    pc->free = ngx_rtmp_relay_free_peer;
-    pc->name = &addr->name;
-    pc->socklen = addr->socklen;
+    rctx->log    = *racf->log;
+    pc->log      = &rctx->log;
+    pc->get      = ngx_rtmp_relay_get_peer;
+    pc->free     = ngx_rtmp_relay_free_peer;
+    pc->name     = &addr->name;
+    pc->socklen  = addr->socklen;
     pc->sockaddr = (struct sockaddr *)ngx_palloc(pool, pc->socklen);
     if (pc->sockaddr == NULL) {
         goto clear;
@@ -468,13 +414,13 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
     ngx_memcpy(pc->sockaddr, addr->sockaddr, pc->socklen);
 
     rc = ngx_event_connect_peer(pc);
-    if (rc != NGX_OK && rc != NGX_AGAIN ) {
+    if (rc != NGX_OK && rc != NGX_AGAIN) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, racf->log, 0,
-                "relay: connection failed");
+                       "relay: connection failed");
         goto clear;
     }
-    c = pc->connection;
-    c->pool = pool;
+    c            = pc->connection;
+    c->pool      = pool;
     c->addr_text = rctx->url;
 
     addr_conf = ngx_pcalloc(pool, sizeof(ngx_rtmp_addr_conf_t));
@@ -485,7 +431,7 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
     if (addr_ctx == NULL) {
         goto clear;
     }
-    addr_conf->ctx = addr_ctx;
+    addr_conf->ctx      = addr_ctx;
     addr_ctx->main_conf = cctx->main_conf;
     addr_ctx->srv_conf  = cctx->srv_conf;
     ngx_str_set(&addr_conf->addr_text, "ngx-relay");
@@ -495,16 +441,16 @@ ngx_rtmp_relay_create_connection(ngx_rtmp_conf_ctx_t *cctx, ngx_str_t* name,
         /* no need to destroy pool */
         return NULL;
     }
-    rs->app_conf = cctx->app_conf;
-    rs->relay = 1;
+    rs->app_conf          = cctx->app_conf;
+    rs->relay             = 1;
     rs->ready_for_publish = 0;
-    rctx->session = rs;
+    rctx->session         = rs;
     ngx_rtmp_set_ctx(rs, rctx, ngx_rtmp_relay_module);
     ngx_str_set(&rs->flashver, "ngx-local-relay");
     ngx_memcpy(&rs->app, &rctx->app, sizeof(rctx->app));
 
 #if (NGX_STAT_STUB)
-    (void) ngx_atomic_fetch_add(ngx_stat_active, 1);
+    (void)ngx_atomic_fetch_add(ngx_stat_active, 1);
 #endif
 
     ngx_rtmp_client_handshake(rs, 1);
@@ -517,26 +463,24 @@ clear:
     return NULL;
 }
 
-
 static ngx_rtmp_relay_ctx_t *
-ngx_rtmp_relay_create_remote_ctx(ngx_rtmp_session_t *s, ngx_str_t* name,
-        ngx_rtmp_relay_target_t *target)
+ngx_rtmp_relay_create_remote_ctx(ngx_rtmp_session_t *s, ngx_str_t *name,
+                                 ngx_rtmp_relay_target_t *target)
 {
-    ngx_rtmp_conf_ctx_t         cctx;
+    ngx_rtmp_conf_ctx_t cctx;
 
-    cctx.app_conf = s->app_conf;
-    cctx.srv_conf = s->srv_conf;
+    cctx.app_conf  = s->app_conf;
+    cctx.srv_conf  = s->srv_conf;
     cctx.main_conf = s->main_conf;
 
     return ngx_rtmp_relay_create_connection(&cctx, name, target);
 }
 
-
 static ngx_rtmp_relay_ctx_t *
 ngx_rtmp_relay_create_local_ctx(ngx_rtmp_session_t *s, ngx_str_t *name,
-        ngx_rtmp_relay_target_t *target)
+                                ngx_rtmp_relay_target_t *target)
 {
-    ngx_rtmp_relay_ctx_t           *ctx;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "relay: create local context");
@@ -551,34 +495,31 @@ ngx_rtmp_relay_create_local_ctx(ngx_rtmp_session_t *s, ngx_str_t *name,
     }
     ctx->session = s;
 
-    ctx->push_evt.data = s;
-    ctx->push_evt.log = s->connection->log;
+    ctx->push_evt.data    = s;
+    ctx->push_evt.log     = s->connection->log;
     ctx->push_evt.handler = ngx_rtmp_relay_push_reconnect;
 
     if (ctx->publish) {
         return NULL;
     }
 
-    if (ngx_rtmp_relay_copy_str(s->connection->pool, &ctx->name, name)
-            != NGX_OK)
-    {
+    if (ngx_rtmp_relay_copy_str(s->connection->pool, &ctx->name, name) !=
+        NGX_OK) {
         return NULL;
     }
 
     return ctx;
 }
 
-
 static ngx_int_t
 ngx_rtmp_relay_create(ngx_rtmp_session_t *s, ngx_str_t *name,
-        ngx_rtmp_relay_target_t *target,
-        ngx_rtmp_relay_create_ctx_pt create_publish_ctx,
-        ngx_rtmp_relay_create_ctx_pt create_play_ctx)
+                      ngx_rtmp_relay_target_t *target,
+                      ngx_rtmp_relay_create_ctx_pt create_publish_ctx,
+                      ngx_rtmp_relay_create_ctx_pt create_play_ctx)
 {
-    ngx_rtmp_relay_app_conf_t      *racf;
-    ngx_rtmp_relay_ctx_t           *publish_ctx, *play_ctx, **cctx;
-    ngx_uint_t                      hash;
-
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_ctx_t *publish_ctx, *play_ctx, **cctx;
+    ngx_uint_t hash;
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_relay_module);
     if (racf == NULL) {
@@ -593,18 +534,16 @@ ngx_rtmp_relay_create(ngx_rtmp_session_t *s, ngx_str_t *name,
     hash = ngx_hash_key(name->data, name->len);
     cctx = &racf->ctx[hash % racf->nbuckets];
     for (; *cctx; cctx = &(*cctx)->next) {
-        if ((*cctx)->name.len == name->len
-            && !ngx_memcmp(name->data, (*cctx)->name.data,
-                name->len))
-        {
+        if ((*cctx)->name.len == name->len &&
+            !ngx_memcmp(name->data, (*cctx)->name.data, name->len)) {
             break;
         }
     }
 
     if (*cctx) {
         play_ctx->publish = (*cctx)->publish;
-        play_ctx->next = (*cctx)->play;
-        (*cctx)->play = play_ctx;
+        play_ctx->next    = (*cctx)->play;
+        (*cctx)->play     = play_ctx;
         return NGX_OK;
     }
 
@@ -615,50 +554,47 @@ ngx_rtmp_relay_create(ngx_rtmp_session_t *s, ngx_str_t *name,
     }
 
     publish_ctx->publish = publish_ctx;
-    publish_ctx->play = play_ctx;
-    play_ctx->publish = publish_ctx;
-    *cctx = publish_ctx;
+    publish_ctx->play    = play_ctx;
+    play_ctx->publish    = publish_ctx;
+    *cctx                = publish_ctx;
 
     return NGX_OK;
 }
 
-
-ngx_int_t
-ngx_rtmp_relay_pull(ngx_rtmp_session_t *s, ngx_str_t *name,
-        ngx_rtmp_relay_target_t *target)
+ngx_int_t ngx_rtmp_relay_pull(ngx_rtmp_session_t *s, ngx_str_t *name,
+                              ngx_rtmp_relay_target_t *target)
 {
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "relay: create pull name='%V' app='%V' playpath='%V' url='%V'",
-            name, &target->app, &target->play_path, &target->url.url);
+    ngx_log_error(
+        NGX_LOG_INFO, s->connection->log, 0,
+        "relay: create pull name='%V' app='%V' playpath='%V' url='%V'", name,
+        &target->app, &target->play_path, &target->url.url);
 
     return ngx_rtmp_relay_create(s, name, target,
-            ngx_rtmp_relay_create_remote_ctx,
-            ngx_rtmp_relay_create_local_ctx);
+                                 ngx_rtmp_relay_create_remote_ctx,
+                                 ngx_rtmp_relay_create_local_ctx);
 }
 
-
-ngx_int_t
-ngx_rtmp_relay_push(ngx_rtmp_session_t *s, ngx_str_t *name,
-        ngx_rtmp_relay_target_t *target)
+ngx_int_t ngx_rtmp_relay_push(ngx_rtmp_session_t *s, ngx_str_t *name,
+                              ngx_rtmp_relay_target_t *target)
 {
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "relay: create push name='%V' app='%V' playpath='%V' url='%V'",
-            name, &target->app, &target->play_path, &target->url.url);
+    ngx_log_error(
+        NGX_LOG_INFO, s->connection->log, 0,
+        "relay: create push name='%V' app='%V' playpath='%V' url='%V'", name,
+        &target->app, &target->play_path, &target->url.url);
 
     return ngx_rtmp_relay_create(s, name, target,
-            ngx_rtmp_relay_create_local_ctx,
-            ngx_rtmp_relay_create_remote_ctx);
+                                 ngx_rtmp_relay_create_local_ctx,
+                                 ngx_rtmp_relay_create_remote_ctx);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
+static ngx_int_t ngx_rtmp_relay_publish(ngx_rtmp_session_t *s,
+                                        ngx_rtmp_publish_t *v)
 {
-    ngx_rtmp_relay_app_conf_t      *racf;
-    ngx_rtmp_relay_target_t        *target, **t;
-    ngx_str_t                       name;
-    size_t                          n;
-    ngx_rtmp_relay_ctx_t           *ctx;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_target_t *target, **t;
+    ngx_str_t name;
+    size_t n;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     if (s->auto_pushed) {
         goto next;
@@ -674,16 +610,16 @@ ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-    name.len = ngx_strlen(v->name);
+    name.len  = ngx_strlen(v->name);
     name.data = v->name;
 
     t = racf->pushes.elts;
     for (n = 0; n < racf->pushes.nelts; ++n, ++t) {
         target = *t;
 
-        if (target->name.len && (name.len != target->name.len ||
-            ngx_memcmp(name.data, target->name.data, name.len)))
-        {
+        if (target->name.len &&
+            (name.len != target->name.len ||
+             ngx_memcmp(name.data, target->name.data, name.len))) {
             continue;
         }
 
@@ -692,10 +628,10 @@ ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         }
 
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                "relay: push failed name='%V' app='%V' "
-                "playpath='%V' url='%V'",
-                &name, &target->app, &target->play_path,
-                &target->url.url);
+                      "relay: push failed name='%V' app='%V' "
+                      "playpath='%V' url='%V'",
+                      &name, &target->app, &target->play_path,
+                      &target->url.url);
 
         if (!ctx->push_evt.timer_set) {
             ngx_add_timer(&ctx->push_evt, racf->push_reconnect);
@@ -706,18 +642,16 @@ next:
     return next_publish(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
+static ngx_int_t ngx_rtmp_relay_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
                   "relay: ngx_rtmp_relay_play");
 
-    ngx_rtmp_relay_app_conf_t      *racf;
-    ngx_rtmp_relay_target_t        *target, **t;
-    ngx_str_t                       name;
-    size_t                          n;
-    ngx_rtmp_relay_ctx_t           *ctx;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_target_t *target, **t;
+    ngx_str_t name;
+    size_t n;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx && s->relay) {
@@ -729,16 +663,16 @@ ngx_rtmp_relay_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         goto next;
     }
 
-    name.len = ngx_strlen(v->name);
+    name.len  = ngx_strlen(v->name);
     name.data = v->name;
 
     t = racf->pulls.elts;
     for (n = 0; n < racf->pulls.nelts; ++n, ++t) {
         target = *t;
 
-        if (target->name.len && (name.len != target->name.len ||
-            ngx_memcmp(name.data, target->name.data, name.len)))
-        {
+        if (target->name.len &&
+            (name.len != target->name.len ||
+             ngx_memcmp(name.data, target->name.data, name.len))) {
             continue;
         }
 
@@ -747,25 +681,23 @@ ngx_rtmp_relay_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         }
 
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                "relay: pull failed name='%V' app='%V' "
-                "playpath='%V' url='%V'",
-                &name, &target->app, &target->play_path,
-                &target->url.url);
+                      "relay: pull failed name='%V' app='%V' "
+                      "playpath='%V' url='%V'",
+                      &name, &target->app, &target->play_path,
+                      &target->url.url);
     }
 
 next:
     ngx_log_error(NGX_LOG_DEBUG, s->connection->log, 0,
-              "relay: ngx_rtmp_relay_play: next");
+                  "relay: ngx_rtmp_relay_play: next");
 
     return next_play(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_play_local(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_play_local(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_play_t             v;
-    ngx_rtmp_relay_ctx_t       *ctx;
+    ngx_rtmp_play_t v;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL) {
@@ -775,17 +707,15 @@ ngx_rtmp_relay_play_local(ngx_rtmp_session_t *s)
     ngx_memzero(&v, sizeof(ngx_rtmp_play_t));
     v.silent = 1;
     *(ngx_cpymem(v.name, ctx->name.data,
-            ngx_min(sizeof(v.name) - 1, ctx->name.len))) = 0;
+                 ngx_min(sizeof(v.name) - 1, ctx->name.len))) = 0;
 
     return ngx_rtmp_play(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_publish_local(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_publish_local(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_publish_t          v;
-    ngx_rtmp_relay_ctx_t       *ctx;
+    ngx_rtmp_publish_t v;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL) {
@@ -795,76 +725,51 @@ ngx_rtmp_relay_publish_local(ngx_rtmp_session_t *s)
     ngx_memzero(&v, sizeof(ngx_rtmp_publish_t));
     v.silent = 1;
     *(ngx_cpymem(v.name, ctx->name.data,
-            ngx_min(sizeof(v.name) - 1, ctx->name.len))) = 0;
+                 ngx_min(sizeof(v.name) - 1, ctx->name.len))) = 0;
 
     return ngx_rtmp_publish(s, &v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_send_connect(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_send_connect(ngx_rtmp_session_t *s)
 {
-    static double               trans = NGX_RTMP_RELAY_CONNECT_TRANS;
-    static double               acodecs = 3575;
-    static double               vcodecs = 252;
+    static double trans   = NGX_RTMP_RELAY_CONNECT_TRANS;
+    static double acodecs = 3575;
+    static double vcodecs = 252;
 
-    static ngx_rtmp_amf_elt_t   out_cmd[] = {
+    static ngx_rtmp_amf_elt_t out_cmd[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("app"),
-          NULL, 0 }, /* <-- fill */
+        {NGX_RTMP_AMF_STRING, ngx_string("app"), NULL, 0}, /* <-- fill */
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("tcUrl"),
-          NULL, 0 }, /* <-- fill */
+        {NGX_RTMP_AMF_STRING, ngx_string("tcUrl"), NULL, 0}, /* <-- fill */
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("pageUrl"),
-          NULL, 0 }, /* <-- fill */
+        {NGX_RTMP_AMF_STRING, ngx_string("pageUrl"), NULL, 0}, /* <-- fill */
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("swfUrl"),
-          NULL, 0 }, /* <-- fill */
+        {NGX_RTMP_AMF_STRING, ngx_string("swfUrl"), NULL, 0}, /* <-- fill */
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("flashVer"),
-          NULL, 0 }, /* <-- fill */
+        {NGX_RTMP_AMF_STRING, ngx_string("flashVer"), NULL, 0}, /* <-- fill */
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audioCodecs"),
-          &acodecs, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audioCodecs"), &acodecs, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videoCodecs"),
-          &vcodecs, 0 }
-    };
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videoCodecs"), &vcodecs, 0}};
 
-    static ngx_rtmp_amf_elt_t   out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "connect", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "connect", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_cmd, sizeof(out_cmd) }
-    };
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_cmd, sizeof(out_cmd)}};
 
-    ngx_rtmp_core_app_conf_t   *cacf;
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_rtmp_relay_ctx_t       *ctx;
-    ngx_rtmp_header_t           h;
-    size_t                      len, url_len;
-    u_char                     *p, *url_end;
-
+    ngx_rtmp_core_app_conf_t *cacf;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_rtmp_relay_ctx_t *ctx;
+    ngx_rtmp_header_t h;
+    size_t len, url_len;
+    u_char *p, *url_end;
 
     cacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_core_module);
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (cacf == NULL || ctx == NULL) {
         return NGX_ERROR;
     }
@@ -883,24 +788,24 @@ ngx_rtmp_relay_send_connect(ngx_rtmp_session_t *s)
         out_cmd[1].data = ctx->tc_url.data;
         out_cmd[1].len  = ctx->tc_url.len;
     } else {
-        len = sizeof("rtmp://") - 1 + ctx->url.len +
-            sizeof("/") - 1 + ctx->app.len;
+        len = sizeof("rtmp://") - 1 + ctx->url.len + sizeof("/") - 1 +
+              ctx->app.len;
         p = ngx_palloc(s->connection->pool, len);
         if (p == NULL) {
             return NGX_ERROR;
         }
         out_cmd[1].data = p;
-        p = ngx_cpymem(p, "rtmp://", sizeof("rtmp://") - 1);
+        p               = ngx_cpymem(p, "rtmp://", sizeof("rtmp://") - 1);
 
         url_len = ctx->url.len;
         url_end = ngx_strlchr(ctx->url.data, ctx->url.data + ctx->url.len, '/');
         if (url_end) {
-            url_len = (size_t) (url_end - ctx->url.data);
+            url_len = (size_t)(url_end - ctx->url.data);
         }
 
-        p = ngx_cpymem(p, ctx->url.data, url_len);
-        *p++ = '/';
-        p = ngx_cpymem(p, ctx->app.data, ctx->app.len);
+        p              = ngx_cpymem(p, ctx->url.data, url_len);
+        *p++           = '/';
+        p              = ngx_cpymem(p, ctx->app.data, ctx->app.len);
         out_cmd[1].len = p - (u_char *)out_cmd[1].data;
     }
 
@@ -925,78 +830,55 @@ ngx_rtmp_relay_send_connect(ngx_rtmp_session_t *s)
     h.csid = NGX_RTMP_RELAY_CSID_AMF_INI;
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
-    return ngx_rtmp_send_chunk_size(s, cscf->chunk_size) != NGX_OK
-        || ngx_rtmp_send_ack_size(s, cscf->ack_window) != NGX_OK
-        || ngx_rtmp_send_amf(s, &h, out_elts,
-            sizeof(out_elts) / sizeof(out_elts[0])) != NGX_OK
-        ? NGX_ERROR
-        : NGX_OK;
+    return ngx_rtmp_send_chunk_size(s, cscf->chunk_size) != NGX_OK ||
+                   ngx_rtmp_send_ack_size(s, cscf->ack_window) != NGX_OK ||
+                   ngx_rtmp_send_amf(s, &h, out_elts,
+                                     sizeof(out_elts) / sizeof(out_elts[0])) !=
+                       NGX_OK
+               ? NGX_ERROR
+               : NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_send_create_stream(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_send_create_stream(ngx_rtmp_session_t *s)
 {
-    static double               trans = NGX_RTMP_RELAY_CREATE_STREAM_TRANS;
+    static double trans = NGX_RTMP_RELAY_CREATE_STREAM_TRANS;
 
-    static ngx_rtmp_amf_elt_t   out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "createStream", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "createStream", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 }
-    };
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0}};
 
-    ngx_rtmp_header_t           h;
-
+    ngx_rtmp_header_t h;
 
     ngx_memzero(&h, sizeof(h));
     h.csid = NGX_RTMP_RELAY_CSID_AMF_INI;
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
     return ngx_rtmp_send_amf(s, &h, out_elts,
-            sizeof(out_elts) / sizeof(out_elts[0]));
+                             sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_send_publish(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_send_publish(ngx_rtmp_session_t *s)
 {
-    static double               trans;
+    static double trans;
 
-    static ngx_rtmp_amf_elt_t   out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "publish", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "publish", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 }, /* <- to fill */
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0}, /* <- to fill */
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "live", 0 }
-    };
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "live", 0}};
 
-    ngx_rtmp_header_t           h;
-    ngx_rtmp_relay_ctx_t       *ctx;
-
+    ngx_rtmp_header_t h;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL) {
@@ -1017,50 +899,35 @@ ngx_rtmp_relay_send_publish(ngx_rtmp_session_t *s)
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
     return ngx_rtmp_send_amf(s, &h, out_elts,
-            sizeof(out_elts) / sizeof(out_elts[0]));
+                             sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_send_play(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_send_play(ngx_rtmp_session_t *s)
 {
-    static double               trans;
-    static double               start, duration;
+    static double trans;
+    static double start, duration;
 
-    static ngx_rtmp_amf_elt_t   out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "play", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "play", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 }, /* <- fill */
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0}, /* <- fill */
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &start, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &start, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &duration, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &duration, 0},
     };
 
-    ngx_rtmp_header_t           h;
-    ngx_rtmp_relay_ctx_t       *ctx;
-    ngx_rtmp_relay_app_conf_t  *racf;
-
+    ngx_rtmp_header_t h;
+    ngx_rtmp_relay_ctx_t *ctx;
+    ngx_rtmp_relay_app_conf_t *racf;
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_relay_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
+    ctx  = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (racf == NULL || ctx == NULL) {
         return NGX_ERROR;
     }
@@ -1074,11 +941,11 @@ ngx_rtmp_relay_send_play(ngx_rtmp_session_t *s)
     }
 
     if (ctx->live) {
-        start = -1000;
+        start    = -1000;
         duration = -1000;
     } else {
         start    = (ctx->start ? ctx->start : -2000);
-        duration = (ctx->stop  ? ctx->stop - ctx->start : -1000);
+        duration = (ctx->stop ? ctx->stop - ctx->start : -1000);
     }
 
     ngx_memzero(&h, sizeof(h));
@@ -1087,56 +954,43 @@ ngx_rtmp_relay_send_play(ngx_rtmp_session_t *s)
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
     return ngx_rtmp_send_amf(s, &h, out_elts,
-            sizeof(out_elts) / sizeof(out_elts[0])) != NGX_OK
-           || ngx_rtmp_send_set_buflen(s, NGX_RTMP_RELAY_MSID,
-                   racf->buflen) != NGX_OK
-           ? NGX_ERROR
-           : NGX_OK;
+                             sizeof(out_elts) / sizeof(out_elts[0])) !=
+                       NGX_OK ||
+                   ngx_rtmp_send_set_buflen(s, NGX_RTMP_RELAY_MSID,
+                                            racf->buflen) != NGX_OK
+               ? NGX_ERROR
+               : NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_on_result(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_relay_on_result(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_relay_ctx_t       *ctx;
+    ngx_rtmp_relay_ctx_t *ctx;
     static struct {
-        double                  trans;
-        u_char                  level[32];
-        u_char                  code[128];
-        u_char                  desc[1024];
+        double trans;
+        u_char level[32];
+        u_char code[128];
+        u_char desc[1024];
     } v;
 
-    static ngx_rtmp_amf_elt_t   in_inf[] = {
+    static ngx_rtmp_amf_elt_t in_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          &v.code, sizeof(v.code) },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), &v.code, sizeof(v.code)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          &v.desc, sizeof(v.desc) },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), &v.desc,
+         sizeof(v.desc)},
     };
 
-    static ngx_rtmp_amf_elt_t   in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
-
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL || !s->relay) {
@@ -1145,81 +999,66 @@ ngx_rtmp_relay_on_result(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_memzero(&v, sizeof(v));
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "relay: _result: level='%s' code='%s' description='%s'",
-            v.level, v.code, v.desc);
+                   "relay: _result: level='%s' code='%s' description='%s'",
+                   v.level, v.code, v.desc);
 
     switch ((ngx_int_t)v.trans) {
-        case NGX_RTMP_RELAY_CONNECT_TRANS:
-            return ngx_rtmp_relay_send_create_stream(s);
+    case NGX_RTMP_RELAY_CONNECT_TRANS:
+        return ngx_rtmp_relay_send_create_stream(s);
 
-        case NGX_RTMP_RELAY_CREATE_STREAM_TRANS:
-            if (ctx->publish != ctx && !s->static_relay) {
-                if (ngx_rtmp_relay_send_publish(s) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                return ngx_rtmp_relay_play_local(s);
-
-            } else {
-                if (ngx_rtmp_relay_send_play(s) != NGX_OK) {
-                    return NGX_ERROR;
-                }
-                return ngx_rtmp_relay_publish_local(s);
+    case NGX_RTMP_RELAY_CREATE_STREAM_TRANS:
+        if (ctx->publish != ctx && !s->static_relay) {
+            if (ngx_rtmp_relay_send_publish(s) != NGX_OK) {
+                return NGX_ERROR;
             }
+            return ngx_rtmp_relay_play_local(s);
 
-        default:
-            return NGX_OK;
+        } else {
+            if (ngx_rtmp_relay_send_play(s) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            return ngx_rtmp_relay_publish_local(s);
+        }
+
+    default:
+        return NGX_OK;
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_on_error(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_relay_on_error(ngx_rtmp_session_t *s,
+                                         ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_relay_ctx_t       *ctx;
+    ngx_rtmp_relay_ctx_t *ctx;
     static struct {
-        double                  trans;
-        u_char                  level[32];
-        u_char                  code[128];
-        u_char                  desc[1024];
+        double trans;
+        u_char level[32];
+        u_char code[128];
+        u_char desc[1024];
     } v;
 
-    static ngx_rtmp_amf_elt_t   in_inf[] = {
+    static ngx_rtmp_amf_elt_t in_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          &v.code, sizeof(v.code) },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), &v.code, sizeof(v.code)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          &v.desc, sizeof(v.desc) },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), &v.desc,
+         sizeof(v.desc)},
     };
 
-    static ngx_rtmp_amf_elt_t   in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
-
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL || !s->relay) {
@@ -1228,216 +1067,167 @@ ngx_rtmp_relay_on_error(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_memzero(&v, sizeof(v));
     if (ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0])))
-    {
+                             sizeof(in_elts) / sizeof(in_elts[0]))) {
         return NGX_ERROR;
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "relay: _error: level='%s' code='%s' description='%s'",
-            v.level, v.code, v.desc);
+                   "relay: _error: level='%s' code='%s' description='%s'",
+                   v.level, v.code, v.desc);
 
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_relay_send_set_data_frame(ngx_rtmp_session_t *s)
+static ngx_int_t ngx_rtmp_relay_send_set_data_frame(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_relay_ctx_t           *ctx;
-    ngx_rtmp_codec_ctx_t           *codec_ctx;
-    ngx_rtmp_header_t               hdr;
+    ngx_rtmp_relay_ctx_t *ctx;
+    ngx_rtmp_codec_ctx_t *codec_ctx;
+    ngx_rtmp_header_t hdr;
 
     static struct {
-        double                      width;
-        double                      height;
-        double                      duration;
-        double                      frame_rate;
-        double                      video_data_rate;
-        double                      video_codec_id;
-        double                      audio_data_rate;
-        double                      audio_codec_id;
-        u_char                      profile[32];
-        u_char                      level[32];
-    }                               v;
+        double width;
+        double height;
+        double duration;
+        double frame_rate;
+        double video_data_rate;
+        double video_codec_id;
+        double audio_data_rate;
+        double audio_codec_id;
+        u_char profile[32];
+        u_char level[32];
+    } v;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("Server"),
-          "NGINX RTMP (github.com/arut/nginx-rtmp-module)", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("Server"),
+         "NGINX RTMP (github.com/arut/nginx-rtmp-module)", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("width"),
-          &v.width, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("width"), &v.width, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("height"),
-          &v.height, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("height"), &v.height, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("displayWidth"),
-          &v.width, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("displayWidth"), &v.width, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("displayHeight"),
-          &v.height, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("displayHeight"), &v.height, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("duration"),
-          &v.duration, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("duration"), &v.duration, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("framerate"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("framerate"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("fps"),
-          &v.frame_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("fps"), &v.frame_rate, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videodatarate"),
-          &v.video_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videodatarate"), &v.video_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("videocodecid"),
-          &v.video_codec_id, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("videocodecid"), &v.video_codec_id, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audiodatarate"),
-          &v.audio_data_rate, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audiodatarate"), &v.audio_data_rate,
+         0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("audiocodecid"),
-          &v.audio_codec_id, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("audiocodecid"), &v.audio_codec_id, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("profile"),
-          &v.profile, sizeof(v.profile) },
+        {NGX_RTMP_AMF_STRING, ngx_string("profile"), &v.profile,
+         sizeof(v.profile)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) }
-    };
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)}};
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "@setDataFrame", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "@setDataFrame", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onMetaData", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onMetaData", 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf, sizeof(out_inf) }
-    };
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)}};
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL || !s->relay) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "relay: couldn't get relay context");
+                       "relay: couldn't get relay context");
         return NGX_OK;
     }
 
     /* we need to get the codec context from the incoming publisher in order to
      * send the metadata along */
-    codec_ctx = ngx_rtmp_get_module_ctx(ctx->publish->session,
-            ngx_rtmp_codec_module);
+    codec_ctx =
+        ngx_rtmp_get_module_ctx(ctx->publish->session, ngx_rtmp_codec_module);
     if (codec_ctx == NULL) {
         ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                "relay: couldn't get codec context");
+                       "relay: couldn't get codec context");
         return NGX_OK;
     }
 
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-            "relay: data frame from codec context: "
-            "width=%ui height=%ui duration=%ui frame_rate=%ui "
-            "video_codec_id=%ui audio_codec_id=%ui",
-            codec_ctx->width, codec_ctx->height, codec_ctx->duration,
-            codec_ctx->frame_rate, codec_ctx->video_codec_id,
-            codec_ctx->audio_codec_id);
+                  "relay: data frame from codec context: "
+                  "width=%ui height=%ui duration=%ui frame_rate=%ui "
+                  "video_codec_id=%ui audio_codec_id=%ui",
+                  codec_ctx->width, codec_ctx->height, codec_ctx->duration,
+                  codec_ctx->frame_rate, codec_ctx->video_codec_id,
+                  codec_ctx->audio_codec_id);
 
     /* we only want to send the metadata if the codec module has already
      * parsed it -- is there a better way to check this? */
     if (codec_ctx->width > 0 && codec_ctx->height > 0) {
-      v.width = codec_ctx->width;
-      v.height = codec_ctx->height;
-      v.duration = codec_ctx->duration;
-      v.frame_rate = codec_ctx->frame_rate;
-      v.video_data_rate = codec_ctx->video_data_rate;
-      v.video_codec_id = codec_ctx->video_codec_id;
-      v.audio_data_rate = codec_ctx->audio_data_rate;
-      v.audio_codec_id = codec_ctx->audio_codec_id;
-      ngx_memcpy(v.profile, codec_ctx->profile, sizeof(codec_ctx->profile));
-      ngx_memcpy(v.level, codec_ctx->level, sizeof(codec_ctx->level));
+        v.width           = codec_ctx->width;
+        v.height          = codec_ctx->height;
+        v.duration        = codec_ctx->duration;
+        v.frame_rate      = codec_ctx->frame_rate;
+        v.video_data_rate = codec_ctx->video_data_rate;
+        v.video_codec_id  = codec_ctx->video_codec_id;
+        v.audio_data_rate = codec_ctx->audio_data_rate;
+        v.audio_codec_id  = codec_ctx->audio_codec_id;
+        ngx_memcpy(v.profile, codec_ctx->profile, sizeof(codec_ctx->profile));
+        ngx_memcpy(v.level, codec_ctx->level, sizeof(codec_ctx->level));
 
-      ngx_memzero(&hdr, sizeof(hdr));
-      hdr.csid = NGX_RTMP_RELAY_CSID_AMF_INI;
-      hdr.msid = NGX_RTMP_RELAY_MSID;
-      hdr.type = NGX_RTMP_MSG_AMF_META;
+        ngx_memzero(&hdr, sizeof(hdr));
+        hdr.csid = NGX_RTMP_RELAY_CSID_AMF_INI;
+        hdr.msid = NGX_RTMP_RELAY_MSID;
+        hdr.type = NGX_RTMP_MSG_AMF_META;
 
-      ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "relay: sending @setDataFrame");
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                      "relay: sending @setDataFrame");
 
-      return ngx_rtmp_send_amf(s, &hdr, out_elts,
-              sizeof(out_elts) / sizeof(out_elts[0]));
+        return ngx_rtmp_send_amf(s, &hdr, out_elts,
+                                 sizeof(out_elts) / sizeof(out_elts[0]));
     }
 
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s,
+                                          ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
-    ngx_rtmp_relay_ctx_t       *ctx;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     static struct {
-        double                  trans;
-        u_char                  level[32];
-        u_char                  code[128];
-        u_char                  desc[1024];
+        double trans;
+        u_char level[32];
+        u_char code[128];
+        u_char desc[1024];
     } v;
 
-    static ngx_rtmp_amf_elt_t   in_inf[] = {
+    static ngx_rtmp_amf_elt_t in_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          &v.level, sizeof(v.level) },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), &v.level, sizeof(v.level)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          &v.code, sizeof(v.code) },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), &v.code, sizeof(v.code)},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          &v.desc, sizeof(v.desc) },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), &v.desc,
+         sizeof(v.desc)},
     };
 
-    static ngx_rtmp_amf_elt_t   in_elts[] = {
+    static ngx_rtmp_amf_elt_t in_elts[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &v.trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &v.trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
 
-    static ngx_rtmp_amf_elt_t   in_elts_meta[] = {
+    static ngx_rtmp_amf_elt_t in_elts_meta[] = {
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          in_inf, sizeof(in_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, in_inf, sizeof(in_inf)},
     };
-
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL || !s->relay) {
@@ -1447,47 +1237,50 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ngx_memzero(&v, sizeof(v));
     if (h->type == NGX_RTMP_MSG_AMF_META) {
         ngx_rtmp_receive_amf(s, in, in_elts_meta,
-                sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
+                             sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
     } else {
         ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0]));
+                             sizeof(in_elts) / sizeof(in_elts[0]));
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-            "relay: onStatus: level='%s' code='%s' description='%s'",
-            v.level, v.code, v.desc);
+                   "relay: onStatus: level='%s' code='%s' description='%s'",
+                   v.level, v.code, v.desc);
 
     /* when doing a push to Adobe Media Server, we have to use the
      * @setDataFrame command to send the metadata
-     * see: http://help.adobe.com/en_US/adobemediaserver/devguide/WS5b3ccc516d4fbf351e63e3d11a0773d56e-7ff6Dev.2.3.html
+     * see:
+     * http://help.adobe.com/en_US/adobemediaserver/devguide/WS5b3ccc516d4fbf351e63e3d11a0773d56e-7ff6Dev.2.3.html
      */
     if (!ngx_strncasecmp(v.code, (u_char *)"NetStream.Publish.Start",
-            ngx_strlen("NetStream.Publish.Start"))) {
-
-        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "relay: sending metadata from NetStream.Publish.Start from player");
+                         ngx_strlen("NetStream.Publish.Start"))) {
+        ngx_log_error(
+            NGX_LOG_INFO, s->connection->log, 0,
+            "relay: sending metadata from NetStream.Publish.Start from player");
 
         s->ready_for_publish = 1;
 
         if (ngx_rtmp_relay_send_set_data_frame(s) != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                    "relay: unable to send metadata via @setDataFrame");
+                          "relay: unable to send metadata via @setDataFrame");
         }
     }
 
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_relay_on_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_relay_on_meta_data(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_header_t *h,
+                                             ngx_chain_t *in)
 {
     /* when we receive onMetaData, the session (s) is our incoming publisher's
-     * session, so we need to send the @setDataFrame to our ctx->play->session */
-    ngx_rtmp_relay_ctx_t       *ctx;
-    ngx_rtmp_relay_ctx_t       *pctx;
+     * session, so we need to send the @setDataFrame to our ctx->play->session
+     */
+    ngx_rtmp_relay_ctx_t *ctx;
+    ngx_rtmp_relay_ctx_t *pctx;
 
-    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+    ngx_log_error(
+        NGX_LOG_INFO, s->connection->log, 0,
         "relay: got metadata from @setDataFrame invocation from publisher.");
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
@@ -1497,23 +1290,29 @@ ngx_rtmp_relay_on_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     for (pctx = ctx->play; pctx; pctx = pctx->next) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                "relay: %ssending metadata from @setDataFrame invocation from publisher to %V/%V/%V",
-                (pctx->session->relay && pctx->session->ready_for_publish) ? "" : "not ", &pctx->url,  &pctx->app, &pctx->play_path);
-        if (!pctx->session->relay || !pctx->session->ready_for_publish) continue;
+                      "relay: %ssending metadata from @setDataFrame invocation "
+                      "from publisher to %V/%V/%V",
+                      (pctx->session->relay && pctx->session->ready_for_publish)
+                          ? ""
+                          : "not ",
+                      &pctx->url, &pctx->app, &pctx->play_path);
+        if (!pctx->session->relay || !pctx->session->ready_for_publish)
+            continue;
         if (ngx_rtmp_relay_send_set_data_frame(pctx->session) != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                    "relay: unable to send @setDataFrame to %V/%V", &pctx->url, &pctx->play_path);
+                          "relay: unable to send @setDataFrame to %V/%V",
+                          &pctx->url, &pctx->play_path);
         }
     }
 
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_relay_handshake_done(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-        ngx_chain_t *in)
+static ngx_int_t ngx_rtmp_relay_handshake_done(ngx_rtmp_session_t *s,
+                                               ngx_rtmp_header_t *h,
+                                               ngx_chain_t *in)
 {
-    ngx_rtmp_relay_ctx_t   *ctx;
+    ngx_rtmp_relay_ctx_t *ctx;
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_relay_module);
     if (ctx == NULL || !s->relay) {
@@ -1523,13 +1322,11 @@ ngx_rtmp_relay_handshake_done(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return ngx_rtmp_relay_send_connect(s);
 }
 
-
-static void
-ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
+static void ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_relay_app_conf_t          *racf;
-    ngx_rtmp_relay_ctx_t               *ctx, **cctx;
-    ngx_uint_t                          hash;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_ctx_t *ctx, **cctx;
+    ngx_uint_t hash;
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_relay_module);
 
@@ -1556,21 +1353,22 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
         }
 
         ngx_log_debug2(NGX_LOG_DEBUG_RTMP, ctx->session->connection->log, 0,
-                "relay: play disconnect app='%V' name='%V'",
-                &ctx->app, &ctx->name);
+                       "relay: play disconnect app='%V' name='%V'", &ctx->app,
+                       &ctx->name);
 
         /* push reconnect */
         if (s->relay && ctx->tag == &ngx_rtmp_relay_module &&
-            !ctx->publish->push_evt.timer_set)
-        {
+            !ctx->publish->push_evt.timer_set) {
             ngx_add_timer(&ctx->publish->push_evt, racf->push_reconnect);
         }
 
 #ifdef NGX_DEBUG
         {
-            ngx_uint_t  n = 0;
-            for (cctx = &ctx->publish->play; *cctx; cctx = &(*cctx)->next, ++n);
-            ngx_log_debug3(NGX_LOG_DEBUG_RTMP, ctx->session->connection->log, 0,
+            ngx_uint_t n = 0;
+            for (cctx = &ctx->publish->play; *cctx; cctx = &(*cctx)->next, ++n)
+                ;
+            ngx_log_debug3(
+                NGX_LOG_DEBUG_RTMP, ctx->session->connection->log, 0,
                 "relay: play left after disconnect app='%V' name='%V': %ui",
                 &ctx->app, &ctx->name, n);
         }
@@ -1578,9 +1376,9 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
 
         if (ctx->publish->play == NULL && ctx->publish->session->relay) {
             ngx_log_debug2(NGX_LOG_DEBUG_RTMP,
-                 ctx->publish->session->connection->log, 0,
-                "relay: publish disconnect empty app='%V' name='%V'",
-                &ctx->app, &ctx->name);
+                           ctx->publish->session->connection->log, 0,
+                           "relay: publish disconnect empty app='%V' name='%V'",
+                           &ctx->app, &ctx->name);
             ngx_rtmp_finalize_session(ctx->publish->session);
         }
 
@@ -1591,8 +1389,8 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
 
     /* publish end disconnect */
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, ctx->session->connection->log, 0,
-            "relay: publish disconnect app='%V' name='%V'",
-            &ctx->app, &ctx->name);
+                   "relay: publish disconnect app='%V' name='%V'", &ctx->app,
+                   &ctx->name);
 
     if (ctx->push_evt.timer_set) {
         ngx_del_timer(&ctx->push_evt);
@@ -1600,26 +1398,26 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
 
     for (cctx = &ctx->play; *cctx; cctx = &(*cctx)->next) {
         (*cctx)->publish = NULL;
-        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, (*cctx)->session->connection->log,
-            0, "relay: play disconnect orphan app='%V' name='%V'",
-            &(*cctx)->app, &(*cctx)->name);
+        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, (*cctx)->session->connection->log, 0,
+                       "relay: play disconnect orphan app='%V' name='%V'",
+                       &(*cctx)->app, &(*cctx)->name);
         ngx_rtmp_finalize_session((*cctx)->session);
     }
     ctx->publish = NULL;
 
     hash = ngx_hash_key(ctx->name.data, ctx->name.len);
     cctx = &racf->ctx[hash % racf->nbuckets];
-    for (; *cctx && *cctx != ctx; cctx = &(*cctx)->next);
+    for (; *cctx && *cctx != ctx; cctx = &(*cctx)->next)
+        ;
     if (*cctx) {
         *cctx = ctx->next;
     }
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_close_stream(ngx_rtmp_session_t *s, ngx_rtmp_close_stream_t *v)
+static ngx_int_t ngx_rtmp_relay_close_stream(ngx_rtmp_session_t *s,
+                                             ngx_rtmp_close_stream_t *v)
 {
-    ngx_rtmp_relay_app_conf_t  *racf;
+    ngx_rtmp_relay_app_conf_t *racf;
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_relay_module);
     if (racf && !racf->session_relay) {
@@ -1629,34 +1427,32 @@ ngx_rtmp_relay_close_stream(ngx_rtmp_session_t *s, ngx_rtmp_close_stream_t *v)
     return next_close_stream(s, v);
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_delete_stream(ngx_rtmp_session_t *s, ngx_rtmp_delete_stream_t *v)
+static ngx_int_t ngx_rtmp_relay_delete_stream(ngx_rtmp_session_t *s,
+                                              ngx_rtmp_delete_stream_t *v)
 {
     ngx_rtmp_relay_close(s);
 
     return next_delete_stream(s, v);
 }
 
-
-static char *
-ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+static char *ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd,
+                                      void *conf)
 {
-    ngx_str_t                          *value, v, n;
-    ngx_rtmp_relay_app_conf_t          *racf;
-    ngx_rtmp_relay_target_t            *target, **t;
-    ngx_url_t                          *u;
-    ngx_uint_t                          i;
-    ngx_int_t                           is_pull, is_static;
-    ngx_event_t                       **ee, *e;
-    ngx_rtmp_relay_static_t            *rs;
-    u_char                             *p;
+    ngx_str_t *value, v, n;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_rtmp_relay_target_t *target, **t;
+    ngx_url_t *u;
+    ngx_uint_t i;
+    ngx_int_t is_pull, is_static;
+    ngx_event_t **ee, *e;
+    ngx_rtmp_relay_static_t *rs;
+    u_char *p;
 
     value = cf->args->elts;
 
     racf = ngx_rtmp_conf_get_module_app_conf(cf, ngx_rtmp_relay_module);
 
-    is_pull = (value[0].data[3] == 'l');
+    is_pull   = (value[0].data[3] == 'l');
     is_static = 0;
 
     target = ngx_pcalloc(cf->pool, sizeof(*target));
@@ -1664,23 +1460,23 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
-    target->tag = &ngx_rtmp_relay_module;
+    target->tag  = &ngx_rtmp_relay_module;
     target->data = target;
 
-    u = &target->url;
+    u               = &target->url;
     u->default_port = 1935;
-    u->uri_part = 1;
-    u->url = value[1];
+    u->uri_part     = 1;
+    u->url          = value[1];
 
-    if (ngx_strncasecmp(u->url.data, (u_char *) "rtmp://", 7) == 0) {
+    if (ngx_strncasecmp(u->url.data, (u_char *)"rtmp://", 7) == 0) {
         u->url.data += 7;
-        u->url.len  -= 7;
+        u->url.len -= 7;
     }
 
     if (ngx_parse_url(cf->pool, u) != NGX_OK) {
         if (u->err) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                    "%s in url \"%V\"", u->err, &u->url);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "%s in url \"%V\"", u->err,
+                               &u->url);
         }
         return NGX_CONF_ERROR;
     }
@@ -1701,40 +1497,37 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             v.len  = value->data + value->len - p - 1;
         }
 
-#define NGX_RTMP_RELAY_STR_PAR(name, var)                                     \
-        if (n.len == sizeof(name) - 1                                         \
-            && ngx_strncasecmp(n.data, (u_char *) name, n.len) == 0)          \
-        {                                                                     \
-            target->var = v;                                                  \
-            continue;                                                         \
-        }
+#define NGX_RTMP_RELAY_STR_PAR(name, var)                                      \
+    if (n.len == sizeof(name) - 1 &&                                           \
+        ngx_strncasecmp(n.data, (u_char *)name, n.len) == 0) {                 \
+        target->var = v;                                                       \
+        continue;                                                              \
+    }
 
-#define NGX_RTMP_RELAY_NUM_PAR(name, var)                                     \
-        if (n.len == sizeof(name) - 1                                         \
-            && ngx_strncasecmp(n.data, (u_char *) name, n.len) == 0)          \
-        {                                                                     \
-            target->var = ngx_atoi(v.data, v.len);                            \
-            continue;                                                         \
-        }
+#define NGX_RTMP_RELAY_NUM_PAR(name, var)                                      \
+    if (n.len == sizeof(name) - 1 &&                                           \
+        ngx_strncasecmp(n.data, (u_char *)name, n.len) == 0) {                 \
+        target->var = ngx_atoi(v.data, v.len);                                 \
+        continue;                                                              \
+    }
 
-        NGX_RTMP_RELAY_STR_PAR("app",         app);
-        NGX_RTMP_RELAY_STR_PAR("name",        name);
-        NGX_RTMP_RELAY_STR_PAR("tcUrl",       tc_url);
-        NGX_RTMP_RELAY_STR_PAR("pageUrl",     page_url);
-        NGX_RTMP_RELAY_STR_PAR("swfUrl",      swf_url);
-        NGX_RTMP_RELAY_STR_PAR("flashVer",    flash_ver);
-        NGX_RTMP_RELAY_STR_PAR("playPath",    play_path);
-        NGX_RTMP_RELAY_NUM_PAR("live",        live);
-        NGX_RTMP_RELAY_NUM_PAR("start",       start);
-        NGX_RTMP_RELAY_NUM_PAR("stop",        stop);
+        NGX_RTMP_RELAY_STR_PAR("app", app);
+        NGX_RTMP_RELAY_STR_PAR("name", name);
+        NGX_RTMP_RELAY_STR_PAR("tcUrl", tc_url);
+        NGX_RTMP_RELAY_STR_PAR("pageUrl", page_url);
+        NGX_RTMP_RELAY_STR_PAR("swfUrl", swf_url);
+        NGX_RTMP_RELAY_STR_PAR("flashVer", flash_ver);
+        NGX_RTMP_RELAY_STR_PAR("playPath", play_path);
+        NGX_RTMP_RELAY_NUM_PAR("live", live);
+        NGX_RTMP_RELAY_NUM_PAR("start", start);
+        NGX_RTMP_RELAY_NUM_PAR("stop", stop);
 
 #undef NGX_RTMP_RELAY_STR_PAR
 #undef NGX_RTMP_RELAY_NUM_PAR
 
         if (n.len == sizeof("static") - 1 &&
-            ngx_strncasecmp(n.data, (u_char *) "static", n.len) == 0 &&
-            ngx_atoi(v.data, v.len))
-        {
+            ngx_strncasecmp(n.data, (u_char *)"static", n.len) == 0 &&
+            ngx_atoi(v.data, v.len)) {
             is_static = 1;
             continue;
         }
@@ -1743,7 +1536,6 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     if (is_static) {
-
         if (!is_pull) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "static push is not allowed");
@@ -1776,8 +1568,8 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
         rs->target = target;
 
-        e->data = rs;
-        e->log = &cf->cycle->new_log;
+        e->data    = rs;
+        e->log     = &cf->cycle->new_log;
         e->handler = ngx_rtmp_relay_static_pull_reconnect;
 
         t = ngx_array_push(&racf->static_pulls);
@@ -1798,19 +1590,17 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_init_process(ngx_cycle_t *cycle)
+static ngx_int_t ngx_rtmp_relay_init_process(ngx_cycle_t *cycle)
 {
 #if !(NGX_WIN32)
-    ngx_rtmp_core_main_conf_t  *cmcf = ngx_rtmp_core_main_conf;
-    ngx_rtmp_core_srv_conf_t  **pcscf, *cscf;
-    ngx_rtmp_core_app_conf_t  **pcacf, *cacf;
-    ngx_rtmp_relay_app_conf_t  *racf;
-    ngx_uint_t                  n, m, k;
-    ngx_rtmp_relay_static_t    *rs;
-    ngx_rtmp_listen_t          *lst;
-    ngx_event_t               **pevent, *event;
+    ngx_rtmp_core_main_conf_t *cmcf = ngx_rtmp_core_main_conf;
+    ngx_rtmp_core_srv_conf_t **pcscf, *cscf;
+    ngx_rtmp_core_app_conf_t **pcacf, *cacf;
+    ngx_rtmp_relay_app_conf_t *racf;
+    ngx_uint_t n, m, k;
+    ngx_rtmp_relay_static_t *rs;
+    ngx_rtmp_listen_t *lst;
+    ngx_event_t **pevent, *event;
 
     if (cmcf == NULL || cmcf->listen.nelts == 0) {
         return NGX_OK;
@@ -1826,21 +1616,19 @@ ngx_rtmp_relay_init_process(ngx_cycle_t *cycle)
 
     pcscf = cmcf->servers.elts;
     for (n = 0; n < cmcf->servers.nelts; ++n, ++pcscf) {
-
-        cscf = *pcscf;
+        cscf  = *pcscf;
         pcacf = cscf->applications.elts;
 
         for (m = 0; m < cscf->applications.nelts; ++m, ++pcacf) {
-
-            cacf = *pcacf;
-            racf = cacf->app_conf[ngx_rtmp_relay_module.ctx_index];
+            cacf   = *pcacf;
+            racf   = cacf->app_conf[ngx_rtmp_relay_module.ctx_index];
             pevent = racf->static_events.elts;
 
             for (k = 0; k < racf->static_events.nelts; ++k, ++pevent) {
                 event = *pevent;
 
-                rs = event->data;
-                rs->cctx = *lst->ctx;
+                rs                = event->data;
+                rs->cctx          = *lst->ctx;
                 rs->cctx.app_conf = cacf->app_conf;
 
                 ngx_post_event(event, &ngx_rtmp_init_queue);
@@ -1851,33 +1639,28 @@ ngx_rtmp_relay_init_process(ngx_cycle_t *cycle)
     return NGX_OK;
 }
 
-
-static ngx_int_t
-ngx_rtmp_relay_postconfiguration(ngx_conf_t *cf)
+static ngx_int_t ngx_rtmp_relay_postconfiguration(ngx_conf_t *cf)
 {
-    ngx_rtmp_core_main_conf_t          *cmcf;
-    ngx_rtmp_handler_pt                *h;
-    ngx_rtmp_amf_handler_t             *ch;
+    ngx_rtmp_core_main_conf_t *cmcf;
+    ngx_rtmp_handler_pt *h;
+    ngx_rtmp_amf_handler_t *ch;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
-
-    h = ngx_array_push(&cmcf->events[NGX_RTMP_HANDSHAKE_DONE]);
+    h  = ngx_array_push(&cmcf->events[NGX_RTMP_HANDSHAKE_DONE]);
     *h = ngx_rtmp_relay_handshake_done;
 
-
-    next_publish = ngx_rtmp_publish;
+    next_publish     = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_relay_publish;
 
-    next_play = ngx_rtmp_play;
+    next_play     = ngx_rtmp_play;
     ngx_rtmp_play = ngx_rtmp_relay_play;
 
-    next_delete_stream = ngx_rtmp_delete_stream;
+    next_delete_stream     = ngx_rtmp_delete_stream;
     ngx_rtmp_delete_stream = ngx_rtmp_relay_delete_stream;
 
-    next_close_stream = ngx_rtmp_close_stream;
+    next_close_stream     = ngx_rtmp_close_stream;
     ngx_rtmp_close_stream = ngx_rtmp_relay_close_stream;
-
 
     ch = ngx_array_push(&cmcf->amf);
     ngx_str_set(&ch->name, "_result");

--- a/ngx_rtmp_relay_module.h
+++ b/ngx_rtmp_relay_module.h
@@ -3,70 +3,63 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_RELAY_H_INCLUDED_
 #define _NGX_RTMP_RELAY_H_INCLUDED_
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
-
 
 typedef struct {
-    ngx_url_t                       url;
-    ngx_str_t                       app;
-    ngx_str_t                       name;
-    ngx_str_t                       tc_url;
-    ngx_str_t                       page_url;
-    ngx_str_t                       swf_url;
-    ngx_str_t                       flash_ver;
-    ngx_str_t                       play_path;
-    ngx_int_t                       live;
-    ngx_int_t                       start;
-    ngx_int_t                       stop;
+    ngx_url_t url;
+    ngx_str_t app;
+    ngx_str_t name;
+    ngx_str_t tc_url;
+    ngx_str_t page_url;
+    ngx_str_t swf_url;
+    ngx_str_t flash_ver;
+    ngx_str_t play_path;
+    ngx_int_t live;
+    ngx_int_t start;
+    ngx_int_t stop;
 
-    void                           *tag;     /* usually module reference */
-    void                           *data;    /* module-specific data */
-    ngx_uint_t                      counter; /* mutable connection counter */
+    void *tag;          /* usually module reference */
+    void *data;         /* module-specific data */
+    ngx_uint_t counter; /* mutable connection counter */
 } ngx_rtmp_relay_target_t;
-
 
 typedef struct ngx_rtmp_relay_ctx_s ngx_rtmp_relay_ctx_t;
 
 struct ngx_rtmp_relay_ctx_s {
-    ngx_str_t                       name;
-    ngx_str_t                       url;
-    ngx_log_t                       log;
-    ngx_rtmp_session_t             *session;
-    ngx_rtmp_relay_ctx_t           *publish;
-    ngx_rtmp_relay_ctx_t           *play;
-    ngx_rtmp_relay_ctx_t           *next;
+    ngx_str_t name;
+    ngx_str_t url;
+    ngx_log_t log;
+    ngx_rtmp_session_t *session;
+    ngx_rtmp_relay_ctx_t *publish;
+    ngx_rtmp_relay_ctx_t *play;
+    ngx_rtmp_relay_ctx_t *next;
 
-    ngx_str_t                       app;
-    ngx_str_t                       tc_url;
-    ngx_str_t                       page_url;
-    ngx_str_t                       swf_url;
-    ngx_str_t                       flash_ver;
-    ngx_str_t                       play_path;
-    ngx_int_t                       live;
-    ngx_int_t                       start;
-    ngx_int_t                       stop;
+    ngx_str_t app;
+    ngx_str_t tc_url;
+    ngx_str_t page_url;
+    ngx_str_t swf_url;
+    ngx_str_t flash_ver;
+    ngx_str_t play_path;
+    ngx_int_t live;
+    ngx_int_t start;
+    ngx_int_t stop;
 
-    ngx_event_t                     push_evt;
-    ngx_event_t                    *static_evt;
-    void                           *tag;
-    void                           *data;
+    ngx_event_t push_evt;
+    ngx_event_t *static_evt;
+    void *tag;
+    void *data;
 };
 
-
-extern ngx_module_t                 ngx_rtmp_relay_module;
-
+extern ngx_module_t ngx_rtmp_relay_module;
 
 ngx_int_t ngx_rtmp_relay_pull(ngx_rtmp_session_t *s, ngx_str_t *name,
                               ngx_rtmp_relay_target_t *target);
 ngx_int_t ngx_rtmp_relay_push(ngx_rtmp_session_t *s, ngx_str_t *name,
                               ngx_rtmp_relay_target_t *target);
-
 
 #endif /* _NGX_RTMP_RELAY_H_INCLUDED_ */

--- a/ngx_rtmp_send.c
+++ b/ngx_rtmp_send.c
@@ -3,54 +3,50 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_amf.h"
 #include "ngx_rtmp_streams.h"
+#include <ngx_config.h>
+#include <ngx_core.h>
 
-
-#define NGX_RTMP_USER_START(s, tp)                                          \
-    ngx_rtmp_header_t               __h;                                    \
-    ngx_chain_t                    *__l;                                    \
-    ngx_buf_t                      *__b;                                    \
-    ngx_rtmp_core_srv_conf_t       *__cscf;                                 \
-                                                                            \
-    __cscf = ngx_rtmp_get_module_srv_conf(                                  \
-            s, ngx_rtmp_core_module);                                       \
-    memset(&__h, 0, sizeof(__h));                                           \
-    __h.type = tp;                                                          \
-    __h.csid = 2;                                                           \
-    __l = ngx_rtmp_alloc_shared_buf(__cscf);                                \
-    if (__l == NULL) {                                                      \
-        return NULL;                                                        \
-    }                                                                       \
+#define NGX_RTMP_USER_START(s, tp)                                             \
+    ngx_rtmp_header_t __h;                                                     \
+    ngx_chain_t *__l;                                                          \
+    ngx_buf_t *__b;                                                            \
+    ngx_rtmp_core_srv_conf_t *__cscf;                                          \
+                                                                               \
+    __cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);            \
+    memset(&__h, 0, sizeof(__h));                                              \
+    __h.type = tp;                                                             \
+    __h.csid = 2;                                                              \
+    __l      = ngx_rtmp_alloc_shared_buf(__cscf);                              \
+    if (__l == NULL) {                                                         \
+        return NULL;                                                           \
+    }                                                                          \
     __b = __l->buf;
 
-#define NGX_RTMP_UCTL_START(s, type, utype)                                 \
-    NGX_RTMP_USER_START(s, type);                                           \
-    *(__b->last++) = (u_char)((utype) >> 8);                                \
+#define NGX_RTMP_UCTL_START(s, type, utype)                                    \
+    NGX_RTMP_USER_START(s, type);                                              \
+    *(__b->last++) = (u_char)((utype) >> 8);                                   \
     *(__b->last++) = (u_char)(utype);
 
-#define NGX_RTMP_USER_OUT1(v)                                               \
-    *(__b->last++) = ((u_char*)&v)[0];
+#define NGX_RTMP_USER_OUT1(v) *(__b->last++) = ((u_char *)&v)[0];
 
-#define NGX_RTMP_USER_OUT4(v)                                               \
-    *(__b->last++) = ((u_char*)&v)[3];                                      \
-    *(__b->last++) = ((u_char*)&v)[2];                                      \
-    *(__b->last++) = ((u_char*)&v)[1];                                      \
-    *(__b->last++) = ((u_char*)&v)[0];
+#define NGX_RTMP_USER_OUT4(v)                                                  \
+    *(__b->last++) = ((u_char *)&v)[3];                                        \
+    *(__b->last++) = ((u_char *)&v)[2];                                        \
+    *(__b->last++) = ((u_char *)&v)[1];                                        \
+    *(__b->last++) = ((u_char *)&v)[0];
 
-#define NGX_RTMP_USER_END(s)                                                \
-    ngx_rtmp_prepare_message(s, &__h, NULL, __l);                           \
+#define NGX_RTMP_USER_END(s)                                                   \
+    ngx_rtmp_prepare_message(s, &__h, NULL, __l);                              \
     return __l;
 
-
-static ngx_int_t
-ngx_rtmp_send_shared_packet(ngx_rtmp_session_t *s, ngx_chain_t *cl)
+static ngx_int_t ngx_rtmp_send_shared_packet(ngx_rtmp_session_t *s,
+                                             ngx_chain_t *cl)
 {
-    ngx_rtmp_core_srv_conf_t       *cscf;
-    ngx_int_t                       rc;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_int_t rc;
 
     if (cl == NULL) {
         return NGX_ERROR;
@@ -65,14 +61,13 @@ ngx_rtmp_send_shared_packet(ngx_rtmp_session_t *s, ngx_chain_t *cl)
     return rc;
 }
 
-
 /* Protocol control messages */
 
-ngx_chain_t *
-ngx_rtmp_create_chunk_size(ngx_rtmp_session_t *s, uint32_t chunk_size)
+ngx_chain_t *ngx_rtmp_create_chunk_size(ngx_rtmp_session_t *s,
+                                        uint32_t chunk_size)
 {
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "chunk_size=%uD", chunk_size);
+    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0, "chunk_size=%uD",
+                   chunk_size);
 
     {
         NGX_RTMP_USER_START(s, NGX_RTMP_MSG_CHUNK_SIZE);
@@ -83,17 +78,13 @@ ngx_rtmp_create_chunk_size(ngx_rtmp_session_t *s, uint32_t chunk_size)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_chunk_size(ngx_rtmp_session_t *s, uint32_t chunk_size)
+ngx_int_t ngx_rtmp_send_chunk_size(ngx_rtmp_session_t *s, uint32_t chunk_size)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_chunk_size(s, chunk_size));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_chunk_size(s, chunk_size));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_abort(ngx_rtmp_session_t *s, uint32_t csid)
+ngx_chain_t *ngx_rtmp_create_abort(ngx_rtmp_session_t *s, uint32_t csid)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: abort csid=%uD", csid);
@@ -107,17 +98,12 @@ ngx_rtmp_create_abort(ngx_rtmp_session_t *s, uint32_t csid)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_abort(ngx_rtmp_session_t *s, uint32_t csid)
+ngx_int_t ngx_rtmp_send_abort(ngx_rtmp_session_t *s, uint32_t csid)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_abort(s, csid));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_abort(s, csid));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_ack(ngx_rtmp_session_t *s, uint32_t seq)
+ngx_chain_t *ngx_rtmp_create_ack(ngx_rtmp_session_t *s, uint32_t seq)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: ack seq=%uD", seq);
@@ -131,17 +117,12 @@ ngx_rtmp_create_ack(ngx_rtmp_session_t *s, uint32_t seq)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_ack(ngx_rtmp_session_t *s, uint32_t seq)
+ngx_int_t ngx_rtmp_send_ack(ngx_rtmp_session_t *s, uint32_t seq)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_ack(s, seq));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_ack(s, seq));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size)
+ngx_chain_t *ngx_rtmp_create_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: ack_size=%uD", ack_size);
@@ -155,22 +136,18 @@ ngx_rtmp_create_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size)
+ngx_int_t ngx_rtmp_send_ack_size(ngx_rtmp_session_t *s, uint32_t ack_size)
 {
     return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_ack_size(s, ack_size));
+                                       ngx_rtmp_create_ack_size(s, ack_size));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
-                          uint8_t limit_type)
+ngx_chain_t *ngx_rtmp_create_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
+                                       uint8_t limit_type)
 {
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "create: bandwidth ack_size=%uD limit=%d",
-                   ack_size, (int)limit_type);
+                   "create: bandwidth ack_size=%uD limit=%d", ack_size,
+                   (int)limit_type);
 
     {
         NGX_RTMP_USER_START(s, NGX_RTMP_MSG_BANDWIDTH);
@@ -182,20 +159,16 @@ ngx_rtmp_create_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
-                        uint8_t limit_type)
+ngx_int_t ngx_rtmp_send_bandwidth(ngx_rtmp_session_t *s, uint32_t ack_size,
+                                  uint8_t limit_type)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_bandwidth(s, ack_size, limit_type));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_bandwidth(s, ack_size, limit_type));
 }
-
 
 /* User control messages */
 
-ngx_chain_t *
-ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_chain_t *ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s, uint32_t msid)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: stream_begin msid=%uD", msid);
@@ -209,17 +182,13 @@ ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s, uint32_t msid)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_stream_begin(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_int_t ngx_rtmp_send_stream_begin(ngx_rtmp_session_t *s, uint32_t msid)
 {
     return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_stream_begin(s, msid));
+                                       ngx_rtmp_create_stream_begin(s, msid));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_stream_eof(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_chain_t *ngx_rtmp_create_stream_eof(ngx_rtmp_session_t *s, uint32_t msid)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: stream_end msid=%uD", msid);
@@ -233,17 +202,12 @@ ngx_rtmp_create_stream_eof(ngx_rtmp_session_t *s, uint32_t msid)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_stream_eof(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_int_t ngx_rtmp_send_stream_eof(ngx_rtmp_session_t *s, uint32_t msid)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_stream_eof(s, msid));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_stream_eof(s, msid));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_stream_dry(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_chain_t *ngx_rtmp_create_stream_dry(ngx_rtmp_session_t *s, uint32_t msid)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: stream_dry msid=%uD", msid);
@@ -257,22 +221,16 @@ ngx_rtmp_create_stream_dry(ngx_rtmp_session_t *s, uint32_t msid)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_stream_dry(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_int_t ngx_rtmp_send_stream_dry(ngx_rtmp_session_t *s, uint32_t msid)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_stream_dry(s, msid));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_stream_dry(s, msid));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
-                           uint32_t buflen_msec)
+ngx_chain_t *ngx_rtmp_create_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
+                                        uint32_t buflen_msec)
 {
     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "create: set_buflen msid=%uD buflen=%uD",
-                   msid, buflen_msec);
+                   "create: set_buflen msid=%uD buflen=%uD", msid, buflen_msec);
 
     {
         NGX_RTMP_UCTL_START(s, NGX_RTMP_MSG_USER, NGX_RTMP_USER_SET_BUFLEN);
@@ -284,18 +242,14 @@ ngx_rtmp_create_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
-        uint32_t buflen_msec)
+ngx_int_t ngx_rtmp_send_set_buflen(ngx_rtmp_session_t *s, uint32_t msid,
+                                   uint32_t buflen_msec)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_set_buflen(s, msid, buflen_msec));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_set_buflen(s, msid, buflen_msec));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_recorded(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_chain_t *ngx_rtmp_create_recorded(ngx_rtmp_session_t *s, uint32_t msid)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: recorded msid=%uD", msid);
@@ -309,17 +263,13 @@ ngx_rtmp_create_recorded(ngx_rtmp_session_t *s, uint32_t msid)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_recorded(ngx_rtmp_session_t *s, uint32_t msid)
+ngx_int_t ngx_rtmp_send_recorded(ngx_rtmp_session_t *s, uint32_t msid)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_recorded(s, msid));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_recorded(s, msid));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_ping_request(ngx_rtmp_session_t *s, uint32_t timestamp)
+ngx_chain_t *ngx_rtmp_create_ping_request(ngx_rtmp_session_t *s,
+                                          uint32_t timestamp)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: ping_request timestamp=%uD", timestamp);
@@ -333,17 +283,14 @@ ngx_rtmp_create_ping_request(ngx_rtmp_session_t *s, uint32_t timestamp)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_ping_request(ngx_rtmp_session_t *s, uint32_t timestamp)
+ngx_int_t ngx_rtmp_send_ping_request(ngx_rtmp_session_t *s, uint32_t timestamp)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_ping_request(s, timestamp));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_ping_request(s, timestamp));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_ping_response(ngx_rtmp_session_t *s, uint32_t timestamp)
+ngx_chain_t *ngx_rtmp_create_ping_response(ngx_rtmp_session_t *s,
+                                           uint32_t timestamp)
 {
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: ping_response timestamp=%uD", timestamp);
@@ -357,40 +304,34 @@ ngx_rtmp_create_ping_response(ngx_rtmp_session_t *s, uint32_t timestamp)
     }
 }
 
-
-ngx_int_t
-ngx_rtmp_send_ping_response(ngx_rtmp_session_t *s, uint32_t timestamp)
+ngx_int_t ngx_rtmp_send_ping_response(ngx_rtmp_session_t *s, uint32_t timestamp)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_ping_response(s, timestamp));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_ping_response(s, timestamp));
 }
 
-
-static ngx_chain_t *
-ngx_rtmp_alloc_amf_buf(void *arg)
+static ngx_chain_t *ngx_rtmp_alloc_amf_buf(void *arg)
 {
     return ngx_rtmp_alloc_shared_buf((ngx_rtmp_core_srv_conf_t *)arg);
 }
 
-
 /* AMF sender */
 
 /* NOTE: this function does not free shared bufs on error */
-ngx_int_t
-ngx_rtmp_append_amf(ngx_rtmp_session_t *s,
-                    ngx_chain_t **first, ngx_chain_t **last,
-                    ngx_rtmp_amf_elt_t *elts, size_t nelts)
+ngx_int_t ngx_rtmp_append_amf(ngx_rtmp_session_t *s, ngx_chain_t **first,
+                              ngx_chain_t **last, ngx_rtmp_amf_elt_t *elts,
+                              size_t nelts)
 {
-    ngx_rtmp_amf_ctx_t          act;
-    ngx_rtmp_core_srv_conf_t   *cscf;
-    ngx_int_t                   rc;
+    ngx_rtmp_amf_ctx_t act;
+    ngx_rtmp_core_srv_conf_t *cscf;
+    ngx_int_t rc;
 
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     memset(&act, 0, sizeof(act));
-    act.arg = cscf;
+    act.arg   = cscf;
     act.alloc = ngx_rtmp_alloc_amf_buf;
-    act.log = s->connection->log;
+    act.log   = s->connection->log;
 
     if (first) {
         act.first = *first;
@@ -413,14 +354,12 @@ ngx_rtmp_append_amf(ngx_rtmp_session_t *s,
     return rc;
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                    ngx_rtmp_amf_elt_t *elts, size_t nelts)
+ngx_chain_t *ngx_rtmp_create_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                                 ngx_rtmp_amf_elt_t *elts, size_t nelts)
 {
-    ngx_chain_t                *first;
-    ngx_int_t                   rc;
-    ngx_rtmp_core_srv_conf_t   *cscf;
+    ngx_chain_t *first;
+    ngx_int_t rc;
+    ngx_rtmp_core_srv_conf_t *cscf;
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "create: amf nelts=%ui", nelts);
@@ -443,66 +382,47 @@ ngx_rtmp_create_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     return first;
 }
 
-
-ngx_int_t
-ngx_rtmp_send_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
-                  ngx_rtmp_amf_elt_t *elts, size_t nelts)
+ngx_int_t ngx_rtmp_send_amf(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
+                            ngx_rtmp_amf_elt_t *elts, size_t nelts)
 {
     return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_amf(s, h, elts, nelts));
+                                       ngx_rtmp_create_amf(s, h, elts, nelts));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code, char* level,
-                       char *desc)
+ngx_chain_t *ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code,
+                                    char *level, char *desc)
 {
-    ngx_rtmp_header_t               h;
-    static double                   trans;
+    ngx_rtmp_header_t h;
+    static double trans;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), NULL, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onStatus", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onStatus", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "create: status code='%s' level='%s' desc='%s'",
-                   code, level, desc);
+                   "create: status code='%s' level='%s' desc='%s'", code, level,
+                   desc);
 
     out_inf[0].data = level;
     out_inf[1].data = code;
     out_inf[2].data = desc;
-    trans = 0;
+    trans           = 0;
 
     memset(&h, 0, sizeof(h));
 
@@ -514,52 +434,37 @@ ngx_rtmp_create_status(ngx_rtmp_session_t *s, char *code, char* level,
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_status(ngx_rtmp_session_t *s, char *code, char* level, char *desc)
+ngx_int_t ngx_rtmp_send_status(ngx_rtmp_session_t *s, char *code, char *level,
+                               char *desc)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_status(s, code, level, desc));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_status(s, code, level, desc));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_play_status(ngx_rtmp_session_t *s, char *code, char* level,
-                            ngx_uint_t duration, ngx_uint_t bytes)
+ngx_chain_t *ngx_rtmp_create_play_status(ngx_rtmp_session_t *s, char *code,
+                                         char *level, ngx_uint_t duration,
+                                         ngx_uint_t bytes)
 {
-    ngx_rtmp_header_t               h;
-    static double                   dduration;
-    static double                   dbytes;
+    ngx_rtmp_header_t h;
+    static double dduration;
+    static double dbytes;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("duration"),
-          &dduration, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("duration"), &dduration, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("bytes"),
-          &dbytes, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("bytes"), &dbytes, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onPlayStatus", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onPlayStatus", 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
@@ -571,104 +476,86 @@ ngx_rtmp_create_play_status(ngx_rtmp_session_t *s, char *code, char* level,
     out_inf[1].data = level;
 
     dduration = duration;
-    dbytes = bytes;
+    dbytes    = bytes;
 
     memset(&h, 0, sizeof(h));
 
-    h.type = NGX_RTMP_MSG_AMF_META;
-    h.csid = NGX_RTMP_CSID_AMF;
-    h.msid = NGX_RTMP_MSID;
+    h.type      = NGX_RTMP_MSG_AMF_META;
+    h.csid      = NGX_RTMP_CSID_AMF;
+    h.msid      = NGX_RTMP_MSID;
     h.timestamp = duration;
 
     return ngx_rtmp_create_amf(s, &h, out_elts,
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code, char* level,
-                          ngx_uint_t duration, ngx_uint_t bytes)
+ngx_int_t ngx_rtmp_send_play_status(ngx_rtmp_session_t *s, char *code,
+                                    char *level, ngx_uint_t duration,
+                                    ngx_uint_t bytes)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_play_status(s, code, level, duration, bytes));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_play_status(s, code, level, duration, bytes));
 }
 
+// ----------- Based on Adobe FMS 3 application.redirectConnection description
+// --------- //
 
-// ----------- Based on Adobe FMS 3 application.redirectConnection description --------- //
-
-ngx_chain_t *
-ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *callMethod, char *desc, ngx_str_t to_url)
+ngx_chain_t *ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s,
+                                             char *callMethod, char *desc,
+                                             ngx_str_t to_url)
 {
-    ngx_rtmp_header_t               h;
-    static double                   dtrans;
-    static double                   dcode;
+    ngx_rtmp_header_t h;
+    static double dtrans;
+    static double dcode;
 
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
                    "create redirect status: got data");
 
-    ngx_log_debug5(NGX_LOG_DEBUG, s->connection->log, 0,
-                   "create redirect status: method='%s', status code='%s' level='%s' "
-                   "ex.code=%ui ex.redirect='%s'", callMethod,
-                   "NetConnection.Connect.Rejected", "error", 302, to_url.data);
+    ngx_log_debug5(
+        NGX_LOG_DEBUG, s->connection->log, 0,
+        "create redirect status: method='%s', status code='%s' level='%s' "
+        "ex.code=%ui ex.redirect='%s'",
+        callMethod, "NetConnection.Connect.Rejected", "error", 302,
+        to_url.data);
 
-    static ngx_rtmp_amf_elt_t       out_inf_ex_data[] = {
+    static ngx_rtmp_amf_elt_t out_inf_ex_data[] = {
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_string("code"),
-          &dcode, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_string("code"), &dcode, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("redirect"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("redirect"), NULL, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          "error", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), "error", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          "NetConnection.Connect.Rejected", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"),
+         "NetConnection.Connect.Rejected", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_string("ex"),
-          out_inf_ex_data,
-          sizeof(out_inf_ex_data) },
+        {NGX_RTMP_AMF_OBJECT, ngx_string("ex"), out_inf_ex_data,
+         sizeof(out_inf_ex_data)},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &dtrans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &dtrans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
                    "create redirect status: set structure data");
 
-    out_elts[0].data = callMethod;
-    out_inf[2].data = desc;
-    dcode = 302;
-    dtrans = 0;
+    out_elts[0].data        = callMethod;
+    out_inf[2].data         = desc;
+    dcode                   = 302;
+    dtrans                  = 0;
     out_inf_ex_data[1].data = to_url.data;
 
     ngx_memzero(&h, sizeof(h));
@@ -681,38 +568,31 @@ ngx_rtmp_create_redirect_status(ngx_rtmp_session_t *s, char *callMethod, char *d
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s,
-                          char *callMethod, char *desc, ngx_str_t to_url)
+ngx_int_t ngx_rtmp_send_redirect_status(ngx_rtmp_session_t *s, char *callMethod,
+                                        char *desc, ngx_str_t to_url)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_redirect_status(s, callMethod, desc, to_url));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_redirect_status(s, callMethod, desc, to_url));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_close_method(ngx_rtmp_session_t *s, char *methodName)
+ngx_chain_t *ngx_rtmp_create_close_method(ngx_rtmp_session_t *s,
+                                          char *methodName)
 {
-    ngx_rtmp_header_t               h;
-    static double                   dtrans;
+    ngx_rtmp_header_t h;
+    static double dtrans;
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &dtrans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &dtrans, 0},
     };
 
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
                    "create close method: set structure data");
 
     out_elts[0].data = methodName;
-    dtrans = 0;
+    dtrans           = 0;
 
     ngx_memzero(&h, sizeof(h));
 
@@ -724,61 +604,42 @@ ngx_rtmp_create_close_method(ngx_rtmp_session_t *s, char *methodName)
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_close_method(ngx_rtmp_session_t *s, char *methodName)
+ngx_int_t ngx_rtmp_send_close_method(ngx_rtmp_session_t *s, char *methodName)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_close_method(s, methodName));
+    return ngx_rtmp_send_shared_packet(
+        s, ngx_rtmp_create_close_method(s, methodName));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_fcpublish(ngx_rtmp_session_t *s, u_char *desc)
+ngx_chain_t *ngx_rtmp_create_fcpublish(ngx_rtmp_session_t *s, u_char *desc)
 {
-    ngx_rtmp_header_t               h;
-    static double                   trans;
+    ngx_rtmp_header_t h;
+    static double trans;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          "status", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), "status", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          "NetStream.Publish.Start", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), "NetStream.Publish.Start", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), NULL, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onFCPublish", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onFCPublish", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
                    "create: fcpublish - set structure data");
 
     out_inf[2].data = desc;
-//    trans = 3.0;                // magick from ffmpeg
+    //    trans = 3.0;                // magick from ffmpeg
     trans = 0;
 
     memset(&h, 0, sizeof(h));
@@ -791,61 +652,42 @@ ngx_rtmp_create_fcpublish(ngx_rtmp_session_t *s, u_char *desc)
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_fcpublish(ngx_rtmp_session_t *s, u_char *desc)
+ngx_int_t ngx_rtmp_send_fcpublish(ngx_rtmp_session_t *s, u_char *desc)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_fcpublish(s, desc));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_fcpublish(s, desc));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_fcunpublish(ngx_rtmp_session_t *s, u_char *desc)
+ngx_chain_t *ngx_rtmp_create_fcunpublish(ngx_rtmp_session_t *s, u_char *desc)
 {
-    ngx_rtmp_header_t               h;
-    static double                   trans;
+    ngx_rtmp_header_t h;
+    static double trans;
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("level"),
-          "status", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("level"), "status", 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("code"),
-          "NetStream.Unpublish.Success", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("code"), "NetStream.Unpublish.Success",
+         0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("description"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("description"), NULL, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onFCUnpublish", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onFCUnpublish", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     ngx_log_debug0(NGX_LOG_DEBUG, s->connection->log, 0,
                    "create: fcunpublish - set structure data");
 
     out_inf[2].data = desc;
-//    trans = 5.0;                // magick from ffmpeg
+    //    trans = 5.0;                // magick from ffmpeg
     trans = 0;
 
     memset(&h, 0, sizeof(h));
@@ -858,57 +700,38 @@ ngx_rtmp_create_fcunpublish(ngx_rtmp_session_t *s, u_char *desc)
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_fcunpublish(ngx_rtmp_session_t *s, u_char *desc)
+ngx_int_t ngx_rtmp_send_fcunpublish(ngx_rtmp_session_t *s, u_char *desc)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_fcunpublish(s, desc));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_fcunpublish(s, desc));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_fi(ngx_rtmp_session_t *s)
+ngx_chain_t *ngx_rtmp_create_fi(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_header_t               h;
-    static double                   trans;
+    ngx_rtmp_header_t h;
+    static double trans;
 
-    struct tm                       tm;
-    struct timeval                  tv;
+    struct tm tm;
+    struct timeval tv;
 
-    static u_char                   buf_time[NGX_TIME_T_LEN*2 + 1];
-    static u_char                   buf_date[NGX_TIME_T_LEN + 1];
+    static u_char buf_time[NGX_TIME_T_LEN * 2 + 1];
+    static u_char buf_date[NGX_TIME_T_LEN + 1];
 
+    static ngx_rtmp_amf_elt_t out_inf[] = {
 
-    static ngx_rtmp_amf_elt_t       out_inf[] = {
+        {NGX_RTMP_AMF_STRING, ngx_string("st"), NULL, 0},
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("st"),
-          NULL, 0 },
-
-        { NGX_RTMP_AMF_STRING,
-          ngx_string("sd"),
-          NULL, 0 },
+        {NGX_RTMP_AMF_STRING, ngx_string("sd"), NULL, 0},
     };
 
-    static ngx_rtmp_amf_elt_t       out_elts[] = {
+    static ngx_rtmp_amf_elt_t out_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "onFi", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "onFi", 0},
 
-        { NGX_RTMP_AMF_NUMBER,
-          ngx_null_string,
-          &trans, 0 },
+        {NGX_RTMP_AMF_NUMBER, ngx_null_string, &trans, 0},
 
-        { NGX_RTMP_AMF_NULL,
-          ngx_null_string,
-          NULL, 0 },
+        {NGX_RTMP_AMF_NULL, ngx_null_string, NULL, 0},
 
-        { NGX_RTMP_AMF_OBJECT,
-          ngx_null_string,
-          out_inf,
-          sizeof(out_inf) },
+        {NGX_RTMP_AMF_OBJECT, ngx_null_string, out_inf, sizeof(out_inf)},
     };
 
     trans = 0;
@@ -920,9 +743,11 @@ ngx_rtmp_create_fi(ngx_rtmp_session_t *s)
     ngx_memzero(buf_time, sizeof(buf_time));
     ngx_memzero(buf_date, sizeof(buf_date));
 
-    ngx_sprintf(buf_time, "%02d:%02d:%02d.%06d", tm.tm_hour, tm.tm_min, tm.tm_sec, (int)tv.tv_usec);
+    ngx_sprintf(buf_time, "%02d:%02d:%02d.%06d", tm.tm_hour, tm.tm_min,
+                tm.tm_sec, (int)tv.tv_usec);
     // Strange order, but FMLE send like this
-    ngx_sprintf(buf_date, "%02d-%02d-%04d", tm.tm_mday, tm.tm_mon + 1, tm.tm_year + 1900);
+    ngx_sprintf(buf_date, "%02d-%02d-%04d", tm.tm_mday, tm.tm_mon + 1,
+                tm.tm_year + 1900);
 
     out_inf[0].data = buf_time;
     out_inf[1].data = buf_date;
@@ -937,35 +762,24 @@ ngx_rtmp_create_fi(ngx_rtmp_session_t *s)
                                sizeof(out_elts) / sizeof(out_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_fi(ngx_rtmp_session_t *s)
+ngx_int_t ngx_rtmp_send_fi(ngx_rtmp_session_t *s)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_fi(s));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_fi(s));
 }
 
-
-ngx_chain_t *
-ngx_rtmp_create_sample_access(ngx_rtmp_session_t *s)
+ngx_chain_t *ngx_rtmp_create_sample_access(ngx_rtmp_session_t *s)
 {
-    ngx_rtmp_header_t               h;
+    ngx_rtmp_header_t h;
 
-    static int                      access = 1;
+    static int access = 1;
 
-    static ngx_rtmp_amf_elt_t       access_elts[] = {
+    static ngx_rtmp_amf_elt_t access_elts[] = {
 
-        { NGX_RTMP_AMF_STRING,
-          ngx_null_string,
-          "|RtmpSampleAccess", 0 },
+        {NGX_RTMP_AMF_STRING, ngx_null_string, "|RtmpSampleAccess", 0},
 
-        { NGX_RTMP_AMF_BOOLEAN,
-          ngx_null_string,
-          &access, 0 },
+        {NGX_RTMP_AMF_BOOLEAN, ngx_null_string, &access, 0},
 
-        { NGX_RTMP_AMF_BOOLEAN,
-          ngx_null_string,
-          &access, 0 },
+        {NGX_RTMP_AMF_BOOLEAN, ngx_null_string, &access, 0},
     };
 
     memset(&h, 0, sizeof(h));
@@ -978,10 +792,7 @@ ngx_rtmp_create_sample_access(ngx_rtmp_session_t *s)
                                sizeof(access_elts) / sizeof(access_elts[0]));
 }
 
-
-ngx_int_t
-ngx_rtmp_send_sample_access(ngx_rtmp_session_t *s)
+ngx_int_t ngx_rtmp_send_sample_access(ngx_rtmp_session_t *s)
 {
-    return ngx_rtmp_send_shared_packet(s,
-           ngx_rtmp_create_sample_access(s));
+    return ngx_rtmp_send_shared_packet(s, ngx_rtmp_create_sample_access(s));
 }

--- a/ngx_rtmp_shared.c
+++ b/ngx_rtmp_shared.c
@@ -3,32 +3,27 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
+#include "ngx_rtmp.h"
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include "ngx_rtmp.h"
 
-
-ngx_chain_t *
-ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf)
+ngx_chain_t *ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf)
 {
-    u_char                     *p;
-    ngx_chain_t                *out;
-    ngx_buf_t                  *b;
-    size_t                      size;
+    u_char *p;
+    ngx_chain_t *out;
+    ngx_buf_t *b;
+    size_t size;
 
     if (cscf->free) {
-        out = cscf->free;
+        out        = cscf->free;
         cscf->free = out->next;
 
     } else {
-
         size = cscf->chunk_size + NGX_RTMP_MAX_CHUNK_HEADER;
 
-        p = ngx_pcalloc(cscf->pool, NGX_RTMP_REFCOUNT_BYTES
-                + sizeof(ngx_chain_t)
-                + sizeof(ngx_buf_t)
-                + size);
+        p = ngx_pcalloc(cscf->pool, NGX_RTMP_REFCOUNT_BYTES +
+                                        sizeof(ngx_chain_t) +
+                                        sizeof(ngx_buf_t) + size);
         if (p == NULL) {
             return NULL;
         }
@@ -41,13 +36,13 @@ ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf)
 
         p += sizeof(ngx_buf_t);
         out->buf->start = p;
-        out->buf->end = p + size;
+        out->buf->end   = p + size;
     }
 
     out->next = NULL;
-    b = out->buf;
+    b         = out->buf;
     b->pos = b->last = b->start + NGX_RTMP_MAX_CHUNK_HEADER;
-    b->memory = 1;
+    b->memory        = 1;
 
     /* buffer has refcount =1 when created! */
     ngx_rtmp_ref_set(out, 1);
@@ -55,45 +50,41 @@ ngx_rtmp_alloc_shared_buf(ngx_rtmp_core_srv_conf_t *cscf)
     return out;
 }
 
-
-void
-ngx_rtmp_free_shared_chain(ngx_rtmp_core_srv_conf_t *cscf, ngx_chain_t *in)
+void ngx_rtmp_free_shared_chain(ngx_rtmp_core_srv_conf_t *cscf, ngx_chain_t *in)
 {
-    ngx_chain_t        *cl;
+    ngx_chain_t *cl;
 
     if (ngx_rtmp_ref_put(in)) {
         return;
     }
 
-    for (cl = in; ; cl = cl->next) {
+    for (cl = in;; cl = cl->next) {
         if (cl->next == NULL) {
-            cl->next = cscf->free;
+            cl->next   = cscf->free;
             cscf->free = in;
             return;
         }
     }
 }
 
-
-ngx_chain_t *
-ngx_rtmp_append_shared_bufs(ngx_rtmp_core_srv_conf_t *cscf,
-        ngx_chain_t *head, ngx_chain_t *in)
+ngx_chain_t *ngx_rtmp_append_shared_bufs(ngx_rtmp_core_srv_conf_t *cscf,
+                                         ngx_chain_t *head, ngx_chain_t *in)
 {
-    ngx_chain_t                    *l, **ll;
-    u_char                         *p;
-    size_t                          size;
+    ngx_chain_t *l, **ll;
+    u_char *p;
+    size_t size;
 
     ll = &head;
-    p = in->buf->pos;
-    l = head;
+    p  = in->buf->pos;
+    l  = head;
 
     if (l) {
-        for(; l->next; l = l->next);
+        for (; l->next; l = l->next)
+            ;
         ll = &l->next;
     }
 
-    for ( ;; ) {
-
+    for (;;) {
         if (l == NULL || l->buf->last == l->buf->end) {
             l = ngx_rtmp_alloc_shared_buf(cscf);
             if (l == NULL || l->buf == NULL) {
@@ -101,20 +92,19 @@ ngx_rtmp_append_shared_bufs(ngx_rtmp_core_srv_conf_t *cscf,
             }
 
             *ll = l;
-            ll = &l->next;
+            ll  = &l->next;
         }
 
         while (l->buf->end - l->buf->last >= in->buf->last - p) {
-            l->buf->last = ngx_cpymem(l->buf->last, p,
-                    in->buf->last - p);
-            in = in->next;
+            l->buf->last = ngx_cpymem(l->buf->last, p, in->buf->last - p);
+            in           = in->next;
             if (in == NULL) {
                 goto done;
             }
             p = in->buf->pos;
         }
 
-        size = l->buf->end - l->buf->last;
+        size         = l->buf->end - l->buf->last;
         l->buf->last = ngx_cpymem(l->buf->last, p, size);
         p += size;
     }

--- a/ngx_rtmp_streams.h
+++ b/ngx_rtmp_streams.h
@@ -3,17 +3,14 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_STREAMS_H_INCLUDED_
 #define _NGX_RTMP_STREAMS_H_INCLUDED_
 
+#define NGX_RTMP_MSID 1
 
-#define NGX_RTMP_MSID                   1
-
-#define NGX_RTMP_CSID_AMF_INI           3
-#define NGX_RTMP_CSID_AMF               5
-#define NGX_RTMP_CSID_AUDIO             6
-#define NGX_RTMP_CSID_VIDEO             7
-
+#define NGX_RTMP_CSID_AMF_INI 3
+#define NGX_RTMP_CSID_AMF 5
+#define NGX_RTMP_CSID_AUDIO 6
+#define NGX_RTMP_CSID_VIDEO 7
 
 #endif /* _NGX_RTMP_STREAMS_H_INCLUDED_ */

--- a/ngx_rtmp_version.h
+++ b/ngx_rtmp_version.h
@@ -3,13 +3,10 @@
  * Copyright (C) Roman Arutyunyan
  */
 
-
 #ifndef _NGX_RTMP_VERSION_H_INCLUDED_
 #define _NGX_RTMP_VERSION_H_INCLUDED_
 
-
-#define nginx_rtmp_version  1001007
-#define NGINX_RTMP_VERSION  "1.1.7.11-dev"
-
+#define nginx_rtmp_version 1001007
+#define NGINX_RTMP_VERSION "1.1.7.11-dev"
 
 #endif /* _NGX_RTMP_VERSION_H_INCLUDED_ */


### PR DESCRIPTION
http://nginx.org/en/docs/contributing_changes.html#formatting_changes
http://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options

- Based LLVM
- Break before braces Linux
- Column  80
- Indent 4
- Never tabs
- No short functions single line

```bash
cd nginx-rtmp-module
clang-format -style=file -sort-includes -i (ls *.{c,h} dash/*.{c,h} hls/*.{c,h})
```