### PR TITLE
`exec_record_started' call moved

### DIFF
--- a/ngx_rtmp_exec_module.c
+++ b/ngx_rtmp_exec_module.c
@@ -1321,9 +1321,6 @@ next:
 static ngx_int_t
 ngx_rtmp_exec_record_started(ngx_rtmp_session_t *s, ngx_rtmp_record_started_t *v)
 {
-    u_char                     c;
-    ngx_uint_t                 ext, dir;
-    ngx_rtmp_exec_ctx_t       *ctx;
     ngx_rtmp_exec_app_conf_t  *eacf;
 
     if (s->auto_pushed) {
@@ -1335,37 +1332,6 @@ ngx_rtmp_exec_record_started(ngx_rtmp_session_t *s, ngx_rtmp_record_started_t *v
         goto next;
     }
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_exec_module);
-    if (ctx == NULL) {
-        goto next;
-    }
-
-    ctx->recorder = v->recorder;
-    ctx->path = v->path;
-
-    ctx->dirname.data = ctx->path.data;
-    ctx->dirname.len = 0;
-
-    for (dir = ctx->path.len; dir > 0; dir--) {
-        c = ctx->path.data[dir - 1];
-        if (c == '/' || c == '\\') {
-            ctx->dirname.len = dir - 1;
-            break;
-        }
-    }
-
-    ctx->filename.data = ctx->path.data + dir;
-    ctx->filename.len = ctx->path.len - dir;
-
-    ctx->basename = ctx->filename;
-
-    for (ext = ctx->filename.len; ext > 0; ext--) {
-        if (ctx->filename.data[ext - 1] == '.') {
-            ctx->basename.len = ext - 1;
-            break;
-        }
-    }
-
     ngx_rtmp_exec_unmanaged(s, &eacf->conf[NGX_RTMP_EXEC_RECORD_STARTED],
                             "record_started");
 
@@ -1375,6 +1341,7 @@ ngx_rtmp_exec_record_started(ngx_rtmp_session_t *s, ngx_rtmp_record_started_t *v
 next:
     return next_record_started(s, v);
 }
+
 
 static ngx_int_t
 ngx_rtmp_exec_record_done(ngx_rtmp_session_t *s, ngx_rtmp_record_done_t *v)

--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -661,7 +661,6 @@ ngx_rtmp_record_start(ngx_rtmp_session_t *s)
     ngx_rtmp_record_app_conf_t     *racf;
     ngx_rtmp_record_rec_ctx_t      *rctx;
     ngx_rtmp_record_ctx_t          *ctx;
-    ngx_rtmp_record_started_t       v;
     ngx_uint_t                      n;
 
     racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_record_module);
@@ -684,11 +683,6 @@ ngx_rtmp_record_start(ngx_rtmp_session_t *s)
         }
         ngx_rtmp_record_node_open(s, rctx);
     }
-
-    v.recorder = racf->id;
-    ngx_rtmp_record_make_path(s, rctx, &v.path);
-
-    ngx_rtmp_record_started(s, &v);
 }
 
 
@@ -863,6 +857,8 @@ ngx_rtmp_record_node_close(ngx_rtmp_session_t *s,
     v.recorder = rracf->id;
     ngx_rtmp_record_make_path(s, rctx, &v.path);
 
+    rctx->record_started = 0;
+
     rc = ngx_rtmp_record_done(s, &v);
 
     s->app_conf = app_conf;
@@ -910,6 +906,21 @@ ngx_rtmp_record_write_frame(ngx_rtmp_session_t *s,
     }
     if (h->type == NGX_RTMP_MSG_AUDIO) {
         rctx->audio = 1;
+    }
+
+    if (rctx->record_started == 0)
+    {
+        rctx->record_started = 1;
+
+        ngx_rtmp_record_started_t       v;
+        ngx_rtmp_record_app_conf_t     *racf;
+        racf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_record_module);
+
+        if (racf != NULL && racf->rec.nelts != 0) {
+            v.recorder = racf->id;
+            v.path = racf->path;
+            ngx_rtmp_record_started(s, &v);
+        }
     }
 
     timestamp = h->timestamp - rctx->epoch;

--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -54,6 +54,7 @@ typedef struct {
     unsigned                            video_key_sent:1;
     unsigned                            audio:1;
     unsigned                            video:1;
+    unsigned                            record_started:1;
 } ngx_rtmp_record_rec_ctx_t;
 
 


### PR DESCRIPTION
The current `exec_record_started' is fired when the file is created, and this might not reflect what we really want: in a real scenario we might be interested in been notified when the file is going to be filled in. That's what this MR is for.