### PR TITLE
Add RTMPS relay support

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -69,6 +69,13 @@ Table of Contents
     * [push](#push)
     * [push_reconnect](#push_reconnect)
     * [session_relay](#session_relay)
+    * [rtmp_relay_ssl_protocols](#rtmp_relay_ssl_protocols)
+    * [rtmp_relay_ssl_ciphers](#rtmp_relay_ssl_ciphers)
+    * [rtmp_relay_ssl_server_name](#rtmp_relay_ssl_server_name)
+    * [rtmp_relay_ssl_verify](#rtmp_relay_ssl_verify)
+    * [rtmp_relay_ssl_verify_depth](#rtmp_relay_ssl_verify_depth)
+    * [rtmp_relay_ssl_trusted_certificate](#rtmp_relay_ssl_trusted_certificate)
+    * [rtmp_relay_ssl_crl](#rtmp_relay_ssl_crl)
 * [Notify](#notify)
     * [on_connect](#on_connect)
     * [on_play](#on_play)
@@ -913,6 +920,8 @@ all local streams within application are pulled
 * start - start time in seconds
 * stop - stop time in seconds
 * static - makes pull static, such pull is created at nginx start
+* ssl_server_name - overrides rtmp_relay_ssl_server_name directive, values: on, off
+* ssl_verify - overrides rtmp_relay_ssl_verify directive, values: on, off
 
 If a value for a parameter contains spaces then you should use quotes around
 the **WHOLE** key=value pair like this : `'pageUrl=FAKE PAGE URL'`.
@@ -948,6 +957,71 @@ When the setting is off relay is destroyed when stream is closed so that another
 could possibly be created later. Default is off.
 ```sh
 session_relay on;
+```
+
+#### rtmp_relay_ssl_protocols  
+Syntax: `rtmp_relay_ssl_protocols [SSLv2] [SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2] [TLSv1.3];`  
+Context: rtmp, server, application  
+
+Enables the specified protocols for streams pushed/pulled to/from the RTMPS server. Default is TLSv1 TLSv1.1 TLSv1.2.
+```sh
+rtmp_relay_ssl_protocols TLSv1.2 TLSv1.3;
+```
+
+#### rtmp_relay_ssl_ciphers  
+Syntax: `rtmp_relay_ssl_ciphers ciphers;`  
+Context: rtmp, server, application  
+
+Specifies the enabled ciphers for for streams pushed/pulled to/from the RTMPS server. The ciphers are specified in the format understood by the OpenSSL library. Default is openssl `DEFAULT`.  
+
+The full list can be viewed using the `openssl ciphers` command.  
+```sh
+rtmp_relay_ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+```
+
+#### rtmp_relay_ssl_server_name  
+Syntax: `rtmp_relay_ssl_server_name on | off;`  
+Context: rtmp, server, application  
+
+Enables or disables passing of the server name through TLS Server Name Indication extension (SNI, RFC 6066) when establishing a connection with the RTMPS server. Default is on.  
+```sh
+rtmp_relay_ssl_server_name on;
+```
+
+#### rtmp_relay_ssl_verify  
+Syntax: `rtmp_relay_ssl_verify on | off;`  
+Context: rtmp, server, application  
+
+Enables or disables verification of the RTMPS server certificate. Note you must set the rtmp_relay_ssl_trusted_certificate. Default is on.   
+```sh
+rtmp_relay_ssl_verify on;
+```
+
+#### rtmp_relay_ssl_verify_depth  
+Syntax: `rtmp_relay_ssl_verify_depth number;`  
+Context: rtmp, server, application  
+
+Sets the verification depth in the RTMPS server certificates chain. Default is 1.  
+```sh
+rtmp_relay_ssl_verify_depth 1;
+```
+
+#### rtmp_relay_ssl_trusted_certificate  
+Syntax: `rtmp_relay_ssl_trusted_certificate file;`  
+Context: rtmp, server, application  
+
+Specifies a file with trusted CA certificates in the PEM format used to verify the certificate of the RTMPS server. No default set.  
+```sh
+rtmp_relay_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+```
+
+#### rtmp_relay_ssl_crl  
+Syntax: `rtmp_relay_ssl_crl file;`  
+Context: rtmp, server, application  
+
+Specifies a file with revoked certificates (CRL) in the PEM format used to verify the certificate of the RTMPS server. No default set.  
+```sh
+rtmp_relay_ssl_crl /etc/ssl/certs/crl.crt;
 ```
 
 ## Notify

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -365,6 +365,7 @@ typedef struct {
 } ngx_rtmp_module_t;
 
 #define NGX_RTMP_MODULE                 0x504D5452     /* "RTMP" */
+#define NGX_RTMP_SSL                    NGX_OPENSSL
 
 #define NGX_RTMP_MAIN_CONF              0x02000000
 #define NGX_RTMP_SRV_CONF               0x04000000

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -338,6 +338,8 @@ typedef struct ngx_rtmp_core_srv_conf_s {
 typedef struct {
     ngx_array_t             applications; /* ngx_rtmp_core_app_conf_t */
     ngx_str_t               name;
+    ngx_resolver_t         *resolver;
+    ngx_msec_t              resolver_timeout;
     void                  **app_conf;
 } ngx_rtmp_core_app_conf_t;
 

--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -257,6 +257,15 @@ ngx_rtmp_close_connection(ngx_connection_t *c)
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, c->log, 0, "close connection");
 
+#if (NGX_RTMP_SSL)
+
+    if (c->ssl) {
+        c->ssl->no_wait_shutdown = 1;
+        (void) ngx_ssl_shutdown(c);
+    }
+
+#endif
+
 #if (NGX_STAT_STUB)
     (void) ngx_atomic_fetch_add(ngx_stat_active, -1);
 #endif

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -38,10 +38,6 @@ static void ngx_rtmp_ssl_handshake_handler(ngx_connection_t *c);
 static void ngx_rtmp_ssl_handshake(ngx_rtmp_session_t *rs);
 static ngx_int_t ngx_rtmp_ssl_name(ngx_rtmp_session_t *rs,
         ngx_rtmp_relay_target_t *target);
-static ngx_int_t ngx_rtmp_configure_ssl_name(ngx_pool_t *pool,
-        ngx_str_t url, ngx_str_t *ssl_name);
-static ngx_int_t ngx_rtmp_configure_ssl(ngx_conf_t *cf,
-        ngx_rtmp_relay_app_conf_t *racf, ngx_rtmp_relay_target_t *target);
 
 #endif
 
@@ -317,7 +313,7 @@ ngx_rtmp_relay_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
         ngx_rtmp_relay_target_t  *target;                                     \
         for (i = 0; i < (arr).nelts; i++) {                                   \
             target = *((ngx_rtmp_relay_target_t **)((arr).elts) + i);         \
-            if (ngx_rtmp_configure_ssl(cf, conf, target)                      \
+            if (ngx_rtmp_relay_configure_ssl(cf, conf, target)                \
                     != NGX_OK) {                                              \
                 return NGX_CONF_ERROR;                                        \
             }                                                                 \
@@ -1828,8 +1824,8 @@ ngx_rtmp_relay_push_pull(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         target->ssl_server_name = NGX_CONF_UNSET;
         target->ssl_verify = NGX_CONF_UNSET;
 
-        if (ngx_rtmp_configure_ssl_name(cf->pool, u->url,
-                                        &target->ssl_name) != NGX_OK) {
+        if (ngx_rtmp_relay_configure_ssl_name(cf->pool, u->url,
+                                              &target->ssl_name) != NGX_OK) {
             return NGX_CONF_ERROR;
         }
     }
@@ -2216,8 +2212,9 @@ ngx_rtmp_ssl_name(ngx_rtmp_session_t *rs, ngx_rtmp_relay_target_t *target)
     return NGX_OK;
 }
 
-static ngx_int_t
-ngx_rtmp_configure_ssl_name(ngx_pool_t *pool, ngx_str_t url, ngx_str_t *ssl_name)
+ngx_int_t
+ngx_rtmp_relay_configure_ssl_name(ngx_pool_t *pool, ngx_str_t url,
+        ngx_str_t *ssl_name)
 {
     u_char *host, *port, *last, *uri, *args, *p;
 
@@ -2269,8 +2266,8 @@ err:
 }
 
 
-static ngx_int_t
-ngx_rtmp_configure_ssl(ngx_conf_t *cf, ngx_rtmp_relay_app_conf_t *racf,
+ngx_int_t
+ngx_rtmp_relay_configure_ssl(ngx_conf_t *cf, ngx_rtmp_relay_app_conf_t *racf,
         ngx_rtmp_relay_target_t *target)
 {
     ngx_pool_cleanup_t  *cln;

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -812,6 +812,10 @@ ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
     name.len = ngx_strlen(v->name);
     name.data = v->name;
 
+    if (ctx == NULL) {
+        ctx = ngx_rtmp_relay_create_local_ctx(s, &name, NULL);
+    }
+
     t = racf->pushes.elts;
     for (n = 0; n < racf->pushes.nelts; ++n, ++t) {
         target = *t;

--- a/ngx_rtmp_relay_module.h
+++ b/ngx_rtmp_relay_module.h
@@ -26,6 +26,16 @@ typedef struct {
     ngx_int_t                       start;
     ngx_int_t                       stop;
 
+#if (NGX_RTMP_SSL)
+
+    ngx_int_t                       is_rtmps;
+    ngx_ssl_t                      *ssl;
+    ngx_str_t                       ssl_name;
+    ngx_flag_t                      ssl_server_name;
+    ngx_flag_t                      ssl_verify;
+
+#endif
+
     void                           *tag;     /* usually module reference */
     void                           *data;    /* module-specific data */
     ngx_uint_t                      counter; /* mutable connection counter */
@@ -53,11 +63,47 @@ struct ngx_rtmp_relay_ctx_s {
     ngx_int_t                       start;
     ngx_int_t                       stop;
 
+#if (NGX_RTMP_SSL)
+
+    ngx_str_t                       ssl_name;
+    ngx_flag_t                      ssl_server_name;
+    ngx_flag_t                      ssl_verify;
+
+#endif
+
     ngx_event_t                     push_evt;
     ngx_event_t                    *static_evt;
     void                           *tag;
     void                           *data;
 };
+
+
+typedef struct {
+    ngx_array_t                 pulls;         /* ngx_rtmp_relay_target_t * */
+    ngx_array_t                 pushes;        /* ngx_rtmp_relay_target_t * */
+    ngx_array_t                 static_pulls;  /* ngx_rtmp_relay_target_t * */
+    ngx_array_t                 static_events; /* ngx_event_t * */
+    ngx_log_t                  *log;
+    ngx_uint_t                  nbuckets;
+    ngx_msec_t                  buflen;
+    ngx_flag_t                  session_relay;
+    ngx_msec_t                  push_reconnect;
+    ngx_msec_t                  pull_reconnect;
+    ngx_rtmp_relay_ctx_t        **ctx;
+
+#if (NGX_RTMP_SSL)
+
+    ngx_uint_t                  ssl_protocols;
+    ngx_str_t                   ssl_ciphers;
+    ngx_flag_t                  ssl_server_name;
+    ngx_flag_t                  ssl_verify;
+    ngx_uint_t                  ssl_verify_depth;
+    ngx_str_t                   ssl_trusted_certificate;
+    ngx_str_t                   ssl_crl;
+
+#endif
+
+} ngx_rtmp_relay_app_conf_t;
 
 
 extern ngx_module_t                 ngx_rtmp_relay_module;

--- a/ngx_rtmp_relay_module.h
+++ b/ngx_rtmp_relay_module.h
@@ -116,8 +116,6 @@ ngx_int_t ngx_rtmp_relay_push(ngx_rtmp_session_t *s, ngx_str_t *name,
 
 #if (NGX_RTMP_SSL)
 
-ngx_int_t ngx_rtmp_relay_configure_ssl_name(ngx_pool_t *pool, ngx_str_t url,
-                                            ngx_str_t *ssl_name);
 ngx_int_t ngx_rtmp_relay_configure_ssl(ngx_conf_t *cf,
                                        ngx_rtmp_relay_app_conf_t *racf,
                                        ngx_rtmp_relay_target_t *target);

--- a/ngx_rtmp_relay_module.h
+++ b/ngx_rtmp_relay_module.h
@@ -114,5 +114,15 @@ ngx_int_t ngx_rtmp_relay_pull(ngx_rtmp_session_t *s, ngx_str_t *name,
 ngx_int_t ngx_rtmp_relay_push(ngx_rtmp_session_t *s, ngx_str_t *name,
                               ngx_rtmp_relay_target_t *target);
 
+#if (NGX_RTMP_SSL)
+
+ngx_int_t ngx_rtmp_relay_configure_ssl_name(ngx_pool_t *pool, ngx_str_t url,
+                                            ngx_str_t *ssl_name);
+ngx_int_t ngx_rtmp_relay_configure_ssl(ngx_conf_t *cf,
+                                       ngx_rtmp_relay_app_conf_t *racf,
+                                       ngx_rtmp_relay_target_t *target);
+
+#endif
+
 
 #endif /* _NGX_RTMP_RELAY_H_INCLUDED_ */


### PR DESCRIPTION
This is an attempt to add support for the relay module to directly connect to RTMPS targets. This is valuable for security and is required for certain streaming services (Facebook). Please test if you can, feedback is welcome :+1: 

### Notes
- Implemented a number of new SSL directives which are patterned after the ngx_http_proxy_module using the prefix rtmp_relay_. The directives follow the same syntax as the proxy module. Details are added to the doc folder.
- Added two new parameters for relay targets to allow you to override certain behaviors. This is also documented.
- A lot of code is patterned after the ngx_http_proxy_module and the ngx_http_upstream_module.
- All of the new code is conditionally compiled using a new macro NGX_RTMP_SSL which is an alias for NGX_OPENSSL.
- The only change to existing code is moving the ngx_rtmp_relay_app_conf_t to the header file.
- Also included one bugfix discovered while testing, which is a segfault if the initial push fails. Details in the commit description for the fix.
- Added support for the notify module to use RTMPS when receiving a 3xx response in an on_publish callback.
- Added support for the notify module to resolve a hostname using DNS asynchronously when receiving a 3xx response in an on_publish callback.

### Sample Configuration
I provide a sample configuration file below to demonstrate some of the possible options. The purpose of this config is a multi streaming server with one application that will push to YouTube and Facebook live. You will need to replace the `xxxx` with your streaming key.
```
load_module modules/ngx_rtmp_module.so;

worker_processes 1;

events {
    worker_connections 128;
}

http {
    server {
        listen 8080;

        location /facebook {
            rewrite ^.*$ rtmps://live-api-s.facebook.com/rtmp/****? permanent;
        }

        location /youtube {
            rewrite ^.*$ rtmps://a.rtmps.youtube.com/live2/****? permanent;
        }
    }
}

rtmp {
    resolver 1.1.1.1 8.8.8.8 ipv6=off;
    resolver_timeout 30s;

    rtmp_relay_ssl_protocols TLSv1.2 TLSv1.3;
    rtmp_relay_ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
    rtmp_relay_ssl_server_name on;
    rtmp_relay_ssl_verify on;
    rtmp_relay_ssl_verify_depth 5;
    rtmp_relay_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;

    notify_relay_redirect on;
    drop_idle_publisher 10s;

    server {
        listen 1935;

        application test {
            live on;
            drop_idle_publisher 10s;

            push rtmps://a.rtmps.youtube.com/live2/xxxx;
            push rtmps://live-api-s.facebook.com/rtmp/xxxx;
        }

        application test2 {
            live on;

            push rtmp://127.0.0.1/facebook;
            push rtmp://127.0.0.1/youtube;
        }

        application facebook {
            live on;

            on_publish http://127.0.0.1:8080/facebook;
        }

        application youtube {
            live on;

            on_publish http://127.0.0.1:8080/youtube;
        }
    }
}
```
cc: #165 arut#1619 arut#747 arut#1605 arut#1408 arut#1587 arut#1604 arut#1397 arut#457 arut#232 arut#191 arut#68