### PR TITLE
For video streams, wait for a video keyframe before rotating the file.

### DIFF
--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -1103,7 +1103,7 @@ ngx_rtmp_record_node_avd(ngx_rtmp_session_t *s, ngx_rtmp_record_rec_ctx_t *rctx,
         return NGX_OK;
     }
 
-    if (rracf->interval != NGX_CONF_UNSET_MSEC)
+    if (brkframe && rracf->interval != NGX_CONF_UNSET_MSEC)
     {
 	// record interval should work if set, manual mode or not
         next = rctx->last;


### PR DESCRIPTION
Fixes https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/issues/335

Video streams need a keyframe to start each file, so wait until the next video keyframe _after_ `record_interval` before rotating the file.

Audio-only streams will always have `brkframe = true`, so will always be eligible to rotate.

**Test:** with `record_interval 1m`, sending a video stream (`h264+aac`) with a keyframe interval of 10 seconds causes the segments to not always be cut on the same second:

```
room1_2021-07-17_17_11_33.flv
room1_2021-07-17_17_12_33.flv
room1_2021-07-17_17_13_43.flv
```

Playing back all segments in sequence (or concatenating it into a single file) results in a continuous stream, with no missing frames or stuttering.
