### PR TITLE
Revert "Add event-based handle of reload/exit signal"

### DIFF
--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -222,7 +222,7 @@ typedef struct {
     /* handshake data */
     ngx_buf_t              *hs_buf;
     u_char                 *hs_digest;
-    u_char                  hs_old;
+    unsigned                hs_old:1;
     ngx_uint_t              hs_stage;
 
     /* connection timestamps */
@@ -232,20 +232,17 @@ typedef struct {
     uint32_t                current_time;
 
     /* ready for publishing? */
-    u_char                  ready_for_publish;
+    unsigned                ready_for_publish:1;
 
     /* ping */
     ngx_event_t             ping_evt;
-    u_char                  ping_active;
-    u_char                  ping_reset;
-
-    /* reload */
-    ngx_event_t             exit_evt;
+    unsigned                ping_active:1;
+    unsigned                ping_reset:1;
 
     /* auto-pushed? */
-    u_char                  auto_pushed;
-    u_char                  relay;
-    u_char                  static_relay;
+    unsigned                auto_pushed:1;
+    unsigned                relay:1;
+    unsigned                static_relay:1;
 
     /* input stream 0 (reserved by RTMP spec)
      * is used as free chain link */
@@ -317,10 +314,6 @@ typedef struct ngx_rtmp_core_srv_conf_s {
     ngx_msec_t              timeout;
     ngx_msec_t              ping;
     ngx_msec_t              ping_timeout;
-
-    /* Just define, no option really */
-    ngx_msec_t              exit_check;
-
     ngx_flag_t              so_keepalive;
     ngx_int_t               max_streams;
 
@@ -417,7 +410,6 @@ void ngx_rtmp_client_handshake(ngx_rtmp_session_t *s, unsigned async);
 void ngx_rtmp_free_handshake_buffers(ngx_rtmp_session_t *s);
 void ngx_rtmp_cycle(ngx_rtmp_session_t *s);
 void ngx_rtmp_reset_ping(ngx_rtmp_session_t *s);
-void ngx_rtmp_reset_exit(ngx_rtmp_session_t *s);
 ngx_int_t ngx_rtmp_fire_event(ngx_rtmp_session_t *s, ngx_uint_t evt,
         ngx_rtmp_header_t *h, ngx_chain_t *in);
 

--- a/ngx_rtmp_cmd_module.c
+++ b/ngx_rtmp_cmd_module.c
@@ -797,6 +797,7 @@ ngx_rtmp_cmd_playlist(ngx_rtmp_session_t *s, ngx_rtmp_playlist_t *v)
 }
 
 
+
 static ngx_rtmp_amf_handler_t ngx_rtmp_cmd_map[] = {
     { ngx_string("connect"),            ngx_rtmp_cmd_connect_init           },
     { ngx_string("createStream"),       ngx_rtmp_cmd_create_stream_init     },

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -238,7 +238,6 @@ ngx_rtmp_core_create_srv_conf(ngx_conf_t *cf)
     conf->timeout = NGX_CONF_UNSET_MSEC;
     conf->ping = NGX_CONF_UNSET_MSEC;
     conf->ping_timeout = NGX_CONF_UNSET_MSEC;
-    conf->exit_check = NGX_CONF_UNSET_MSEC;
     conf->so_keepalive = NGX_CONF_UNSET;
     conf->max_streams = NGX_CONF_UNSET;
     conf->chunk_size = NGX_CONF_UNSET;
@@ -264,9 +263,6 @@ ngx_rtmp_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_msec_value(conf->timeout, prev->timeout, 60000);
     ngx_conf_merge_msec_value(conf->ping, prev->ping, 60000);
     ngx_conf_merge_msec_value(conf->ping_timeout, prev->ping_timeout, 30000);
-
-    /* Dirty hack */
-    ngx_conf_merge_msec_value(conf->exit_check, prev->exit_check, 1000);
 
     ngx_conf_merge_value(conf->so_keepalive, prev->so_keepalive, 0);
     ngx_conf_merge_value(conf->max_streams, prev->max_streams, 32);

--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -18,6 +18,7 @@ static ngx_rtmp_pause_pt                next_pause;
 static ngx_rtmp_stream_begin_pt         next_stream_begin;
 static ngx_rtmp_stream_eof_pt           next_stream_eof;
 
+
 static ngx_int_t ngx_rtmp_live_postconfiguration(ngx_conf_t *cf);
 static void * ngx_rtmp_live_create_app_conf(ngx_conf_t *cf);
 static char * ngx_rtmp_live_merge_app_conf(ngx_conf_t *cf,
@@ -26,6 +27,7 @@ static char *ngx_rtmp_live_set_msec_slot(ngx_conf_t *cf, ngx_command_t *cmd,
        void *conf);
 static void ngx_rtmp_live_start(ngx_rtmp_session_t *s);
 static void ngx_rtmp_live_stop(ngx_rtmp_session_t *s);
+
 
 static ngx_command_t  ngx_rtmp_live_commands[] = {
 
@@ -1528,4 +1530,3 @@ ngx_rtmp_live_postconfiguration(ngx_conf_t *cf)
 
     return NGX_OK;
 }
-

--- a/ngx_rtmp_play_module.c
+++ b/ngx_rtmp_play_module.c
@@ -18,6 +18,7 @@ static ngx_rtmp_close_stream_pt         next_close_stream;
 static ngx_rtmp_seek_pt                 next_seek;
 static ngx_rtmp_pause_pt                next_pause;
 
+
 static char *ngx_rtmp_play_url(ngx_conf_t *cf, ngx_command_t *cmd,
        void *conf);
 static void *ngx_rtmp_play_create_main_conf(ngx_conf_t *cf);
@@ -52,6 +53,7 @@ static ngx_rtmp_play_entry_t * ngx_rtmp_play_get_current_entry(
 static void ngx_rtmp_play_cleanup_local_file(ngx_rtmp_session_t *s);
 static void ngx_rtmp_play_copy_local_file(ngx_rtmp_session_t *s, u_char *name);
 static u_char * ngx_rtmp_play_get_local_file_path(ngx_rtmp_session_t *s);
+
 
 static ngx_command_t  ngx_rtmp_play_commands[] = {
 
@@ -1349,4 +1351,3 @@ ngx_rtmp_play_postconfiguration(ngx_conf_t *cf)
 
     return NGX_OK;
 }
-


### PR DESCRIPTION
Reverts sergey-dryabzhinsky/nginx-rtmp-module#199

Realy weird action by me.

We need to close ALL seccions and connections, not only one with timer event.
Need to rework branch.