### PR TITLE
Fix hls_datetime not working after the first fragment

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -640,7 +640,7 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s, int final)
 
     for (i = start_i; i < (ngx_int_t)ctx->nfrags; i++) {
         f = ngx_rtmp_hls_get_frag(s, i);
-        if ((i == 0 || f->discont) && f->datetime && f->datetime->len > 0) {
+        if ((i == start_i || f->discont) && f->datetime && f->datetime->len > 0) {
             p = ngx_snprintf(buffer, sizeof(buffer), "#EXT-X-PROGRAM-DATE-TIME:");
             n = ngx_write_fd(fd, buffer, p - buffer);
             if (n < 0) {


### PR DESCRIPTION
After the starting `i` counter got changed from 0 to start_i, someone seemingly forgot to change it for the datetime conditional as well, therefore creating a bug where the `#EXT-X-PROGRAM-DATE-TIME` header is shown only before the first fragment. But after the chunkfile starts rotating it disappears. This fixes it.

Fixes https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/issues/345