### PR TITLE
fix null pointer reference in ngx_pnalloc

### DIFF
--- a/ngx_rtmp_proxy_protocol.c
+++ b/ngx_rtmp_proxy_protocol.c
@@ -116,13 +116,13 @@ ngx_rtmp_proxy_protocol_recv(ngx_event_t *rev)
         ngx_inet_set_port(addr.sockaddr, c->proxy_protocol->src_port);
 
         text = ngx_pnalloc(c->pool, NGX_SOCKADDR_STRLEN);
-        len = ngx_sock_ntop(addr.sockaddr, addr.socklen, text,
-                            NGX_SOCKADDR_STRLEN, 0);
-        if (len == 0) {
+        if (text == NULL) {
             goto failed;
         }
 
-        if (text == NULL) {
+        len = ngx_sock_ntop(addr.sockaddr, addr.socklen, text,
+                            NGX_SOCKADDR_STRLEN, 0);
+        if (len == 0) {
             goto failed;
         }
 


### PR DESCRIPTION
Fix null pointer dereference in proxy_protocol address formatting

  ngx_pnalloc is called to allocate the buffer for ngx_sock_ntop, but the NULL check on the result comes after the ngx_sock_ntop call. If pool allocation fails, text is NULL and passing it to ngx_sock_ntop causes
   a null pointer dereference before the check is ever reached.

  Move the NULL check to immediately after the allocation, before ngx_sock_ntop is called.

  Before:
```
  text = ngx_pnalloc(c->pool, NGX_SOCKADDR_STRLEN);
  len = ngx_sock_ntop(addr.sockaddr, addr.socklen, text,
                      NGX_SOCKADDR_STRLEN, 0);
  if (len == 0) {
      goto failed;
  }

  if (text == NULL) {
      goto failed;
  }
```
  After:
```
  text = ngx_pnalloc(c->pool, NGX_SOCKADDR_STRLEN);
  if (text == NULL) {
      goto failed;
  }

  len = ngx_sock_ntop(addr.sockaddr, addr.socklen, text,
                      NGX_SOCKADDR_STRLEN, 0);
  if (len == 0) {
      goto failed;
  }
```