### PR TITLE
Disable fall through warning

### DIFF
--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -76,7 +76,8 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
             break;
 #endif
-
+                
+        /* fall through */
         case AF_UNIX:
             unix_socket = 1;
 


### PR DESCRIPTION
`ngx_rtmp_init.c:81:25: error: this statement may fall through [-Werror=implicit-fallthrough=]`