### PR TITLE
Correctly set media sequence number

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -73,7 +73,6 @@ typedef struct {
     uint64_t                            key_id;
     ngx_uint_t                          nfrags;
     ngx_rtmp_hls_frag_t                *frags; /* circular 2 * winfrags + 1 */
-    uint64_t                            mediaseq;
 
     ngx_uint_t                          audio_cc;
     ngx_uint_t                          video_cc;
@@ -606,7 +605,7 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s, int final)
                      "#EXT-X-VERSION:3\n"
                      "#EXT-X-MEDIA-SEQUENCE:%uL\n"
                      "#EXT-X-TARGETDURATION:%ui\n",
-                     ctx->mediaseq++, max_frag);
+                     ctx->frag + start_i, max_frag);
 
     if (hacf->type == NGX_RTMP_HLS_TYPE_EVENT) {
         p = ngx_slprintf(p, end, "#EXT-X-PLAYLIST-TYPE:EVENT\n");


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.2 specifies the media sequence number to be the number of the *first* fragment in the list, not the last one.