### PR TITLE
Fix returning 40x on_update handler to correctly disconnect client

### DIFF
--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -1502,7 +1502,7 @@ ngx_rtmp_notify_update_handle(ngx_rtmp_session_t *s,
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
 
-    if ((!nacf->update_strict && rc == NGX_ERROR) ||
+    if ((!nacf->update_strict && (rc == NGX_ERROR || rc == NGX_DECLINED) ) ||
          (nacf->update_strict && rc != NGX_OK))
     {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,


### PR DESCRIPTION
Since the changes to the notify update handler were included, on_update was left out and not set to recognise a 4xx return code.

If I returned 403 when the `on_update` callback was called for a client, it did not disconnect the client.

This fixes that 👍 