### PR TITLE
Add wait_keyframe feature in the record module

### DIFF
--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -33,6 +33,7 @@ typedef struct {
     ngx_flag_t                          append;
     ngx_flag_t                          lock_file;
     ngx_flag_t                          notify;
+    ngx_flag_t                          wait_keyframe;
     ngx_url_t                          *url;
 
     void                              **rec_conf;


### PR DESCRIPTION
I'm using the record module with a low record_interval (1 minute).
When I try to merge the segment files, the video stutters because the segment files have no video frame before the first key frame, and the first key frame can only appear after a few seconds.

This pull request provides an option "record_wait_keyframe"; when enabled, the next segment file always starts with a keyframe.

Tested with nginx 1.13.8, and behaviour verified with `ffprobe -show_frames`.

First video frame in a segment file with record_wait_keyframe **disabled**:
```
[FRAME]
media_type=video
stream_index=1
key_frame=1
pkt_pts=1251
pkt_pts_time=1.251000
...
[/FRAME]
```

First video frame in a segment file with record_wait_keyframe **enabled**:
```
[FRAME]
media_type=video
stream_index=1
key_frame=1
pkt_pts=80
pkt_pts_time=0.080000
...
[/FRAME]
```