### PR TITLE
Write EXT-X-PROGRAM-DATE-TIME before any EXT-X-DISCONTINUITY

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -608,7 +608,7 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
 
     for (i = 0; i < ctx->nfrags; i++) {
         f = ngx_rtmp_hls_get_frag(s, i);
-        if (i == 0 && f->datetime && f->datetime->len > 0) {
+        if ((i == 0 || f->discont) && f->datetime && f->datetime->len > 0) {
             p = ngx_snprintf(buffer, sizeof(buffer), "#EXT-X-PROGRAM-DATE-TIME:");
             n = ngx_write_fd(fd, buffer, p - buffer);
             if (n < 0) {


### PR DESCRIPTION
According to the [RFC](https://tools.ietf.org/html/draft-pantos-http-live-streaming-13#section-6.2.1) the `EXT-X-PROGRAM-DATE-TIME` tag should be written before any segments that have an `EXT-X-DISCONTINUITY` associated with them:

>  The server MAY associate an absolute date and time with a media segment by applying an EXT-X-PROGRAM-DATE-TIME tag to it.  This defines an informative mapping of the (wall-clock) date and time specified by the tag to the first media timestamp in the segment, which may be used as a basis for seeking, for display, or for other purposes.  **If a server provides this mapping, it SHOULD apply an EXT-X-PROGRAM-DATE-TIME tag to every segment that has an EXT-X-DISCONTINUITY tag applied to it.**