### PR TITLE
Remove unused variable

### DIFF
--- a/ngx_rtmp_eval.c
+++ b/ngx_rtmp_eval.c
@@ -84,12 +84,11 @@ static void
 ngx_rtmp_eval_append_var(void *ctx, ngx_buf_t *b, ngx_rtmp_eval_t **e,
     ngx_str_t *name, ngx_log_t *log)
 {
-    ngx_uint_t          k;
     ngx_str_t           v;
     ngx_rtmp_eval_t    *ee;
 
     for (; *e; ++e) {
-        for (k = 0, ee = *e; ee->handler; ++k, ++ee) {
+        for (ee = *e; ee->handler; ++ee) {
             if (ee->name.len == name->len &&
                 ngx_memcmp(ee->name.data, name->data, name->len) == 0)
             {


### PR DESCRIPTION
Fixes:

```
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f objs/Makefile
cc -c -pipe  -O -Wall -Wextra -Wpointer-arith -Wconditional-uninitialized -Wno-unused-parameter -Wno-deprecated-declarations -Werror -g  -I../nginx-rtmp-module  -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /opt/homebrew/Cellar/pcre2/10.42/include -I ../openssl-1.1.1m/.openssl/include -I objs -I src/http -I src/http/modules -I ../nginx-rtmp-module \
		-o objs/addon/nginx-rtmp-module/ngx_rtmp_eval.o \
		../nginx-rtmp-module/ngx_rtmp_eval.c
../nginx-rtmp-module/ngx_rtmp_eval.c:87:25: error: variable 'k' set but not used [-Werror,-Wunused-but-set-variable]
    ngx_uint_t          k;
```